### PR TITLE
feat(API-97): Centralised constants introduction

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,9 @@
       ]
     },
     "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      },
       "typescript": {
         "alwaysTryTypes": true
       }

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx commitlint --edit $1
 npx lint-staged
+
+printf "\n\n${YELLOW}Lint check 🎨${NC}\n\n"
+npm run lint

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,7 @@ const defaultSettings = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   moduleNameMapper: {
+    '@ukef/constants/(.*)': '<rootDir>/../src/constants/$1',
     '@ukef/config/(.*)': '<rootDir>/../src/config/$1',
     '@ukef/helpers/(.*)': '<rootDir>/../src/helpers/$1',
     '@ukef/module/(.*)': '<rootDir>/../src/modules/$1',

--- a/src/constants/application.ts
+++ b/src/constants/application.ts
@@ -1,0 +1,5 @@
+const APPLICATION = {
+  NAME: 'tfs',
+};
+
+export { APPLICATION };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
 /**
- * MDM centralised constants, referred as `@ukef/constants`.
+ * TFS centralised constants, referred as `@ukef/constants`.
  * Following constants are served:
  *
  * 1. Application

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,8 @@
+/**
+ * MDM centralised constants, referred as `@ukef/constants`.
+ * Following constants are served:
+ *
+ * 1. Application
+ */
+
+export * from './application';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "lib": ["ES2015"],
     "paths": {
       "@ukef/*": ["src/*"],
+      "@ukef/constants/*": ["src/constants/index"],
       "@ukef/config/*": ["src/config/index"],
       "@ukef/helpers/*": ["src/helpers/*"],
       "@ukef/module/*": ["src/modules/*"],


### PR DESCRIPTION
## Introduction
Centralised micro-service constants

## Resolution
* Jest, TS and ESLint config have been updated with alias `@ukef/constants`.
* Added `APPLICATION` constant.
* `.husky` pre-comment script executes `npm run lint`.