### PR TITLE
feat: added unit tests for ApiKeyStrategy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,4 +19,3 @@ ACBS_MAX_REDIRECTS=
 ACBS_TIMEOUT=
 
 API_KEY=your-randomised-api-key
-API_KEY_STRATEGY=api-key

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,9 @@
   },
   "settings": {
     "node": {
+      "allowModules": [
+        "express"
+      ],
       "tryExtensions": [
         ".js",
         ".json",

--- a/src/modules/auth/strategy/api-key.strategy.test.ts
+++ b/src/modules/auth/strategy/api-key.strategy.test.ts
@@ -1,0 +1,147 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AUTH } from '@ukef/constants';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { Request } from 'express';
+import { when } from 'jest-when';
+import { BadRequestError } from 'passport-headerapikey';
+
+import { AuthService } from '../auth.service';
+import { ApiKeyStrategy } from './api-key.strategy';
+
+jest.mock('../auth.service');
+
+describe('ApiKeyStrategy', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const apiKeyHeaderName = AUTH.STRATEGY.toLowerCase();
+  const validApiKey = valueGenerator.string();
+  const otherHeaderName = valueGenerator.word().toLowerCase();
+  const invalidApiKey = valueGenerator.string();
+
+  let error: jest.Mock;
+  let fail: jest.Mock;
+  let pass: jest.Mock;
+  let redirect: jest.Mock;
+  let success: jest.Mock;
+
+  let authService: AuthService;
+
+  let strategy: ApiKeyStrategy;
+
+  beforeEach(() => {
+    authService = new AuthService(null);
+    const authServiceValidateApiKey = jest.fn();
+    authService.validateApiKey = authServiceValidateApiKey;
+
+    when(authServiceValidateApiKey).mockReturnValue(false);
+    when(authServiceValidateApiKey).calledWith(validApiKey).mockReturnValue(true);
+
+    strategy = new ApiKeyStrategy(authService);
+
+    // When Passport uses the strategy to authenticate the request, it will
+    // augment the strategy with the below callbacks. The strategy should
+    // call exactly one of the below callbacks to indicate the result of the
+    // authentication.
+    // See https://github.com/jaredhanson/passport-strategy#augmented-methods
+    // for more details.
+    error = strategy['error'] = jest.fn();
+    fail = strategy['fail'] = jest.fn();
+    pass = strategy['pass'] = jest.fn();
+    redirect = strategy['redirect'] = jest.fn();
+    success = strategy['success'] = jest.fn();
+  });
+
+  describe('authenticate', () => {
+    describe('when the api key header is not present', () => {
+      beforeEach(() => {
+        const requestWithoutApiKeyHeader = createRequestWithHeaders({
+          [otherHeaderName]: validApiKey,
+        });
+        strategy.authenticate(requestWithoutApiKeyHeader);
+      });
+
+      it('does not error', () => {
+        expect(error).not.toHaveBeenCalled();
+      });
+
+      it('fails with a BadRequestError', () => {
+        expect(fail).toHaveBeenCalledTimes(1);
+        expect(fail).toHaveBeenCalledWith(new BadRequestError('Missing API Key'), null);
+      });
+
+      it('does not pass', () => {
+        expect(pass).not.toHaveBeenCalled();
+      });
+
+      it('does not redirect', () => {
+        expect(redirect).not.toHaveBeenCalled();
+      });
+
+      it('does not succeed', () => {
+        expect(success).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the api key header is present and the api key value is invalid', () => {
+      beforeEach(() => {
+        const requestWithIncorrectApiKeyValue = createRequestWithHeaders({
+          [apiKeyHeaderName]: invalidApiKey,
+        });
+        strategy.authenticate(requestWithIncorrectApiKeyValue);
+      });
+
+      it('errors with an UnauthorizedException', () => {
+        expect(error).toHaveBeenCalledTimes(1);
+        expect(error).toHaveBeenCalledWith(new UnauthorizedException());
+      });
+
+      it('does not fail', () => {
+        expect(fail).not.toHaveBeenCalled();
+      });
+
+      it('does not pass', () => {
+        expect(pass).not.toHaveBeenCalled();
+      });
+
+      it('does not redirect', () => {
+        expect(redirect).not.toHaveBeenCalled();
+      });
+
+      it('does not succeed', () => {
+        expect(success).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the api key header is present and the api key value is valid', () => {
+      beforeEach(() => {
+        const requestWithCorrectApiKeyValue = createRequestWithHeaders({
+          [apiKeyHeaderName]: validApiKey,
+          [otherHeaderName]: invalidApiKey,
+        });
+        strategy.authenticate(requestWithCorrectApiKeyValue);
+      });
+
+      it('does not error', () => {
+        expect(error).not.toHaveBeenCalled();
+      });
+
+      it('does not fail', () => {
+        expect(fail).not.toHaveBeenCalled();
+      });
+
+      it('does not pass', () => {
+        expect(pass).not.toHaveBeenCalled();
+      });
+
+      it('does not redirect', () => {
+        expect(redirect).not.toHaveBeenCalled();
+      });
+
+      it('succeeds with `true` as the user and `undefined` as the info', () => {
+        expect(success).toHaveBeenCalledTimes(1);
+        expect(success).toHaveBeenCalledWith(true, undefined);
+      });
+    });
+  });
+
+  const createRequestWithHeaders = (headers: Record<string, string>): Request => ({ headers } as unknown as Request);
+});


### PR DESCRIPTION
## Introduction

We want to merge https://github.com/UK-Export-Finance/tfs-api/pull/21 but we have one final comment to address: unit testing the ApiKeyStrategy.
Note that I can't update that review directly as I don't have permission to push to the repo.

## Resolution

I've added a unit test file for the ApiKeyStrategy. I found the best way to test this was to mimic how passport will use it by calling the authenticate method and checking the correct callback is triggered. This does mean we're testing a bit of 3rd party logic from `passport-headerapikey` which provides the base class we inherit from, but I think this is worth it in this case to get a more meaningful test