### PR TITLE
feat(APIM-78): add endpoint to get party by party identifier

### DIFF
--- a/src/modules/acbs/acbs-authentication.service.test.ts
+++ b/src/modules/acbs/acbs-authentication.service.test.ts
@@ -57,8 +57,18 @@ describe('AcbsAuthenticationService', () => {
   let logger: PinoLogger;
   let service: AcbsAuthenticationService;
 
+  let httpServiceGet: jest.Mock;
+  let httpServicePost: jest.Mock;
+
   beforeEach(() => {
     httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
+    httpServicePost = jest.fn();
+    httpService.post = httpServicePost;
+
     logger = new PinoLogger({});
     logger.error = jest.fn();
     service = new AcbsAuthenticationService({ apiKey, apiKeyHeaderName, authentication: { baseUrl, loginName, password, clientId } }, httpService, logger);
@@ -103,8 +113,7 @@ describe('AcbsAuthenticationService', () => {
   describe('failed authentication', () => {
     it('throws an AcbsAuthenticationFailedException if there is an error when creating a session with the IdP', async () => {
       const sessionCreationError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.post)
+      when(httpServicePost)
         .calledWith(...expectedPostSessionsArguments)
         .mockReturnValueOnce(throwError(() => sessionCreationError));
 
@@ -117,8 +126,7 @@ describe('AcbsAuthenticationService', () => {
 
     it('logs the http service error if there is an error when creating a session with the IdP', async () => {
       const sessionCreationError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.post)
+      when(httpServicePost)
         .calledWith(...expectedPostSessionsArguments)
         .mockReturnValueOnce(throwError(() => sessionCreationError));
 
@@ -144,8 +152,7 @@ describe('AcbsAuthenticationService', () => {
     it('throws an AcbsAuthenticationFailedException if there is an error when getting a token from the IdP', async () => {
       mockSuccessfulCreateSessionRequest();
       const getTokenError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(...expectedGetTokenArguments)
         .mockReturnValueOnce(throwError(() => getTokenError));
 
@@ -159,8 +166,7 @@ describe('AcbsAuthenticationService', () => {
     it('logs the http service error if there is an error when getting a token from the IdP', async () => {
       mockSuccessfulCreateSessionRequest();
       const getTokenError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(...expectedGetTokenArguments)
         .mockReturnValueOnce(throwError(() => getTokenError));
 
@@ -256,8 +262,7 @@ describe('AcbsAuthenticationService', () => {
     const headers = new AxiosHeaders();
     headers['set-cookie'] = cookies;
 
-    // eslint-disable-next-line jest/unbound-method
-    when(httpService.post)
+    when(httpServicePost)
       .calledWith(...expectedPostSessionsArguments)
       .mockReturnValueOnce(
         of({
@@ -273,8 +278,7 @@ describe('AcbsAuthenticationService', () => {
   const mockSuccessfulGetTokenForSessionRequest = (): void => mockSuccessfulGetTokenForSessionRequestReturning({ id_token: idToken });
 
   const mockSuccessfulGetTokenForSessionRequestReturning = (data: any): void => {
-    // eslint-disable-next-line jest/unbound-method
-    when(httpService.get)
+    when(httpServiceGet)
       .calledWith(...expectedGetTokenArguments)
       .mockReturnValueOnce(
         of({

--- a/src/modules/acbs/acbs-party-external-rating.service.test.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.test.ts
@@ -23,7 +23,7 @@ describe('AcbsPartyExternalRatingService', () => {
   });
 
   describe('getExternalRatingsForParty', () => {
-    const partyIdentifier = '001';
+    const partyIdentifier = valueGenerator.stringOfNumericCharacters();
 
     it('throws an AcbsException if the request to ACBS fails', async () => {
       const getExternalRatingsForPartyError = new AxiosError();

--- a/src/modules/acbs/acbs-party-external-rating.service.test.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.test.ts
@@ -17,8 +17,14 @@ describe('AcbsPartyExternalRatingService', () => {
   let httpService: HttpService;
   let service: AcbsPartyExternalRatingService;
 
+  let httpServiceGet: jest.Mock;
+
   beforeEach(() => {
     httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
     service = new AcbsPartyExternalRatingService({ baseUrl }, httpService);
   });
 
@@ -27,8 +33,7 @@ describe('AcbsPartyExternalRatingService', () => {
 
     it('throws an AcbsException if the request to ACBS fails', async () => {
       const getExternalRatingsForPartyError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },
@@ -43,8 +48,7 @@ describe('AcbsPartyExternalRatingService', () => {
     });
 
     it('returns an empty array of external ratings for the party if ACBS responds with an empty array of external ratings', async () => {
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },
@@ -74,8 +78,7 @@ describe('AcbsPartyExternalRatingService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },
@@ -99,8 +102,7 @@ describe('AcbsPartyExternalRatingService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },
@@ -124,8 +126,7 @@ describe('AcbsPartyExternalRatingService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },
@@ -142,8 +143,7 @@ describe('AcbsPartyExternalRatingService', () => {
     it('returns the external ratings for the party if ACBS responds with the external ratings', async () => {
       const { externalRatingsInAcbs } = new PartyExternalRatingGenerator(valueGenerator).generate({ partyIdentifier, numberToGenerate: 2 });
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}/PartyExternalRating`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${authToken}` },

--- a/src/modules/acbs/acbs-party-external-rating.service.test.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.test.ts
@@ -5,21 +5,21 @@ import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
-import { AcbsService } from './acbs.service';
+import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.service';
 import { AcbsException } from './exception/acbs.exception';
 import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
 
-describe('AcbsService', () => {
+describe('AcbsPartyExternalRatingService', () => {
   const valueGenerator = new RandomValueGenerator();
   const authToken = valueGenerator.string();
   const baseUrl = valueGenerator.string();
 
   let httpService: HttpService;
-  let service: AcbsService;
+  let service: AcbsPartyExternalRatingService;
 
   beforeEach(() => {
     httpService = new HttpService();
-    service = new AcbsService({ baseUrl }, httpService);
+    service = new AcbsPartyExternalRatingService({ baseUrl }, httpService);
   });
 
   describe('getExternalRatingsForParty', () => {

--- a/src/modules/acbs/acbs-party-external-rating.service.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.ts
@@ -2,12 +2,10 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
-import { AxiosError } from 'axios';
-import { catchError, lastValueFrom } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
 
 import { AcbsPartyExternalRatingsResponseDto } from './dto/acbs-party-external-ratings-response.dto';
-import { AcbsException } from './exception/acbs.exception';
-import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { wrapAcbsHttpError } from './wrap-acbs-http-error';
 
 @Injectable()
 export class AcbsPartyExternalRatingService {
@@ -27,11 +25,9 @@ export class AcbsPartyExternalRatingService {
           },
         })
         .pipe(
-          catchError((error: Error) => {
-            if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
-              throw new AcbsResourceNotFoundException(`Party with identifier ${partyIdentifier} was not found by ACBS.`, error);
-            }
-            throw new AcbsException(`Failed to get the external ratings for the party with id ${partyIdentifier}.`, error);
+          wrapAcbsHttpError({
+            resourceIdentifier: partyIdentifier,
+            messageForUnknownException: `Failed to get the external ratings for the party with id ${partyIdentifier}.`,
           }),
         ),
     );

--- a/src/modules/acbs/acbs-party-external-rating.service.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.ts
@@ -10,7 +10,7 @@ import { AcbsException } from './exception/acbs.exception';
 import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
 
 @Injectable()
-export class AcbsService {
+export class AcbsPartyExternalRatingService {
   constructor(
     @Inject(AcbsConfig.KEY)
     private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,

--- a/src/modules/acbs/acbs-party.service.test.ts
+++ b/src/modules/acbs/acbs-party.service.test.ts
@@ -1,0 +1,145 @@
+import { HttpService } from '@nestjs/axios';
+import { PartyGenerator } from '@ukef-test/support/generator/party-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsPartyService } from './acbs-party.service';
+import { AcbsException } from './exception/acbs.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+
+describe('AcbsPartyService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.string();
+
+  let httpService: HttpService;
+  let service: AcbsPartyService;
+
+  beforeEach(() => {
+    httpService = new HttpService();
+    service = new AcbsPartyService({ baseUrl }, httpService);
+  });
+
+  describe('getPartyByIdentifier', () => {
+    const partyIdentifier = valueGenerator.stringOfNumericCharacters();
+
+    it('returns the party if ACBS responds with the party', async () => {
+      const { partiesInAcbs } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+      const partyInAcbs = partiesInAcbs[0];
+
+      // eslint-disable-next-line jest/unbound-method
+      when(httpService.get)
+        .calledWith(`/Party/${partyIdentifier}`, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .mockReturnValueOnce(
+          of({
+            data: partyInAcbs,
+            status: 200,
+            statusText: 'OK',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const party = await service.getPartyByIdentifier(partyIdentifier, idToken);
+
+      expect(party).toStrictEqual(partyInAcbs);
+    });
+
+    it('throws an AcbsException if the request to ACBS fails', async () => {
+      const getPartyByIdentifierError = new AxiosError();
+      // eslint-disable-next-line jest/unbound-method
+      when(httpService.get)
+        .calledWith(`/Party/${partyIdentifier}`, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .mockReturnValueOnce(throwError(() => getPartyByIdentifierError));
+
+      const getExternalRatingsPromise = service.getPartyByIdentifier(partyIdentifier, idToken);
+
+      await expect(getExternalRatingsPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getExternalRatingsPromise).rejects.toThrow(`Failed to get the party with identifier ${partyIdentifier}.`);
+      await expect(getExternalRatingsPromise).rejects.toHaveProperty('innerError', getPartyByIdentifierError);
+    });
+
+    it('throws an AcbsResourceNotFoundException if ACBS responds with a 400 response that is a string containing "Party not found"', async () => {
+      const axiosError = new AxiosError();
+      axiosError.response = {
+        data: 'Party not found or user does not have access',
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      // eslint-disable-next-line jest/unbound-method
+      when(httpService.get)
+        .calledWith(`/Party/${partyIdentifier}`, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const getExternalRatingsPromise = service.getPartyByIdentifier(partyIdentifier, idToken);
+
+      await expect(getExternalRatingsPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(getExternalRatingsPromise).rejects.toThrow(`Party with identifier ${partyIdentifier} was not found by ACBS.`);
+      await expect(getExternalRatingsPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+
+    it('throws an AcbsException if ACBS responds with a 400 response that is a string that does NOT contain "Party not found"', async () => {
+      const axiosError = new AxiosError();
+      axiosError.response = {
+        data: 'some error string',
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      // eslint-disable-next-line jest/unbound-method
+      when(httpService.get)
+        .calledWith(`/Party/${partyIdentifier}`, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const getExternalRatingsPromise = service.getPartyByIdentifier(partyIdentifier, idToken);
+
+      await expect(getExternalRatingsPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getExternalRatingsPromise).rejects.toThrow(`Failed to get the party with identifier ${partyIdentifier}.`);
+      await expect(getExternalRatingsPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+
+    it('throws an AcbsException if ACBS responds with a 400 response that is NOT a string', async () => {
+      const axiosError = new AxiosError();
+      axiosError.response = {
+        data: { errorMessage: valueGenerator.string() },
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      // eslint-disable-next-line jest/unbound-method
+      when(httpService.get)
+        .calledWith(`/Party/${partyIdentifier}`, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const getExternalRatingsPromise = service.getPartyByIdentifier(partyIdentifier, idToken);
+
+      await expect(getExternalRatingsPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getExternalRatingsPromise).rejects.toThrow(`Failed to get the party with identifier ${partyIdentifier}.`);
+      await expect(getExternalRatingsPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-party.service.test.ts
+++ b/src/modules/acbs/acbs-party.service.test.ts
@@ -17,8 +17,14 @@ describe('AcbsPartyService', () => {
   let httpService: HttpService;
   let service: AcbsPartyService;
 
+  let httpServiceGet: jest.Mock;
+
   beforeEach(() => {
     httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
     service = new AcbsPartyService({ baseUrl }, httpService);
   });
 
@@ -29,8 +35,7 @@ describe('AcbsPartyService', () => {
       const { partiesInAcbs } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
       const partyInAcbs = partiesInAcbs[0];
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${idToken}` },
@@ -52,8 +57,7 @@ describe('AcbsPartyService', () => {
 
     it('throws an AcbsException if the request to ACBS fails', async () => {
       const getPartyByIdentifierError = new AxiosError();
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${idToken}` },
@@ -77,8 +81,7 @@ describe('AcbsPartyService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${idToken}` },
@@ -102,8 +105,7 @@ describe('AcbsPartyService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${idToken}` },
@@ -127,8 +129,7 @@ describe('AcbsPartyService', () => {
         config: undefined,
       };
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(`/Party/${partyIdentifier}`, {
           baseURL: baseUrl,
           headers: { Authorization: `Bearer ${idToken}` },

--- a/src/modules/acbs/acbs-party.service.ts
+++ b/src/modules/acbs/acbs-party.service.ts
@@ -1,0 +1,34 @@
+import { HttpService } from '@nestjs/axios';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import AcbsConfig from '@ukef/config/acbs.config';
+import { AxiosError } from 'axios';
+import { catchError, lastValueFrom } from 'rxjs';
+
+import { AcbsGetPartyResponseDto } from './dto/acbs-get-party-response.dto';
+import { AcbsException } from './exception/acbs.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+
+@Injectable()
+export class AcbsPartyService {
+  constructor(@Inject(AcbsConfig.KEY) private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, private readonly httpService: HttpService) {}
+
+  async getPartyByIdentifier(partyIdentifier: string, idToken: string): Promise<AcbsGetPartyResponseDto> {
+    const { data: party } = await lastValueFrom(
+      this.httpService
+        .get<AcbsGetPartyResponseDto>(`/Party/${partyIdentifier}`, {
+          baseURL: this.config.baseUrl,
+          headers: { Authorization: `Bearer ${idToken}` },
+        })
+        .pipe(
+          catchError((error: Error) => {
+            if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
+              throw new AcbsResourceNotFoundException(`Party with identifier ${partyIdentifier} was not found by ACBS.`, error);
+            }
+            throw new AcbsException(`Failed to get the party with identifier ${partyIdentifier}.`, error);
+          }),
+        ),
+    );
+    return party;
+  }
+}

--- a/src/modules/acbs/acbs-party.service.ts
+++ b/src/modules/acbs/acbs-party.service.ts
@@ -2,12 +2,10 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
-import { AxiosError } from 'axios';
-import { catchError, lastValueFrom } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
 
 import { AcbsGetPartyResponseDto } from './dto/acbs-get-party-response.dto';
-import { AcbsException } from './exception/acbs.exception';
-import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { wrapAcbsHttpError } from './wrap-acbs-http-error';
 
 @Injectable()
 export class AcbsPartyService {
@@ -21,11 +19,9 @@ export class AcbsPartyService {
           headers: { Authorization: `Bearer ${idToken}` },
         })
         .pipe(
-          catchError((error: Error) => {
-            if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
-              throw new AcbsResourceNotFoundException(`Party with identifier ${partyIdentifier} was not found by ACBS.`, error);
-            }
-            throw new AcbsException(`Failed to get the party with identifier ${partyIdentifier}.`, error);
+          wrapAcbsHttpError({
+            resourceIdentifier: partyIdentifier,
+            messageForUnknownException: `Failed to get the party with identifier ${partyIdentifier}.`,
           }),
         ),
     );

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -3,8 +3,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { TestController } from './acbs.controller';
-import { AcbsService } from './acbs.service';
 import { AcbsAuthenticationService } from './acbs-authentication.service';
+import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.service';
 
 @Module({
   imports: [
@@ -18,7 +18,7 @@ import { AcbsAuthenticationService } from './acbs-authentication.service';
     }),
   ],
   controllers: [TestController],
-  providers: [AcbsAuthenticationService, AcbsService],
-  exports: [AcbsAuthenticationService, AcbsService],
+  providers: [AcbsAuthenticationService, AcbsPartyExternalRatingService],
+  exports: [AcbsAuthenticationService, AcbsPartyExternalRatingService],
 })
 export class AcbsModule {}

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { TestController } from './acbs.controller';
 import { AcbsAuthenticationService } from './acbs-authentication.service';
+import { AcbsPartyService } from './acbs-party.service';
 import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.service';
 
 @Module({
@@ -18,7 +19,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     }),
   ],
   controllers: [TestController],
-  providers: [AcbsAuthenticationService, AcbsPartyExternalRatingService],
-  exports: [AcbsAuthenticationService, AcbsPartyExternalRatingService],
+  providers: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService],
+  exports: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService],
 })
 export class AcbsModule {}

--- a/src/modules/acbs/dto/acbs-get-party-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-party-response.dto.ts
@@ -1,0 +1,13 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
+export interface AcbsGetPartyResponseDto {
+  PartyAlternateIdentifier: string;
+  IndustryClassification: { IndustryClassificationCode: string };
+  PartyName1: string;
+  PartyName2: string;
+  PartyName3: string;
+  MinorityClass: { MinorityClassCode: string };
+  CitizenshipClass: { CitizenshipClassCode: string };
+  OfficerRiskDate: DateString;
+  PrimaryAddress: { Country: { CountryCode: string } };
+}

--- a/src/modules/acbs/wrap-acbs-http-error.ts
+++ b/src/modules/acbs/wrap-acbs-http-error.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios';
+import { catchError, ObservableInput, ObservedValueOf, OperatorFunction } from 'rxjs';
+
+import { AcbsException } from './exception/acbs.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+
+export function wrapAcbsHttpError<T, O extends ObservableInput<any>>({
+  resourceIdentifier,
+  messageForUnknownException,
+}: {
+  resourceIdentifier: string;
+  messageForUnknownException: string;
+}): OperatorFunction<T, T | ObservedValueOf<O>> {
+  return catchError((error: Error) => {
+    if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
+      throw new AcbsResourceNotFoundException(`Party with identifier ${resourceIdentifier} was not found by ACBS.`, error);
+    }
+    throw new AcbsException(messageForUnknownException, error);
+  });
+}

--- a/src/modules/party-external-rating/party-external-rating.controller.test.ts
+++ b/src/modules/party-external-rating/party-external-rating.controller.test.ts
@@ -21,14 +21,19 @@ describe('PartyExternalRatingController', () => {
     let partyExternalRatingService: PartyExternalRatingService;
     let controller: PartyExternalRatingController;
 
+    let partyExternalRatingServiceGetExternalRatingsForParty: jest.Mock;
+
     beforeEach(() => {
       partyExternalRatingService = new PartyExternalRatingService(null, null);
+
+      partyExternalRatingServiceGetExternalRatingsForParty = jest.fn();
+      partyExternalRatingService.getExternalRatingsForParty = partyExternalRatingServiceGetExternalRatingsForParty;
+
       controller = new PartyExternalRatingController(partyExternalRatingService);
     });
 
     it('returns the external ratings for the party from the service', async () => {
-      // eslint-disable-next-line jest/unbound-method
-      when(partyExternalRatingService.getExternalRatingsForParty).calledWith(partyIdentifier).mockResolvedValueOnce(externalRatings);
+      when(partyExternalRatingServiceGetExternalRatingsForParty).calledWith(partyIdentifier).mockResolvedValueOnce(externalRatings);
 
       const ratings = await controller.getExternalRatingsForParty(partyIdentifier);
 
@@ -40,8 +45,7 @@ describe('PartyExternalRatingController', () => {
         ...externalRatings[0],
         unexpectedKey: valueGenerator.string(),
       };
-      // eslint-disable-next-line jest/unbound-method
-      when(partyExternalRatingService.getExternalRatingsForParty).calledWith(partyIdentifier).mockResolvedValueOnce([externalRatingWithUnexpectedKey]);
+      when(partyExternalRatingServiceGetExternalRatingsForParty).calledWith(partyIdentifier).mockResolvedValueOnce([externalRatingWithUnexpectedKey]);
 
       const ratings = await controller.getExternalRatingsForParty(partyIdentifier);
 

--- a/src/modules/party-external-rating/party-external-rating.controller.test.ts
+++ b/src/modules/party-external-rating/party-external-rating.controller.test.ts
@@ -35,7 +35,7 @@ describe('PartyExternalRatingController', () => {
       expect(ratings).toStrictEqual(expectedExternalRatings);
     });
 
-    it('does NOT return unexpected keys from the response', async () => {
+    it('does NOT return unexpected keys from the external ratings from the service', async () => {
       const externalRatingWithUnexpectedKey = {
         ...externalRatings[0],
         unexpectedKey: valueGenerator.string(),

--- a/src/modules/party-external-rating/party-external-rating.service.test.ts
+++ b/src/modules/party-external-rating/party-external-rating.service.test.ts
@@ -17,13 +17,19 @@ describe('PartyExternalRatingService', () => {
   let acbsService: AcbsPartyExternalRatingService;
   let service: PartyExternalRatingService;
 
+  let acbsPartyExternalRatingServiceGetExternalRatingsForParty: jest.Mock;
+
   beforeEach(() => {
     acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
-    acbsService = new AcbsPartyExternalRatingService(null, null);
-    service = new PartyExternalRatingService(acbsAuthenticationService, acbsService);
+    const acbsAuthenticationServiceGetIdToken = jest.fn();
+    acbsAuthenticationService.getIdToken = acbsAuthenticationServiceGetIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(authToken);
 
-    // eslint-disable-next-line jest/unbound-method
-    when(acbsAuthenticationService.getIdToken).calledWith().mockResolvedValueOnce(authToken);
+    acbsService = new AcbsPartyExternalRatingService(null, null);
+    acbsPartyExternalRatingServiceGetExternalRatingsForParty = jest.fn();
+    acbsService.getExternalRatingsForParty = acbsPartyExternalRatingServiceGetExternalRatingsForParty;
+
+    service = new PartyExternalRatingService(acbsAuthenticationService, acbsService);
   });
 
   describe('getExternalRatingsForParty', () => {
@@ -34,8 +40,7 @@ describe('PartyExternalRatingService', () => {
         partyIdentifier,
         numberToGenerate: 2,
       });
-      // eslint-disable-next-line jest/unbound-method
-      when(acbsService.getExternalRatingsForParty).calledWith(partyIdentifier, authToken).mockResolvedValueOnce(externalRatingsInAcbs);
+      when(acbsPartyExternalRatingServiceGetExternalRatingsForParty).calledWith(partyIdentifier, authToken).mockResolvedValueOnce(externalRatingsInAcbs);
 
       const externalRatings = await service.getExternalRatingsForParty(partyIdentifier);
 
@@ -43,8 +48,7 @@ describe('PartyExternalRatingService', () => {
     });
 
     it('returns an empty array if ACBS returns an empty array', async () => {
-      // eslint-disable-next-line jest/unbound-method
-      when(acbsService.getExternalRatingsForParty).calledWith(partyIdentifier, authToken).mockResolvedValueOnce([]);
+      when(acbsPartyExternalRatingServiceGetExternalRatingsForParty).calledWith(partyIdentifier, authToken).mockResolvedValueOnce([]);
 
       const externalRatings = await service.getExternalRatingsForParty(partyIdentifier);
 

--- a/src/modules/party-external-rating/party-external-rating.service.test.ts
+++ b/src/modules/party-external-rating/party-external-rating.service.test.ts
@@ -27,7 +27,7 @@ describe('PartyExternalRatingService', () => {
   });
 
   describe('getExternalRatingsForParty', () => {
-    const partyIdentifier = '001';
+    const partyIdentifier = valueGenerator.stringOfNumericCharacters();
 
     it('returns a transformation of the external ratings from ACBS', async () => {
       const { externalRatingsInAcbs, externalRatings: expectedExternalRatings } = new PartyExternalRatingGenerator(valueGenerator).generate({

--- a/src/modules/party-external-rating/party-external-rating.service.test.ts
+++ b/src/modules/party-external-rating/party-external-rating.service.test.ts
@@ -1,4 +1,4 @@
-import { AcbsService } from '@ukef/modules/acbs/acbs.service';
+import { AcbsPartyExternalRatingService } from '@ukef/modules/acbs/acbs-party-external-rating.service';
 import { PartyExternalRatingGenerator } from '@ukef-test/support/generator/party-external-rating-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
@@ -6,20 +6,20 @@ import { when } from 'jest-when';
 import { AcbsAuthenticationService } from '../acbs/acbs-authentication.service';
 import { PartyExternalRatingService } from './party-external-rating.service';
 
-jest.mock('@ukef/modules/acbs/acbs.service');
+jest.mock('@ukef/modules/acbs/acbs-party-external-rating.service');
 jest.mock('@ukef/modules/acbs/acbs-authentication.service');
 
-describe('AcbsPartyExternalRatingService', () => {
+describe('PartyExternalRatingService', () => {
   const valueGenerator = new RandomValueGenerator();
   const authToken = valueGenerator.string();
 
   let acbsAuthenticationService: AcbsAuthenticationService;
-  let acbsService: AcbsService;
+  let acbsService: AcbsPartyExternalRatingService;
   let service: PartyExternalRatingService;
 
   beforeEach(() => {
     acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
-    acbsService = new AcbsService(null, null);
+    acbsService = new AcbsPartyExternalRatingService(null, null);
     service = new PartyExternalRatingService(acbsAuthenticationService, acbsService);
 
     // eslint-disable-next-line jest/unbound-method

--- a/src/modules/party-external-rating/party-external-rating.service.ts
+++ b/src/modules/party-external-rating/party-external-rating.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { AcbsService } from '@ukef/modules/acbs/acbs.service';
 import { AcbsAuthenticationService } from '@ukef/modules/acbs/acbs-authentication.service';
+import { AcbsPartyExternalRatingService } from '@ukef/modules/acbs/acbs-party-external-rating.service';
 import { PartyExternalRating } from '@ukef/modules/party-external-rating/party-external-rating.interface';
 
 @Injectable()
 export class PartyExternalRatingService {
-  constructor(private readonly acbsAuthenticationService: AcbsAuthenticationService, private readonly acbsService: AcbsService) {}
+  constructor(private readonly acbsAuthenticationService: AcbsAuthenticationService, private readonly acbsService: AcbsPartyExternalRatingService) {}
 
   async getExternalRatingsForParty(partyIdentifier: string): Promise<PartyExternalRating[]> {
     const idToken = await this.acbsAuthenticationService.getIdToken();

--- a/src/modules/party/dto/get-party-by-response.dto.ts
+++ b/src/modules/party/dto/get-party-by-response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty, ApiResponseProperty } from '@nestjs/swagger';
+import { DateString } from '@ukef/helpers/date-string.type';
+
+export class GetPartyByIdentifierResponse {
+  @ApiResponseProperty()
+  alternateIdentifier: string;
+
+  @ApiResponseProperty()
+  industryClassification: string;
+
+  @ApiResponseProperty()
+  name1: string;
+
+  @ApiResponseProperty()
+  name2: string;
+
+  @ApiResponseProperty()
+  name3: string;
+
+  @ApiResponseProperty()
+  smeType: string;
+
+  @ApiResponseProperty()
+  citizenshipClass: string;
+
+  @ApiProperty({ readOnly: true, type: Date, nullable: true })
+  officerRiskDate: DateString;
+
+  @ApiResponseProperty()
+  countryCode: string;
+}

--- a/src/modules/party/party.controller.test.ts
+++ b/src/modules/party/party.controller.test.ts
@@ -14,8 +14,14 @@ describe('PartyController', () => {
   let partyService: PartyService;
   let controller: PartyController;
 
+  let partyServiceGetPartyByIdentifier: jest.Mock;
+
   beforeEach(() => {
     partyService = new PartyService({ baseUrl: valueGenerator.httpsUrl() }, null, null, null);
+
+    partyServiceGetPartyByIdentifier = jest.fn();
+    partyService.getPartyByIdentifier = partyServiceGetPartyByIdentifier;
+
     controller = new PartyController(null, partyService);
   });
 
@@ -25,8 +31,7 @@ describe('PartyController', () => {
     const expectedParty = partiesFromApi[0];
 
     it('returns the party from the service', async () => {
-      // eslint-disable-next-line jest/unbound-method
-      when(partyService.getPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyFromService);
+      when(partyServiceGetPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyFromService);
 
       const party = await controller.getPartyByIdentifier(partyIdentifier);
 
@@ -38,8 +43,7 @@ describe('PartyController', () => {
         ...partyFromService,
         unexpectedKey: valueGenerator.string(),
       };
-      // eslint-disable-next-line jest/unbound-method
-      when(partyService.getPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyWithUnexpectedKey);
+      when(partyServiceGetPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyWithUnexpectedKey);
 
       const party = await controller.getPartyByIdentifier(partyIdentifier);
 

--- a/src/modules/party/party.controller.test.ts
+++ b/src/modules/party/party.controller.test.ts
@@ -1,0 +1,50 @@
+import { PartyGenerator } from '@ukef-test/support/generator/party-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { PartyController } from './party.controller';
+import { PartyService } from './party.service';
+
+jest.mock('./party.service');
+
+describe('PartyController', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const partyIdentifier = valueGenerator.stringOfNumericCharacters();
+
+  let partyService: PartyService;
+  let controller: PartyController;
+
+  beforeEach(() => {
+    partyService = new PartyService({ baseUrl: valueGenerator.httpsUrl() }, null, null, null);
+    controller = new PartyController(null, partyService);
+  });
+
+  describe('getPartyByIdentifier', () => {
+    const { parties, partiesFromApi } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+    const partyFromService = parties[0];
+    const expectedParty = partiesFromApi[0];
+
+    it('returns the party from the service', async () => {
+      // eslint-disable-next-line jest/unbound-method
+      when(partyService.getPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyFromService);
+
+      const party = await controller.getPartyByIdentifier(partyIdentifier);
+
+      expect(party).toStrictEqual(expectedParty);
+    });
+
+    it.skip('does NOT return unexpected keys for the party from the service', async () => {
+      // TODO APIM-78: do we want to do this, or should this be middleware?
+      const partyWithUnexpectedKey = {
+        ...partyFromService,
+        unexpectedKey: valueGenerator.string(),
+      };
+      // eslint-disable-next-line jest/unbound-method
+      when(partyService.getPartyByIdentifier).calledWith(partyIdentifier).mockResolvedValueOnce(partyWithUnexpectedKey);
+
+      const party = await controller.getPartyByIdentifier(partyIdentifier);
+
+      expect(party).toStrictEqual(expectedParty);
+    });
+  });
+});

--- a/src/modules/party/party.controller.test.ts
+++ b/src/modules/party/party.controller.test.ts
@@ -33,8 +33,7 @@ describe('PartyController', () => {
       expect(party).toStrictEqual(expectedParty);
     });
 
-    it.skip('does NOT return unexpected keys for the party from the service', async () => {
-      // TODO APIM-78: do we want to do this, or should this be middleware?
+    it('does NOT return unexpected keys for the party from the service', async () => {
       const partyWithUnexpectedKey = {
         ...partyFromService,
         unexpectedKey: valueGenerator.string(),

--- a/src/modules/party/party.controller.ts
+++ b/src/modules/party/party.controller.ts
@@ -49,7 +49,18 @@ export class PartyController {
   @ApiInternalServerErrorResponse({
     description: 'An internal server error has occurred.',
   })
-  getPartyByIdentifier(@Param('partyIdentifier') partyIdentifier: string): Promise<GetPartyByIdentifierResponse> {
-    return this.partyService.getPartyByIdentifier(partyIdentifier);
+  async getPartyByIdentifier(@Param('partyIdentifier') partyIdentifier: string): Promise<GetPartyByIdentifierResponse> {
+    const party = await this.partyService.getPartyByIdentifier(partyIdentifier);
+    return {
+      alternateIdentifier: party.alternateIdentifier,
+      industryClassification: party.industryClassification,
+      name1: party.name1,
+      name2: party.name2,
+      name3: party.name3,
+      smeType: party.smeType,
+      citizenshipClass: party.citizenshipClass,
+      officerRiskDate: party.officerRiskDate,
+      countryCode: party.countryCode,
+    };
   }
 }

--- a/src/modules/party/party.controller.ts
+++ b/src/modules/party/party.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Query } from '@nestjs/common';
-import { ApiInternalServerErrorResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
 
 import { AcbsAuthenticationService } from '../acbs/acbs-authentication.service';
 import { GetPartiesBySearchTextResponse, GetPartiesBySearchTextResponseElement } from './dto/get-parties-by-search-text-response-element.dto';
+import { GetPartyByIdentifierResponse } from './dto/get-party-by-response.dto';
 import { PartiesQueryDto } from './dto/parties-query.dto';
 import { PartyService } from './party.service';
 
@@ -27,5 +28,28 @@ export class PartyController {
     const response = await this.partyService.getPartiesBySearchText(token, query.searchText);
 
     return response;
+  }
+
+  @Get(':partyIdentifier')
+  @ApiOperation({ summary: 'Get the party matching the specified party identifier.' })
+  @ApiParam({
+    name: 'partyIdentifier',
+    required: true,
+    type: 'string',
+    description: 'The identifier of the party in ACBS.',
+    example: '00000001',
+  })
+  @ApiOkResponse({
+    description: 'The party has been successfully retrieved.',
+    type: GetPartyByIdentifierResponse,
+  })
+  @ApiNotFoundResponse({
+    description: 'The specified party was not found.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An internal server error has occurred.',
+  })
+  getPartyByIdentifier(@Param('partyIdentifier') partyIdentifier: string): Promise<GetPartyByIdentifierResponse> {
+    return this.partyService.getPartyByIdentifier(partyIdentifier);
   }
 }

--- a/src/modules/party/party.interface.ts
+++ b/src/modules/party/party.interface.ts
@@ -1,0 +1,13 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
+export interface Party {
+  alternateIdentifier: string;
+  industryClassification: string;
+  name1: string;
+  name2: string;
+  name3: string;
+  smeType: string;
+  citizenshipClass: string;
+  officerRiskDate: DateString;
+  countryCode: string;
+}

--- a/src/modules/party/party.service.get-party-by-identifier.test.ts
+++ b/src/modules/party/party.service.get-party-by-identifier.test.ts
@@ -20,13 +20,21 @@ describe('PartyService', () => {
   let acbsPartyService: AcbsPartyService;
   let service: PartyService;
 
+  let acbsPartyServiceGetPartyByIdentifier: jest.Mock;
+
   beforeEach(() => {
-    acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
     acbsPartyService = new AcbsPartyService(null, null);
+
+    acbsPartyServiceGetPartyByIdentifier = jest.fn();
+    acbsPartyService.getPartyByIdentifier = acbsPartyServiceGetPartyByIdentifier;
+
+    acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
+    const acbsAuthenticationServiceGetIdToken = jest.fn();
+    acbsAuthenticationService.getIdToken = acbsAuthenticationServiceGetIdToken;
+
     service = new PartyService({ baseUrl }, null, acbsAuthenticationService, acbsPartyService);
 
-    // eslint-disable-next-line jest/unbound-method
-    when(acbsAuthenticationService.getIdToken).calledWith().mockResolvedValueOnce(idToken);
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
   });
 
   describe('getPartyByIdentifier', () => {
@@ -44,8 +52,7 @@ describe('PartyService', () => {
         ...parties[0],
         officerRiskDate: expectedOfficerRiskDate,
       };
-      // eslint-disable-next-line jest/unbound-method
-      when(acbsPartyService.getPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
+      when(acbsPartyServiceGetPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
 
       const party = await service.getPartyByIdentifier(partyIdentifier);
 
@@ -62,8 +69,7 @@ describe('PartyService', () => {
         ...parties[0],
         officerRiskDate: null,
       };
-      // eslint-disable-next-line jest/unbound-method
-      when(acbsPartyService.getPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
+      when(acbsPartyServiceGetPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
 
       const party = await service.getPartyByIdentifier(partyIdentifier);
 

--- a/src/modules/party/party.service.get-party-by-identifier.test.ts
+++ b/src/modules/party/party.service.get-party-by-identifier.test.ts
@@ -1,0 +1,73 @@
+import { PartyGenerator } from '@ukef-test/support/generator/party-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { AcbsAuthenticationService } from '../acbs/acbs-authentication.service';
+import { AcbsPartyService } from '../acbs/acbs-party.service';
+import { AcbsGetPartyResponseDto } from '../acbs/dto/acbs-get-party-response.dto';
+import { Party } from './party.interface';
+import { PartyService } from './party.service';
+
+jest.mock('@ukef/modules/acbs/acbs-party.service');
+jest.mock('@ukef/modules/acbs/acbs-authentication.service');
+
+describe('PartyService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+
+  let acbsAuthenticationService: AcbsAuthenticationService;
+  let acbsPartyService: AcbsPartyService;
+  let service: PartyService;
+
+  beforeEach(() => {
+    acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
+    acbsPartyService = new AcbsPartyService(null, null);
+    service = new PartyService({ baseUrl }, null, acbsAuthenticationService, acbsPartyService);
+
+    // eslint-disable-next-line jest/unbound-method
+    when(acbsAuthenticationService.getIdToken).calledWith().mockResolvedValueOnce(idToken);
+  });
+
+  describe('getPartyByIdentifier', () => {
+    const partyIdentifier = valueGenerator.stringOfNumericCharacters();
+
+    it('returns a transformation of the external ratings from ACBS when OfficerRiskDate IS NOT null', async () => {
+      const officerRiskDateInAcbs = '2023-02-01T00:00:00Z';
+      const expectedOfficerRiskDate = '2023-02-01';
+      const { partiesInAcbs, parties } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+      const partyInAcbs: AcbsGetPartyResponseDto = {
+        ...partiesInAcbs[0],
+        OfficerRiskDate: officerRiskDateInAcbs,
+      };
+      const expectedParty: Party = {
+        ...parties[0],
+        officerRiskDate: expectedOfficerRiskDate,
+      };
+      // eslint-disable-next-line jest/unbound-method
+      when(acbsPartyService.getPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
+
+      const party = await service.getPartyByIdentifier(partyIdentifier);
+
+      expect(party).toStrictEqual(expectedParty);
+    });
+
+    it('returns a transformation of the external ratings from ACBS when OfficerRiskDate IS null', async () => {
+      const { partiesInAcbs, parties } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+      const partyInAcbs: AcbsGetPartyResponseDto = {
+        ...partiesInAcbs[0],
+        OfficerRiskDate: null,
+      };
+      const expectedParty: Party = {
+        ...parties[0],
+        officerRiskDate: null,
+      };
+      // eslint-disable-next-line jest/unbound-method
+      when(acbsPartyService.getPartyByIdentifier).calledWith(partyIdentifier, idToken).mockResolvedValueOnce(partyInAcbs);
+
+      const party = await service.getPartyByIdentifier(partyIdentifier);
+
+      expect(party).toStrictEqual(expectedParty);
+    });
+  });
+});

--- a/src/modules/party/party.service.test.ts
+++ b/src/modules/party/party.service.test.ts
@@ -14,6 +14,8 @@ describe('PartyService', () => {
   let httpService: HttpService;
   let partyService: PartyService;
 
+  let httpServiceGet: jest.Mock;
+
   const getExpectedGetPartiesBySearchTextArguments = (searchText: string): [string, object] => [
     '/Party/Search/' + searchText,
     {
@@ -65,6 +67,10 @@ describe('PartyService', () => {
 
   beforeEach(() => {
     httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
     partyService = new PartyService(config, httpService, null, null);
   });
 
@@ -160,8 +166,7 @@ describe('PartyService', () => {
     it('returns an empty array if the request is successful and there are no matching parties', async () => {
       const searchText = 'searchText';
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(...getExpectedGetPartiesBySearchTextArguments(searchText))
         .mockReturnValueOnce(
           of({
@@ -184,8 +189,7 @@ describe('PartyService', () => {
       const searchText = 'searchText';
       const getPartiesError = new AxiosError();
 
-      // eslint-disable-next-line jest/unbound-method
-      when(httpService.get)
+      when(httpServiceGet)
         .calledWith(...getExpectedGetPartiesBySearchTextArguments(searchText))
         .mockReturnValueOnce(throwError(() => getPartiesError));
 
@@ -222,8 +226,7 @@ describe('PartyService', () => {
   });
 
   function mockSuccessfulAcbsGetPartiesBySearchTextRequest(searchText: string, response: AcbsGetPartiesBySearchTextResponseElement[]): void {
-    // eslint-disable-next-line jest/unbound-method
-    when(httpService.get)
+    when(httpServiceGet)
       .calledWith(...getExpectedGetPartiesBySearchTextArguments(searchText))
       .mockReturnValueOnce(
         of({

--- a/src/modules/party/party.service.test.ts
+++ b/src/modules/party/party.service.test.ts
@@ -65,7 +65,7 @@ describe('PartyService', () => {
 
   beforeEach(() => {
     httpService = new HttpService();
-    partyService = new PartyService(config, httpService);
+    partyService = new PartyService(config, httpService, null, null);
   });
 
   describe('successful request', () => {

--- a/src/modules/tfs.module.ts
+++ b/src/modules/tfs.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AcbsModule } from '@ukef/module/acbs/acbs.module';
+import { PartyModule } from '@ukef/modules/party/party.module';
 import { PartyExternalRatingModule } from '@ukef/modules/party-external-rating/party-external-rating.module';
 
 import { AcbsExceptionTransformInterceptor } from './acbs-adapter/acbs-exception-transform.interceptor';
-import { PartyModule } from './party/party.module';
 
 @Module({
   imports: [AcbsModule, PartyExternalRatingModule, PartyModule],

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -10,27 +10,6 @@ paths:
       responses:
         '200':
           description: ''
-  /api/v1/parties:
-    get:
-      operationId: PartyController_getPartyBySearchText
-      summary: Get all parties matching the specified search text.
-      parameters:
-        - name: searchText
-          required: true
-          in: query
-          schema:
-            type: string
-      responses:
-        '200':
-          description: The matching parties have been successfully retrieved.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/GetPartyBySearchTextResponseElement'
-        '500':
-          description: An internal server error has occurred.
   /api/v1/parties/{partyIdentifier}:
     get:
       operationId: PartyController_getPartyByIdentifier
@@ -90,46 +69,6 @@ tags: []
 servers: []
 components:
   schemas:
-    GetPartyBySearchTextResponseElement:
-      type: object
-      properties:
-        alternateIdentifier:
-          type: string
-          readOnly: true
-        industryClassification:
-          type: string
-          readOnly: true
-        name1:
-          type: string
-          readOnly: true
-        name2:
-          type: string
-          readOnly: true
-        name3:
-          type: string
-          readOnly: true
-        smeType:
-          type: string
-          readOnly: true
-        citizenshipClass:
-          type: string
-          readOnly: true
-        officerRiskDate:
-          type: string
-          readOnly: true
-        countryCode:
-          type: string
-          readOnly: true
-      required:
-        - alternateIdentifier
-        - industryClassification
-        - name1
-        - name2
-        - name3
-        - smeType
-        - citizenshipClass
-        - officerRiskDate
-        - countryCode
     GetPartyByIdentifierResponse:
       type: object
       properties:

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -10,29 +10,6 @@ paths:
       responses:
         '200':
           description: ''
-  /api/v1/parties/{partyIdentifier}:
-    get:
-      operationId: PartyController_getPartyByIdentifier
-      summary: Get the party matching the specified party identifier.
-      parameters:
-        - name: partyIdentifier
-          required: true
-          in: path
-          description: The identifier of the party in ACBS.
-          example: '00000001'
-          schema:
-            type: string
-      responses:
-        '200':
-          description: The party has been successfully retrieved.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetPartyByIdentifierResponse'
-        '404':
-          description: The specified party was not found.
-        '500':
-          description: An internal server error has occurred.
   /api/v1/parties/{partyIdentifier}/external-ratings:
     get:
       operationId: PartyExternalRatingController_getExternalRatingsForParty
@@ -60,6 +37,52 @@ paths:
             not found.
         '500':
           description: An internal server error has occurred.
+  /api/v1/parties:
+    get:
+      operationId: PartyController_getPartiesBySearchText
+      summary: Get all parties matching the specified search text.
+      parameters:
+        - name: searchText
+          required: true
+          in: query
+          description: 'Minimum length: 3'
+          schema:
+            minLength: 3
+            type: string
+      responses:
+        '200':
+          description: The matching parties have been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetPartiesBySearchTextResponseElement'
+        '500':
+          description: An internal server error has occurred.
+  /api/v1/parties/{partyIdentifier}:
+    get:
+      operationId: PartyController_getPartyByIdentifier
+      summary: Get the party matching the specified party identifier.
+      parameters:
+        - name: partyIdentifier
+          required: true
+          in: path
+          description: The identifier of the party in ACBS.
+          example: '00000001'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The party has been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPartyByIdentifierResponse'
+        '404':
+          description: The specified party was not found.
+        '500':
+          description: An internal server error has occurred.
 info:
   title: TFS API Specification
   description: TFS API documentation
@@ -69,48 +92,6 @@ tags: []
 servers: []
 components:
   schemas:
-    GetPartyByIdentifierResponse:
-      type: object
-      properties:
-        alternateIdentifier:
-          type: string
-          readOnly: true
-        industryClassification:
-          type: string
-          readOnly: true
-        name1:
-          type: string
-          readOnly: true
-        name2:
-          type: string
-          readOnly: true
-        name3:
-          type: string
-          readOnly: true
-        smeType:
-          type: string
-          readOnly: true
-        citizenshipClass:
-          type: string
-          readOnly: true
-        officerRiskDate:
-          format: date-time
-          type: string
-          readOnly: true
-          nullable: true
-        countryCode:
-          type: string
-          readOnly: true
-      required:
-        - alternateIdentifier
-        - industryClassification
-        - name1
-        - name2
-        - name3
-        - smeType
-        - citizenshipClass
-        - officerRiskDate
-        - countryCode
     GetPartyExternalRatingResponseRatingEntity:
       type: object
       properties:
@@ -179,5 +160,87 @@ components:
         - externalRatingNote2
         - externalRatingUserCode1
         - externalRatingUserCode2
+    GetPartiesBySearchTextResponseElement:
+      type: object
+      properties:
+        alternateIdentifier:
+          type: string
+          readOnly: true
+        industryClassification:
+          type: string
+          readOnly: true
+        name1:
+          type: string
+          readOnly: true
+        name2:
+          type: string
+          readOnly: true
+        name3:
+          type: string
+          readOnly: true
+        smeType:
+          type: string
+          readOnly: true
+        citizenshipClass:
+          type: string
+          readOnly: true
+        officerRiskDate:
+          type: string
+          readOnly: true
+        countryCode:
+          type: string
+          readOnly: true
+      required:
+        - alternateIdentifier
+        - industryClassification
+        - name1
+        - name2
+        - name3
+        - smeType
+        - citizenshipClass
+        - officerRiskDate
+        - countryCode
+    GetPartyByIdentifierResponse:
+      type: object
+      properties:
+        alternateIdentifier:
+          type: string
+          readOnly: true
+        industryClassification:
+          type: string
+          readOnly: true
+        name1:
+          type: string
+          readOnly: true
+        name2:
+          type: string
+          readOnly: true
+        name3:
+          type: string
+          readOnly: true
+        smeType:
+          type: string
+          readOnly: true
+        citizenshipClass:
+          type: string
+          readOnly: true
+        officerRiskDate:
+          format: date-time
+          type: string
+          readOnly: true
+          nullable: true
+        countryCode:
+          type: string
+          readOnly: true
+      required:
+        - alternateIdentifier
+        - industryClassification
+        - name1
+        - name2
+        - name3
+        - smeType
+        - citizenshipClass
+        - officerRiskDate
+        - countryCode
 "
 `;

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GET /docs-yaml matches the snapshot 1`] = `
+"openapi: 3.0.0
+paths:
+  /api/v1/test:
+    get:
+      operationId: TestController_getToken
+      parameters: []
+      responses:
+        '200':
+          description: ''
+  /api/v1/parties:
+    get:
+      operationId: PartyController_getPartyBySearchText
+      summary: Get all parties matching the specified search text.
+      parameters:
+        - name: searchText
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The matching parties have been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetPartyBySearchTextResponseElement'
+        '500':
+          description: An internal server error has occurred.
+  /api/v1/parties/{partyIdentifier}:
+    get:
+      operationId: PartyController_getPartyByIdentifier
+      summary: Get the party matching the specified party identifier.
+      parameters:
+        - name: partyIdentifier
+          required: true
+          in: path
+          description: The identifier of the party in ACBS.
+          example: '00000001'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The party has been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPartyByIdentifierResponse'
+        '404':
+          description: The specified party was not found.
+        '500':
+          description: An internal server error has occurred.
+  /api/v1/parties/{partyIdentifier}/external-ratings:
+    get:
+      operationId: PartyExternalRatingController_getExternalRatingsForParty
+      summary: Get all external ratings for a party.
+      parameters:
+        - name: partyIdentifier
+          required: true
+          in: path
+          description: The identifier of the party in ACBS.
+          example: '00000001'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The external ratings for the party have been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetPartyExternalRatingsResponseElement'
+        '404':
+          description: >-
+            The specified party, or the external ratings for that party, were
+            not found.
+        '500':
+          description: An internal server error has occurred.
+info:
+  title: TFS API Specification
+  description: TFS API documentation
+  version: '1.0'
+  contact: {}
+tags: []
+servers: []
+components:
+  schemas:
+    GetPartyBySearchTextResponseElement:
+      type: object
+      properties:
+        alternateIdentifier:
+          type: string
+          readOnly: true
+        industryClassification:
+          type: string
+          readOnly: true
+        name1:
+          type: string
+          readOnly: true
+        name2:
+          type: string
+          readOnly: true
+        name3:
+          type: string
+          readOnly: true
+        smeType:
+          type: string
+          readOnly: true
+        citizenshipClass:
+          type: string
+          readOnly: true
+        officerRiskDate:
+          type: string
+          readOnly: true
+        countryCode:
+          type: string
+          readOnly: true
+      required:
+        - alternateIdentifier
+        - industryClassification
+        - name1
+        - name2
+        - name3
+        - smeType
+        - citizenshipClass
+        - officerRiskDate
+        - countryCode
+    GetPartyByIdentifierResponse:
+      type: object
+      properties:
+        alternateIdentifier:
+          type: string
+          readOnly: true
+        industryClassification:
+          type: string
+          readOnly: true
+        name1:
+          type: string
+          readOnly: true
+        name2:
+          type: string
+          readOnly: true
+        name3:
+          type: string
+          readOnly: true
+        smeType:
+          type: string
+          readOnly: true
+        citizenshipClass:
+          type: string
+          readOnly: true
+        officerRiskDate:
+          format: date-time
+          type: string
+          readOnly: true
+          nullable: true
+        countryCode:
+          type: string
+          readOnly: true
+      required:
+        - alternateIdentifier
+        - industryClassification
+        - name1
+        - name2
+        - name3
+        - smeType
+        - citizenshipClass
+        - officerRiskDate
+        - countryCode
+    GetPartyExternalRatingResponseRatingEntity:
+      type: object
+      properties:
+        ratingEntityCode:
+          type: string
+          readOnly: true
+      required:
+        - ratingEntityCode
+    GetPartyExternalRatingResponseAssignedRating:
+      type: object
+      properties:
+        assignedRatingCode:
+          type: string
+          readOnly: true
+      required:
+        - assignedRatingCode
+    GetPartyExternalRatingsResponseElement:
+      type: object
+      properties:
+        partyIdentifier:
+          type: string
+          readOnly: true
+        ratingEntity:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/GetPartyExternalRatingResponseRatingEntity'
+        assignedRating:
+          readOnly: true
+          allOf:
+            - $ref: >-
+                #/components/schemas/GetPartyExternalRatingResponseAssignedRating
+        ratedDate:
+          format: date-time
+          type: string
+          readOnly: true
+        probabilityofDefault:
+          type: number
+          readOnly: true
+        lossGivenDefault:
+          type: number
+          readOnly: true
+        riskWeighting:
+          type: number
+          readOnly: true
+        externalRatingNote1:
+          type: string
+          readOnly: true
+        externalRatingNote2:
+          type: string
+          readOnly: true
+        externalRatingUserCode1:
+          type: string
+          readOnly: true
+        externalRatingUserCode2:
+          type: string
+          readOnly: true
+      required:
+        - partyIdentifier
+        - ratingEntity
+        - assignedRating
+        - ratedDate
+        - probabilityofDefault
+        - lossGivenDefault
+        - riskWeighting
+        - externalRatingNote1
+        - externalRatingNote2
+        - externalRatingUserCode1
+        - externalRatingUserCode2
+"
+`;

--- a/test/docs/get-docs-yaml.api-test.ts
+++ b/test/docs/get-docs-yaml.api-test.ts
@@ -1,0 +1,30 @@
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+
+describe('GET /docs-yaml', () => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  it('returns a 200 OK response', async () => {
+    const { status } = await api.getWithBasicAuth('/docs-yaml', {
+      username: ENVIRONMENT_VARIABLES.SWAGGER_USER,
+      password: ENVIRONMENT_VARIABLES.SWAGGER_PASSWORD,
+    });
+    expect(status).toBe(200);
+  });
+
+  it('matches the snapshot', async () => {
+    const { text } = await api.getWithBasicAuth('/docs-yaml', {
+      username: ENVIRONMENT_VARIABLES.SWAGGER_USER,
+      password: ENVIRONMENT_VARIABLES.SWAGGER_PASSWORD,
+    });
+    expect(text).toMatchSnapshot();
+  });
+});

--- a/test/party-external-rating/get-party-external-ratings.api-test.ts
+++ b/test/party-external-rating/get-party-external-ratings.api-test.ts
@@ -82,7 +82,7 @@ describe('GET /parties/{partyIdentifier}/external-ratings', () => {
     });
   });
 
-  it('returns a 500 response if ACBS if ACBS returns a status code that is NOT 200 or 400', async () => {
+  it('returns a 500 response if getting the external ratings from ACBS returns a status code that is NOT 200 or 400', async () => {
     givenAuthenticationWithTheIdpSucceeds();
     requestToGetExternalRatingsForParty().reply(401);
 

--- a/test/party/get-party-by-party-identifier.api-test.ts
+++ b/test/party/get-party-by-party-identifier.api-test.ts
@@ -1,0 +1,102 @@
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { PartyGenerator } from '@ukef-test/support/generator/party-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+describe('GET /parties/{partyIdentifier}', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const partyIdentifier = '001';
+  const getPartyUrl = `/api/v1/parties/${partyIdentifier}`;
+
+  let api: Api;
+
+  const { partiesInAcbs, partiesFromApi } = new PartyGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+  const partyInAcbs = partiesInAcbs[0];
+  const expectedParty = partiesFromApi[0];
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => requestToGetParty().reply(200, partyInAcbs),
+    makeRequest: () => api.get(getPartyUrl),
+  });
+
+  it('returns a 200 response with the party if it is returned by ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetParty().reply(200, partyInAcbs);
+
+    const { status, body } = await api.get(getPartyUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedParty)));
+  });
+
+  it('returns a 404 response if ACBS returns a 400 response with the string "Party not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetParty().reply(400, 'Party not found');
+
+    const { status, body } = await api.get(getPartyUrl);
+
+    expect(status).toBe(404);
+    expect(body).toStrictEqual({
+      statusCode: 404,
+      message: 'Not found',
+    });
+  });
+
+  it('returns a 500 response if ACBS returns a 400 response without the string "Party not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetParty().reply(400, 'An error message from ACBS.');
+
+    const { status, body } = await api.get(getPartyUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns a 500 response if getting the party from ACBS returns a status code that is NOT 200 or 400', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetParty().reply(401);
+
+    const { status, body } = await api.get(getPartyUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns a 500 response if getting the party from ACBS times out', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetParty()
+      .delay(ENVIRONMENT_VARIABLES.ACBS_TIMEOUT + 500)
+      .reply(200, partyInAcbs);
+
+    const { status, body } = await api.get(getPartyUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  const requestToGetParty = () => nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL).get(`/Party/${partyIdentifier}`).matchHeader('authorization', `Bearer ${idToken}`);
+});

--- a/test/support/api.ts
+++ b/test/support/api.ts
@@ -14,6 +14,10 @@ export class Api {
     return request(this.app.getHttpServer()).get(url);
   }
 
+  getWithBasicAuth(url: string, { username, password }: { username: string; password: string }): request.Test {
+    return request(this.app.getHttpServer()).get(url).auth(username, password);
+  }
+
   destroy(): Promise<void> {
     return this.app.destroy();
   }

--- a/test/support/generator/abstract-generator.ts
+++ b/test/support/generator/abstract-generator.ts
@@ -1,0 +1,16 @@
+import { RandomValueGenerator } from './random-value-generator';
+
+export abstract class AbstractGenerator<TRawValues, TGeneratedValues, TOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {}
+
+  generate(options: { numberToGenerate: number } & TOptions): TGeneratedValues {
+    const values = Array(options.numberToGenerate)
+      .fill(0)
+      .map(() => this.generateValues());
+    return this.transformRawValuesToGeneratedValues(values, options);
+  }
+
+  protected abstract generateValues(): TRawValues;
+
+  protected abstract transformRawValuesToGeneratedValues(values: TRawValues[], options: TOptions): TGeneratedValues;
+}

--- a/test/support/generator/party-external-rating-generator.ts
+++ b/test/support/generator/party-external-rating-generator.ts
@@ -3,16 +3,25 @@ import { AcbsPartyExternalRatingsResponseDto } from '@ukef/modules/acbs/dto/acbs
 import { GetPartyExternalRatingsResponse } from '@ukef/modules/party-external-rating/dto/get-party-external-ratings-response.dto';
 import { PartyExternalRating } from '@ukef/modules/party-external-rating/party-external-rating.interface';
 
-import { RandomValueGenerator } from './random-value-generator';
+import { AbstractGenerator } from './abstract-generator';
 
-export class PartyExternalRatingGenerator {
-  constructor(private readonly valueGenerator: RandomValueGenerator) {}
+export class PartyExternalRatingGenerator extends AbstractGenerator<PartyExternalRatingValues, GenerateResult, GenerateOptions> {
+  protected generateValues(): PartyExternalRatingValues {
+    return {
+      ratingEntityCode: this.valueGenerator.stringOfNumericCharacters(),
+      assignedRatingCode: this.valueGenerator.stringOfNumericCharacters(),
+      ratedDate: this.valueGenerator.date().toISOString(),
+      probabilityofDefault: this.valueGenerator.probabilityFloat(),
+      lossGivenDefault: this.valueGenerator.nonnegativeFloat(),
+      riskWeighting: this.valueGenerator.nonnegativeFloat(),
+      externalRatingNote1: this.valueGenerator.string(),
+      externalRatingNote2: this.valueGenerator.string(),
+      externalRatingUserCode1: this.valueGenerator.string(),
+      externalRatingUserCode2: this.valueGenerator.string(),
+    };
+  }
 
-  generate({ partyIdentifier, numberToGenerate }: GenerateOptions): GenerateResult {
-    const values = Array(numberToGenerate)
-      .fill(0)
-      .map(() => this.generateValues());
-
+  protected transformRawValuesToGeneratedValues(values: PartyExternalRatingValues[], { partyIdentifier }: GenerateOptions): GenerateResult {
     const externalRatingsInAcbs: AcbsPartyExternalRatingsResponseDto = values.map((v) => ({
       PartyIdentifier: partyIdentifier,
       RatingEntity: {
@@ -61,21 +70,6 @@ export class PartyExternalRatingGenerator {
       externalRatingsFromApi,
     };
   }
-
-  private generateValues(): PartyExternalRatingValues {
-    return {
-      ratingEntityCode: this.valueGenerator.stringOfNumericCharacters(),
-      assignedRatingCode: this.valueGenerator.stringOfNumericCharacters(),
-      ratedDate: this.valueGenerator.date().toISOString(),
-      probabilityofDefault: this.valueGenerator.probabilityFloat(),
-      lossGivenDefault: this.valueGenerator.nonnegativeFloat(),
-      riskWeighting: this.valueGenerator.nonnegativeFloat(),
-      externalRatingNote1: this.valueGenerator.string(),
-      externalRatingNote2: this.valueGenerator.string(),
-      externalRatingUserCode1: this.valueGenerator.string(),
-      externalRatingUserCode2: this.valueGenerator.string(),
-    };
-  }
 }
 
 interface PartyExternalRatingValues {
@@ -93,7 +87,6 @@ interface PartyExternalRatingValues {
 
 interface GenerateOptions {
   partyIdentifier: string;
-  numberToGenerate: number;
 }
 
 interface GenerateResult {

--- a/test/support/generator/party-generator.ts
+++ b/test/support/generator/party-generator.ts
@@ -1,0 +1,85 @@
+import { AcbsGetPartyResponseDto } from '@ukef/modules/acbs/dto/acbs-get-party-response.dto';
+import { GetPartyByIdentifierResponse } from '@ukef/modules/party/dto/get-party-by-response.dto';
+import { Party } from '@ukef/modules/party/party.interface';
+
+import { AbstractGenerator } from './abstract-generator';
+
+export class PartyGenerator extends AbstractGenerator<PartyValues, GenerateResult, GenerateOptions> {
+  protected generateValues(): PartyValues {
+    return {
+      alternateIdentifier: this.valueGenerator.stringOfNumericCharacters(),
+      industryClassification: this.valueGenerator.stringOfNumericCharacters(),
+      name1: this.valueGenerator.string(),
+      name2: this.valueGenerator.string(),
+      name3: this.valueGenerator.string(),
+      smeType: this.valueGenerator.stringOfNumericCharacters(),
+      citizenshipClass: this.valueGenerator.stringOfNumericCharacters(),
+      officerRiskDate: this.valueGenerator.date(),
+      countryCode: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: PartyValues[], options: GenerateOptions): GenerateResult {
+    const partiesInAcbs = values.map((v, index) => ({
+      PartyAlternateIdentifier: this.getPartyAlternateIdentifier(v.alternateIdentifier, index, options.basePartyAlternateIdentifier),
+      IndustryClassification: { IndustryClassificationCode: v.industryClassification },
+      PartyName1: v.name1,
+      PartyName2: v.name2,
+      PartyName3: v.name3,
+      MinorityClass: { MinorityClassCode: v.smeType },
+      CitizenshipClass: { CitizenshipClassCode: v.citizenshipClass },
+      OfficerRiskDate: v.officerRiskDate.toISOString(),
+      PrimaryAddress: { Country: { CountryCode: v.countryCode } },
+    }));
+
+    const parties = values.map((v, index) => ({
+      alternateIdentifier: this.getPartyAlternateIdentifier(v.alternateIdentifier, index, options.basePartyAlternateIdentifier),
+      industryClassification: v.industryClassification,
+      name1: v.name1,
+      name2: v.name2,
+      name3: v.name3,
+      smeType: v.smeType,
+      citizenshipClass: v.citizenshipClass,
+      officerRiskDate: v.officerRiskDate.toISOString().split('T')[0],
+      countryCode: v.countryCode,
+    }));
+
+    const partiesFromApi = parties;
+
+    return {
+      partiesInAcbs,
+      parties,
+      partiesFromApi,
+    };
+  }
+
+  private getPartyAlternateIdentifier(candidateValue: string, partyIndex: number, basePartyAlternateIdentifier?: string): string {
+    if (basePartyAlternateIdentifier === undefined) {
+      return candidateValue;
+    }
+
+    return `${basePartyAlternateIdentifier}${partyIndex}`;
+  }
+}
+
+interface PartyValues {
+  alternateIdentifier: string;
+  industryClassification: string;
+  name1: string;
+  name2: string;
+  name3: string;
+  smeType: string;
+  citizenshipClass: string;
+  officerRiskDate: Date;
+  countryCode: string;
+}
+
+interface GenerateResult {
+  partiesInAcbs: AcbsGetPartyResponseDto[];
+  parties: Party[];
+  partiesFromApi: GetPartyByIdentifierResponse[];
+}
+
+interface GenerateOptions {
+  basePartyAlternateIdentifier?: string;
+}


### PR DESCRIPTION
## Introduction
`GET /parties/{partyIdentifier}` needs to get the party with the given identifier from ACBS

## Resolution
- I've added the new endpoint, `GET /parties/{partyIdentifier}`, to get an authentication token from ACBS and then get the party from ACBS
  - if ACBS returns a 200 response, then we transform and return the party
  - if ACBS returns a 400 response with a message containing "Party not found" then we return a 404
  - if ACBS returns an unexpected error or times out, then we return a 500
- there's no validation on the `partyIdentifier` URL param

## Misc
- I've also added a snapshot test for the swagger yaml we're generating from our decorators, so that we can double-check any changes we make to this
- There is some overlap with APIM-79 which isn't merged yet