### PR TITLE
feat: add eslint unused imports plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "simple-import-sort",
     "deprecation",
     "import",
-    "prettier"
+    "prettier",
+    "unused-imports"
   ],
   "extends": [
     "plugin:@typescript-eslint/recommended",
@@ -104,12 +105,14 @@
     "import/newline-after-import": "off",
     "import/prefer-default-export": "off",
     "consistent-return": "off",
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": "error",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-function": "off",
     "no-empty-function": "off",
-    "no-unused-vars": "off",
     "require-await": "error",
     "no-useless-constructor": "off",
     "class-methods-use-this": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "eslint-plugin-security": "^1.7.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-switch-case": "^1.1.2",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "husky": "^8.0.3",
         "jest": "29.4.3",
         "jest-when": "^3.5.2",
@@ -6479,6 +6480,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-security": "^1.7.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-switch-case": "^1.1.2",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.3",
     "jest": "29.4.3",
     "jest-when": "^3.5.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,8 +5,6 @@ import { SwaggerDocs } from '@ukef/swagger';
 import compression from 'compression';
 import { Logger, LoggerErrorInterceptor } from 'nestjs-pino';
 
-import { AcbsExceptionTransformInterceptor } from './modules/acbs-adapter/acbs-exception-transform.interceptor';
-
 export class App {
   private readonly configService: ConfigService;
   public readonly port: number;

--- a/src/helpers/date-string.type.ts
+++ b/src/helpers/date-string.type.ts
@@ -1,1 +1,1 @@
-type DateString = string;
+export type DateString = string;

--- a/src/main.module.ts
+++ b/src/main.module.ts
@@ -17,7 +17,7 @@ import { LoggerModule } from 'nestjs-pino';
     }),
     LoggerModule.forRoot({
       pinoHttp: {
-        customProps: (req, res) => ({
+        customProps: () => ({
           context: 'HTTP',
         }),
         transport: {

--- a/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
+++ b/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
@@ -1,5 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
-import { lastValueFrom, of, throwError } from 'rxjs';
+import { lastValueFrom, throwError } from 'rxjs';
 
 import { AcbsResourceNotFoundException } from '../acbs/exception/acbs-resource-not-found.exception';
 import { AcbsExceptionTransformInterceptor } from './acbs-exception-transform.interceptor';

--- a/src/modules/acbs/dto/acbs-party-external-ratings-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-party-external-ratings-response.dto.ts
@@ -1,3 +1,5 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
 export type AcbsPartyExternalRatingsResponseDto = AcbsPartyExternalRatingDto[];
 
 interface AcbsPartyExternalRatingDto {

--- a/src/modules/acbs/exception/acbs.exception.test.ts
+++ b/src/modules/acbs/exception/acbs.exception.test.ts
@@ -1,7 +1,6 @@
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 
 import { AcbsException } from './acbs.exception';
-import { AcbsAuthenticationFailedException } from './acbs-authentication-failed.exception';
 
 describe('AcbsException', () => {
   const valueGenerator = new RandomValueGenerator();

--- a/src/modules/party-external-rating/dto/get-party-external-ratings-response.dto.ts
+++ b/src/modules/party-external-rating/dto/get-party-external-ratings-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiResponseProperty } from '@nestjs/swagger';
+import { DateString } from '@ukef/helpers/date-string.type';
 
 export type GetPartyExternalRatingsResponse = GetPartyExternalRatingsResponseElement[];
 

--- a/src/modules/party-external-rating/party-external-rating.interface.ts
+++ b/src/modules/party-external-rating/party-external-rating.interface.ts
@@ -1,3 +1,5 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
 export interface PartyExternalRating {
   partyIdentifier: string;
   ratingEntity: {

--- a/test/support/generator/party-external-rating-generator.ts
+++ b/test/support/generator/party-external-rating-generator.ts
@@ -1,3 +1,4 @@
+import { DateString } from '@ukef/helpers/date-string.type';
 import { AcbsPartyExternalRatingsResponseDto } from '@ukef/modules/acbs/dto/acbs-party-external-ratings-response.dto';
 import { GetPartyExternalRatingsResponse } from '@ukef/modules/party-external-rating/dto/get-party-external-ratings-response.dto';
 import { PartyExternalRating } from '@ukef/modules/party-external-rating/party-external-rating.interface';


### PR DESCRIPTION
## Introduction

We want our linter to tell us if we ever have unused imports in the code.

## Resolution

I have
- installed the [unused-imports eslint plugin](https://www.npmjs.com/package/eslint-plugin-unused-imports)
- configured our eslint settings to use the plugin to
  - error on unused imports
  - error on unused variables
- removed some unused imports and variables  