### PR TITLE
feat(APIM-73): Add create deal guarantee endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,10 @@
     "consistent-return": "off",
     "no-unused-vars": "off",
     "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-vars": "error",
+    "unused-imports/no-unused-vars": [
+      "error",
+      { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
+    ],
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,3 +10,4 @@
 export * from './acbs.constant';
 export * from './application.constant';
 export * from './auth.constant';
+export * from './properties.constant';

--- a/src/constants/properties.constant.ts
+++ b/src/constants/properties.constant.ts
@@ -1,0 +1,21 @@
+const PROPERTIES = {
+  GLOBAL: {
+    portfolioIdentifier: 'E1',
+  },
+  DEAL_GUARANTEE: {
+    DEFAULT: {
+      sectionIdentifier: '00',
+      guaranteedPercentage: 100,
+      lenderType: {
+        lenderTypeCode: '100',
+      },
+      limitType: {
+        limitTypeCode: '00',
+      },
+      guarantorParty: '00000141',
+      guaranteeTypeCode: '450',
+    },
+  },
+};
+
+export { PROPERTIES };

--- a/src/decorators/validated-date-only-api-property.decorator.ts
+++ b/src/decorators/validated-date-only-api-property.decorator.ts
@@ -1,0 +1,14 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsISO8601, Matches } from 'class-validator';
+
+export const ValidatedDateOnlyApiProperty = ({ description }: { description: string }) =>
+  applyDecorators(
+    ApiProperty({
+      description,
+      type: Date,
+      format: 'date',
+    }),
+    IsISO8601({ strict: true }),
+    Matches(/^\d{4}-\d{2}-\d{2}$/),
+  );

--- a/src/decorators/validated-number-api-property.decorator.ts
+++ b/src/decorators/validated-number-api-property.decorator.ts
@@ -1,24 +1,21 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, Max, Min } from 'class-validator';
+import { IsNotEmpty, Min } from 'class-validator';
 
 interface Options {
   description: string;
   minimum: number;
-  maximum: number;
 }
 
-export const ValidatedNumberApiProperty = ({ description, minimum, maximum }: Options) => {
+export const ValidatedNumberApiProperty = ({ description, minimum }: Options) => {
   const decoratorsToApply = [
     ApiProperty({
       type: 'number',
       description,
       minimum,
-      maximum,
     }),
     IsNotEmpty(),
     Min(minimum),
-    Max(maximum),
   ];
 
   return applyDecorators(...decoratorsToApply);

--- a/src/decorators/validated-number-api-property.decorator.ts
+++ b/src/decorators/validated-number-api-property.decorator.ts
@@ -1,0 +1,25 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, Max, Min } from 'class-validator';
+
+interface Options {
+  description: string;
+  minimum: number;
+  maximum: number;
+}
+
+export const ValidatedNumberApiProperty = ({ description, minimum, maximum }: Options) => {
+  const decoratorsToApply = [
+    ApiProperty({
+      type: 'number',
+      description,
+      minimum,
+      maximum,
+    }),
+    IsNotEmpty(),
+    Min(minimum),
+    Max(maximum),
+  ];
+
+  return applyDecorators(...decoratorsToApply);
+};

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, Length } from 'class-validator';
+
+interface Options {
+  description: string;
+  minLength: number;
+  maxLength: number;
+  example?: string;
+  required?: boolean;
+  default?: string;
+}
+
+export const ValidatedStringApiProperty = ({ description, minLength, maxLength, example, required, default: theDefault }: Options) => {
+  const decoratorsToApply = [
+    ApiProperty({
+      type: 'string',
+      description,
+      example,
+      minLength,
+      maxLength,
+      required,
+      default: theDefault,
+    }),
+    Length(minLength, maxLength),
+  ];
+
+  const isRequiredProperty = required ?? true;
+  if (!isRequiredProperty) {
+    decoratorsToApply.push(IsOptional());
+  }
+  return applyDecorators(...decoratorsToApply);
+};

--- a/src/helpers/date-only-string.type.ts
+++ b/src/helpers/date-only-string.type.ts
@@ -1,0 +1,1 @@
+export type DateOnlyString = string;

--- a/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
+++ b/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
@@ -1,12 +1,16 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { lastValueFrom, throwError } from 'rxjs';
 
+import { AcbsBadRequestException } from '../acbs/exception/acbs-bad-request.exception';
 import { AcbsResourceNotFoundException } from '../acbs/exception/acbs-resource-not-found.exception';
 import { AcbsExceptionTransformInterceptor } from './acbs-exception-transform.interceptor';
 
 describe('AcbsExceptionTransformInterceptor', () => {
+  const valueGenerator = new RandomValueGenerator();
+
   it('converts thrown AcbsResourceNotFoundException to NotFoundException', async () => {
-    const acbsResourceNotFoundException = new AcbsResourceNotFoundException('Test exception');
+    const acbsResourceNotFoundException = new AcbsResourceNotFoundException('Test exception message');
     const interceptor = new AcbsExceptionTransformInterceptor();
 
     const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => acbsResourceNotFoundException) }));
@@ -16,13 +20,25 @@ describe('AcbsExceptionTransformInterceptor', () => {
     await expect(interceptPromise).rejects.toHaveProperty('cause', acbsResourceNotFoundException);
   });
 
-  it('does NOT convert thrown exceptions that are NOT AcbsResourceNotFoundException', async () => {
-    const notAcbsResourceNotFoundException = new Error('Test exception');
+  it('converts thrown AcbsBadRequestException to BadRequestException', async () => {
+    const innerError = new Error();
+    const errorBody = valueGenerator.string();
+    const acbsBadRequestException = new AcbsBadRequestException('Test exception message', innerError, errorBody);
     const interceptor = new AcbsExceptionTransformInterceptor();
 
-    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => notAcbsResourceNotFoundException) }));
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => acbsBadRequestException) }));
 
-    await expect(interceptPromise).rejects.not.toBeInstanceOf(NotFoundException);
-    await expect(interceptPromise).rejects.toThrow(notAcbsResourceNotFoundException);
+    await expect(interceptPromise).rejects.toBeInstanceOf(BadRequestException);
+    await expect(interceptPromise).rejects.toHaveProperty('message', 'Bad request');
+    await expect(interceptPromise).rejects.toHaveProperty('cause', acbsBadRequestException);
+  });
+
+  it('does NOT convert thrown exceptions that are NOT AcbsResourceNotFoundException or AcbsBadRequestException', async () => {
+    const exceptionThatShouldNotBeTransformed = new Error('Test exception');
+    const interceptor = new AcbsExceptionTransformInterceptor();
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => exceptionThatShouldNotBeTransformed) }));
+
+    await expect(interceptPromise).rejects.toThrow(exceptionThatShouldNotBeTransformed);
   });
 });

--- a/src/modules/acbs-adapter/acbs-exception-transform.interceptor.ts
+++ b/src/modules/acbs-adapter/acbs-exception-transform.interceptor.ts
@@ -7,18 +7,20 @@ import { AcbsBadRequestException } from '../acbs/exception/acbs-bad-request.exce
 @Injectable()
 export class AcbsExceptionTransformInterceptor implements NestInterceptor {
   intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
-    return next
-      .handle()
-      .pipe(
-        catchError((err) =>
-          throwError(() =>
-            err instanceof AcbsResourceNotFoundException
-              ? new NotFoundException('Not found', { cause: err })
-              : err instanceof AcbsBadRequestException
-              ? new BadRequestException('Bad request', { cause: err, description: err.errorBody })
-              : err,
-          ),
-        ),
-      );
+    return next.handle().pipe(
+      catchError((err) =>
+        throwError(() => {
+          if (err instanceof AcbsResourceNotFoundException) {
+            return new NotFoundException('Not found', { cause: err });
+          }
+
+          if (err instanceof AcbsBadRequestException) {
+            return new BadRequestException('Bad request', { cause: err, description: err.errorBody });
+          }
+
+          return err;
+        }),
+      ),
+    );
   }
 }

--- a/src/modules/acbs-adapter/acbs-exception-transform.interceptor.ts
+++ b/src/modules/acbs-adapter/acbs-exception-transform.interceptor.ts
@@ -1,12 +1,24 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor, NotFoundException } from '@nestjs/common';
+import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor, NotFoundException } from '@nestjs/common';
 import { AcbsResourceNotFoundException } from '@ukef/modules/acbs/exception/acbs-resource-not-found.exception';
 import { catchError, Observable, throwError } from 'rxjs';
+
+import { AcbsBadRequestException } from '../acbs/exception/acbs-bad-request.exception';
 
 @Injectable()
 export class AcbsExceptionTransformInterceptor implements NestInterceptor {
   intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
     return next
       .handle()
-      .pipe(catchError((err) => throwError(() => (err instanceof AcbsResourceNotFoundException ? new NotFoundException('Not found', { cause: err }) : err))));
+      .pipe(
+        catchError((err) =>
+          throwError(() =>
+            err instanceof AcbsResourceNotFoundException
+              ? new NotFoundException('Not found', { cause: err })
+              : err instanceof AcbsBadRequestException
+              ? new BadRequestException('Bad request', { cause: err, description: err.errorBody })
+              : err,
+          ),
+        ),
+      );
   }
 }

--- a/src/modules/acbs/acbs-deal-guarantee.service.test.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.test.ts
@@ -1,0 +1,194 @@
+import { HttpService } from '@nestjs/axios';
+import { PROPERTIES } from '@ukef/constants';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
+import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
+
+describe('AcbsDealGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const authToken = valueGenerator.string();
+  const baseUrl = valueGenerator.string();
+  const dealIdentifier = valueGenerator.stringOfNumericCharacters();
+  const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+
+  let httpService: HttpService;
+  let service: AcbsDealGuaranteeService;
+
+  let httpServicePost: jest.Mock;
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServicePost = jest.fn();
+    httpService.post = httpServicePost;
+
+    service = new AcbsDealGuaranteeService({ baseUrl }, httpService);
+  });
+
+  describe('createGuaranteeForDeal', () => {
+    const lenderTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
+    const sectionIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 2 });
+    const limitTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 2 });
+    const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guarantorPartyIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
+    const effectiveDate = valueGenerator.dateTimeString();
+    const expirationDate = valueGenerator.dateTimeString();
+    const guaranteedLimit = valueGenerator.nonnegativeFloat();
+    const guaranteedPercentage = valueGenerator.nonnegativeFloat({ max: 100 });
+
+    const newDealGuarantee = {
+      LenderType: {
+        LenderTypeCode: lenderTypeCode,
+      },
+      SectionIdentifier: sectionIdentifier,
+      LimitType: {
+        LimitTypeCode: limitTypeCode,
+      },
+      LimitKey: limitKey,
+      GuarantorParty: {
+        PartyIdentifier: guarantorPartyIdentifier,
+      },
+      GuaranteeType: {
+        GuaranteeTypeCode: guaranteeTypeCode,
+      },
+      EffectiveDate: effectiveDate,
+      ExpirationDate: expirationDate,
+      GuaranteedLimit: guaranteedLimit,
+      GuaranteedPercentage: guaranteedPercentage,
+    };
+
+    it('sends a POST to ACBS with the specified parameters', async () => {
+      when(httpServicePost)
+        .calledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+        })
+        .mockReturnValueOnce(
+          of({
+            data: '',
+            status: 201,
+            statusText: 'Created',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      await service.createGuaranteeForDeal(dealIdentifier, newDealGuarantee, authToken);
+
+      expect(httpServicePost).toHaveBeenCalledTimes(1);
+      expect(httpServicePost).toHaveBeenCalledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+        baseURL: baseUrl,
+        headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+      });
+    });
+
+    it('throws an AcbsResourceNotFoundException if ACBS responds with a 400 that is a string containing "The deal not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = 'The deal not found or the user does not have access to it.';
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createGuaranteeForDealPromise = service.createGuaranteeForDeal(dealIdentifier, newDealGuarantee, authToken);
+
+      await expect(createGuaranteeForDealPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(createGuaranteeForDealPromise).rejects.toThrow(`Deal with identifier ${dealIdentifier} was not found by ACBS.`);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is a string that does not contain "The deal not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = valueGenerator.string();
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createGuaranteeForDealPromise = service.createGuaranteeForDeal(dealIdentifier, newDealGuarantee, authToken);
+
+      await expect(createGuaranteeForDealPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(createGuaranteeForDealPromise).rejects.toThrow(`Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('errorBody', errorString);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is not a string', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createGuaranteeForDealPromise = service.createGuaranteeForDeal(dealIdentifier, newDealGuarantee, authToken);
+
+      await expect(createGuaranteeForDealPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(createGuaranteeForDealPromise).rejects.toThrow(`Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('errorBody', JSON.stringify(errorBody));
+    });
+
+    it('throws an AcbsUnexpectedException if ACBS responds with an error code that is not 400', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: baseUrl,
+          headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+        })
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createGuaranteeForDealPromise = service.createGuaranteeForDeal(dealIdentifier, newDealGuarantee, authToken);
+
+      await expect(createGuaranteeForDealPromise).rejects.toBeInstanceOf(AcbsUnexpectedException);
+      await expect(createGuaranteeForDealPromise).rejects.toThrow(`Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`);
+      await expect(createGuaranteeForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-deal-guarantee.service.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.ts
@@ -1,0 +1,36 @@
+import { HttpService } from '@nestjs/axios';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import AcbsConfig from '@ukef/config/acbs.config';
+import { PROPERTIES } from '@ukef/constants';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
+
+import { AcbsCreateDealGuaranteeDto } from './dto/acbs-create-deal-guarantee.dto';
+import { wrapAcbsHttpPostError } from './wrap-acbs-http-error';
+
+@Injectable()
+export class AcbsDealGuaranteeService {
+  constructor(
+    @Inject(AcbsConfig.KEY)
+    private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    private readonly httpService: HttpService,
+  ) {}
+
+  async createGuaranteeForDeal(dealIdentifier: string, newDealGuarantee: AcbsCreateDealGuaranteeDto, idToken: string): Promise<void> {
+    const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+    await lastValueFrom(
+      this.httpService
+        .post<never>(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
+          baseURL: this.config.baseUrl,
+          headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+        })
+        .pipe(
+          wrapAcbsHttpPostError<AxiosResponse<never, any>, any>({
+            resourceIdentifier: dealIdentifier,
+            messageForUnknownException: `Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`,
+          }),
+        ),
+    );
+  }
+}

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { TestController } from './acbs.controller';
 import { AcbsAuthenticationService } from './acbs-authentication.service';
+import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
 import { AcbsPartyService } from './acbs-party.service';
 import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.service';
 
@@ -19,7 +20,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     }),
   ],
   controllers: [TestController],
-  providers: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService],
-  exports: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService],
+  providers: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService, AcbsDealGuaranteeService],
+  exports: [AcbsAuthenticationService, AcbsPartyService, AcbsPartyExternalRatingService, AcbsDealGuaranteeService],
 })
 export class AcbsModule {}

--- a/src/modules/acbs/dto/acbs-create-deal-guarantee.dto.ts
+++ b/src/modules/acbs/dto/acbs-create-deal-guarantee.dto.ts
@@ -1,0 +1,22 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
+export interface AcbsCreateDealGuaranteeDto {
+  LenderType: {
+    LenderTypeCode: string;
+  };
+  SectionIdentifier: string;
+  LimitType: {
+    LimitTypeCode: string;
+  };
+  LimitKey: string;
+  GuarantorParty: {
+    PartyIdentifier: string;
+  };
+  GuaranteeType: {
+    GuaranteeTypeCode: string;
+  };
+  EffectiveDate: DateString;
+  ExpirationDate: DateString;
+  GuaranteedLimit: number;
+  GuaranteedPercentage: number;
+}

--- a/src/modules/acbs/exception/acbs-bad-request.exception.test.ts
+++ b/src/modules/acbs/exception/acbs-bad-request.exception.test.ts
@@ -1,0 +1,42 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { AcbsException } from './acbs.exception';
+import { AcbsBadRequestException } from './acbs-bad-request.exception';
+
+describe('AcbsAuthenticationFailedException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new AcbsBadRequestException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new AcbsBadRequestException(message);
+
+    expect(exception.name).toBe('AcbsBadRequestException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new AcbsBadRequestException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('exposes the error body it was created with', () => {
+    const innerError = new Error();
+    const errorBody = JSON.stringify({ errorMessage: valueGenerator.string() });
+
+    const exception = new AcbsBadRequestException(message, innerError, errorBody);
+
+    expect(exception.errorBody).toBe(errorBody);
+  });
+
+  it('is instance of AcbsException', () => {
+    expect(new AcbsBadRequestException(message)).toBeInstanceOf(AcbsException);
+  });
+});

--- a/src/modules/acbs/exception/acbs-bad-request.exception.ts
+++ b/src/modules/acbs/exception/acbs-bad-request.exception.ts
@@ -1,0 +1,7 @@
+import { AcbsException } from './acbs.exception';
+
+export class AcbsBadRequestException extends AcbsException {
+  constructor(message: string, innerError?: Error, public readonly errorBody?: string) {
+    super(message, innerError);
+  }
+}

--- a/src/modules/acbs/exception/acbs-unexpected.exception.test.ts
+++ b/src/modules/acbs/exception/acbs-unexpected.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { AcbsException } from './acbs.exception';
+import { AcbsUnexpectedException } from './acbs-unexpected.exception';
+
+describe('AcbsAuthenticationFailedException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new AcbsUnexpectedException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new AcbsUnexpectedException(message);
+
+    expect(exception.name).toBe('AcbsUnexpectedException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new AcbsUnexpectedException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of AcbsException', () => {
+    expect(new AcbsUnexpectedException(message)).toBeInstanceOf(AcbsException);
+  });
+});

--- a/src/modules/acbs/exception/acbs-unexpected.exception.ts
+++ b/src/modules/acbs/exception/acbs-unexpected.exception.ts
@@ -1,0 +1,7 @@
+import { AcbsException } from './acbs.exception';
+
+export class AcbsUnexpectedException extends AcbsException {
+  constructor(message: string, innerError?: Error) {
+    super(message, innerError);
+  }
+}

--- a/src/modules/acbs/wrap-acbs-http-error.ts
+++ b/src/modules/acbs/wrap-acbs-http-error.ts
@@ -2,7 +2,9 @@ import { AxiosError } from 'axios';
 import { catchError, ObservableInput, ObservedValueOf, OperatorFunction } from 'rxjs';
 
 import { AcbsException } from './exception/acbs.exception';
+import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
 import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
 
 export function wrapAcbsHttpError<T, O extends ObservableInput<any>>({
   resourceIdentifier,
@@ -15,6 +17,31 @@ export function wrapAcbsHttpError<T, O extends ObservableInput<any>>({
     if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
       throw new AcbsResourceNotFoundException(`Party with identifier ${resourceIdentifier} was not found by ACBS.`, error);
     }
+
     throw new AcbsException(messageForUnknownException, error);
+  });
+}
+
+export function wrapAcbsHttpPostError<T, O extends ObservableInput<any>>({
+  resourceIdentifier,
+  messageForUnknownException,
+}: {
+  resourceIdentifier: string;
+  messageForUnknownException: string;
+}): OperatorFunction<T, T | ObservedValueOf<O>> {
+  return catchError((error: Error) => {
+    if (!(error instanceof AxiosError) || !error.response || error.response.status !== 400) {
+      throw new AcbsUnexpectedException(messageForUnknownException, error);
+    }
+
+    if (typeof error.response.data === 'string' && error.response.data.includes('The deal not found')) {
+      throw new AcbsResourceNotFoundException(`Deal with identifier ${resourceIdentifier} was not found by ACBS.`, error);
+    }
+
+    throw new AcbsBadRequestException(
+      messageForUnknownException,
+      error,
+      typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data),
+    );
   });
 }

--- a/src/modules/date/current-date.provider.ts
+++ b/src/modules/date/current-date.provider.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CurrentDateProvider {
+  getLatestDateFromTodayAnd(otherDate: Date): Date {
+    const now = new Date();
+
+    if (now > otherDate) {
+      return now;
+    }
+
+    return otherDate;
+  }
+}

--- a/src/modules/date/date.module.ts
+++ b/src/modules/date/date.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { CurrentDateProvider } from './current-date.provider';
+
+@Module({
+  providers: [CurrentDateProvider],
+  exports: [CurrentDateProvider],
+})
+export class DateModule {}

--- a/src/modules/deal-guarantee/deal-guarantee-to-create.interface.ts
+++ b/src/modules/deal-guarantee/deal-guarantee-to-create.interface.ts
@@ -1,0 +1,11 @@
+import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
+
+export interface DealGuaranteeToCreate {
+  dealIdentifier: string;
+  effectiveDate: DateOnlyString;
+  guarantorParty?: string;
+  limitKey: string;
+  guaranteeExpiryDate: DateOnlyString;
+  maximumLiability: number;
+  guaranteeTypeCode?: string;
+}

--- a/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
@@ -1,0 +1,64 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { DealGuaranteeController } from './deal-guarantee.controller';
+import { DealGuaranteeService } from './deal-guarantee.service';
+import { CreateDealGuaranteeRequestItem } from './dto/create-deal-guarantee-request.dto';
+import { CreateDealGuaranteeResponse } from './dto/create-deal-guarantee-response.dto';
+
+describe('DealGuaranteeController', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let dealGuaranteeService: DealGuaranteeService;
+  let controller: DealGuaranteeController;
+
+  let dealGuaranteeServiceCreateGuaranteeForDeal: jest.Mock;
+
+  beforeEach(() => {
+    dealGuaranteeService = new DealGuaranteeService(null, null, null);
+
+    dealGuaranteeServiceCreateGuaranteeForDeal = jest.fn();
+    dealGuaranteeService.createGuaranteeForDeal = dealGuaranteeServiceCreateGuaranteeForDeal;
+
+    controller = new DealGuaranteeController(dealGuaranteeService);
+  });
+
+  describe('createGuaranteeForDeal', () => {
+    const dealIdentifier = valueGenerator.stringOfNumericCharacters();
+    const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
+    const effectiveDate = valueGenerator.dateOnlyString();
+    const guaranteeExpiryDate = valueGenerator.dateOnlyString();
+    const maximumLiability = valueGenerator.nonnegativeFloat();
+
+    const newGuarantee = new CreateDealGuaranteeRequestItem(
+      dealIdentifier,
+      effectiveDate,
+      limitKey,
+      guaranteeExpiryDate,
+      maximumLiability,
+      guarantorParty,
+      guaranteeTypeCode,
+    );
+
+    it('creates a guarantee for the deal with the service from the request body', async () => {
+      await controller.createGuaranteeForDeal(dealIdentifier, [newGuarantee]);
+
+      expect(dealGuaranteeServiceCreateGuaranteeForDeal).toHaveBeenCalledWith(dealIdentifier, newGuarantee);
+    });
+
+    it('returns the deal identifier if creating the guarantee succeeds', async () => {
+      const response = await controller.createGuaranteeForDeal(dealIdentifier, [newGuarantee]);
+
+      expect(response).toStrictEqual(new CreateDealGuaranteeResponse(dealIdentifier));
+    });
+
+    it('does NOT include unexpected keys from the request body', async () => {
+      const newGuaranteePlusUnexpectedKeys = { ...newGuarantee, unexpectedKey: 'unexpected value' };
+
+      await controller.createGuaranteeForDeal(dealIdentifier, [newGuaranteePlusUnexpectedKeys]);
+
+      expect(dealGuaranteeServiceCreateGuaranteeForDeal).toHaveBeenCalledWith(dealIdentifier, newGuarantee);
+    });
+  });
+});

--- a/src/modules/deal-guarantee/deal-guarantee.controller.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Param, ParseArrayPipe, Post } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+} from '@nestjs/swagger';
+
+import { DealGuaranteeService } from './deal-guarantee.service';
+import { DealGuaranteeToCreate } from './deal-guarantee-to-create.interface';
+import { CreateDealGuaranteeRequest, CreateDealGuaranteeRequestItem } from './dto/create-deal-guarantee-request.dto';
+import { CreateDealGuaranteeResponse } from './dto/create-deal-guarantee-response.dto';
+
+@Controller()
+export class DealGuaranteeController {
+  constructor(private readonly dealGuaranteeService: DealGuaranteeService) {}
+
+  @Post('deals/:dealIdentifier/guarantees')
+  @ApiOperation({
+    summary: 'Create a new guarantee for a deal.',
+  })
+  @ApiParam({
+    name: 'dealIdentifier',
+    required: true,
+    type: 'string',
+    description: 'The identifier of the deal in ACBS.',
+    example: '00000001',
+  })
+  @ApiBody({
+    type: CreateDealGuaranteeRequestItem,
+    isArray: true,
+  })
+  @ApiCreatedResponse({
+    description: 'The guarantee has been successfully created.',
+    type: CreateDealGuaranteeResponse,
+  })
+  @ApiNotFoundResponse({
+    description: 'The deal was not found.',
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad request.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An internal server error has occurred.',
+  })
+  async createGuaranteeForDeal(
+    @Param('dealIdentifier') dealIdentifier: string,
+    @Body(new ParseArrayPipe({ items: CreateDealGuaranteeRequestItem })) newGuaranteeRequest: CreateDealGuaranteeRequest,
+  ): Promise<CreateDealGuaranteeResponse> {
+    const newGuarantee = newGuaranteeRequest[0];
+    const guaranteeToCreate: DealGuaranteeToCreate = {
+      dealIdentifier: newGuarantee.dealIdentifier,
+      effectiveDate: newGuarantee.effectiveDate,
+      limitKey: newGuarantee.limitKey,
+      guaranteeExpiryDate: newGuarantee.guaranteeExpiryDate,
+      maximumLiability: newGuarantee.maximumLiability,
+      guarantorParty: newGuarantee.guarantorParty,
+      guaranteeTypeCode: newGuarantee.guaranteeTypeCode,
+    };
+    await this.dealGuaranteeService.createGuaranteeForDeal(dealIdentifier, guaranteeToCreate);
+    return new CreateDealGuaranteeResponse(dealIdentifier);
+  }
+}

--- a/src/modules/deal-guarantee/deal-guarantee.module.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
+import { DateModule } from '@ukef/modules/date/date.module';
+
+import { DealGuaranteeController } from './deal-guarantee.controller';
+import { DealGuaranteeService } from './deal-guarantee.service';
+
+@Module({
+  imports: [AcbsModule, DateModule],
+  controllers: [DealGuaranteeController],
+  providers: [DealGuaranteeService],
+})
+export class DealGuaranteeModule {}

--- a/src/modules/deal-guarantee/deal-guarantee.service.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.test.ts
@@ -1,0 +1,151 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs/acbs-authentication.service';
+import { AcbsDealGuaranteeService } from '@ukef/modules/acbs/acbs-deal-guarantee.service';
+import { AcbsCreateDealGuaranteeDto } from '@ukef/modules/acbs/dto/acbs-create-deal-guarantee.dto';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { DealGuaranteeService } from './deal-guarantee.service';
+import { DealGuaranteeToCreate } from './deal-guarantee-to-create.interface';
+
+jest.mock('@ukef/modules/date/current-date.provider');
+jest.mock('@ukef/modules/acbs/acbs-deal-guarantee.service');
+jest.mock('@ukef/modules/acbs/acbs-authentication.service');
+
+describe('DealGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+
+  let acbsAuthenticationService: AcbsAuthenticationService;
+  let acbsDealGuaranteeService: AcbsDealGuaranteeService;
+  let currentDateProvider: CurrentDateProvider;
+  let service: DealGuaranteeService;
+
+  let acbsDealGuaranteeServiceCreateGuaranteeForDeal: jest.Mock;
+  let currentDateProviderGetLatestDateFromTodayAnd: jest.Mock;
+
+  beforeEach(() => {
+    acbsDealGuaranteeService = new AcbsDealGuaranteeService(null, null);
+    acbsDealGuaranteeServiceCreateGuaranteeForDeal = jest.fn();
+    acbsDealGuaranteeService.createGuaranteeForDeal = acbsDealGuaranteeServiceCreateGuaranteeForDeal;
+
+    acbsAuthenticationService = new AcbsAuthenticationService(null, null, null);
+    const acbsAuthenticationServiceGetIdToken = jest.fn();
+    acbsAuthenticationService.getIdToken = acbsAuthenticationServiceGetIdToken;
+
+    currentDateProvider = new CurrentDateProvider();
+    currentDateProviderGetLatestDateFromTodayAnd = jest.fn();
+    currentDateProvider.getLatestDateFromTodayAnd = currentDateProviderGetLatestDateFromTodayAnd;
+
+    service = new DealGuaranteeService(acbsAuthenticationService, acbsDealGuaranteeService, currentDateProvider);
+
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+  });
+
+  describe('createGuaranteeForDeal', () => {
+    const dealIdentifier = valueGenerator.stringOfNumericCharacters();
+    const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
+    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
+    const effectiveDate = valueGenerator.dateOnlyString();
+    const effectiveDateAsDate = new Date(effectiveDate + 'T00:00:00Z');
+    const today = valueGenerator.date();
+    const todayAsDateOnlyString = today.toISOString().split('T')[0];
+    const expirationDate = valueGenerator.dateOnlyString();
+    const maximumLiabilityWithOneDecimalPlace = Number(valueGenerator.nonnegativeFloat().toFixed(1));
+
+    const newGuaranteeWithAllFields: DealGuaranteeToCreate = {
+      dealIdentifier,
+      effectiveDate,
+      guarantorParty,
+      limitKey,
+      guaranteeExpiryDate: expirationDate,
+      maximumLiability: maximumLiabilityWithOneDecimalPlace,
+      guaranteeTypeCode,
+    };
+
+    it('creates a guarantee in ACBS with a transformation of the requested new guarantee', async () => {
+      const expectedNewGuaranteeToCreate: AcbsCreateDealGuaranteeDto = {
+        LenderType: {
+          LenderTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.lenderType.lenderTypeCode,
+        },
+        SectionIdentifier: PROPERTIES.DEAL_GUARANTEE.DEFAULT.sectionIdentifier,
+        LimitType: {
+          LimitTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.limitType.limitTypeCode,
+        },
+        LimitKey: limitKey,
+        GuarantorParty: {
+          PartyIdentifier: guarantorParty,
+        },
+        GuaranteeType: {
+          GuaranteeTypeCode: guaranteeTypeCode,
+        },
+        EffectiveDate: effectiveDate + 'T00:00:00Z',
+        ExpirationDate: expirationDate + 'T00:00:00Z',
+        GuaranteedLimit: maximumLiabilityWithOneDecimalPlace,
+        GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
+      };
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(effectiveDateAsDate);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithAllFields);
+
+      expect(acbsDealGuaranteeServiceCreateGuaranteeForDeal).toHaveBeenCalledWith(dealIdentifier, expectedNewGuaranteeToCreate, idToken);
+    });
+
+    it('adds a default value for guarantorParty before creating the new guarantee if it is not specified', async () => {
+      const { guarantorParty: _removed, ...newGuaranteeWithoutGuarantorParty } = newGuaranteeWithAllFields;
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(effectiveDateAsDate);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithoutGuarantorParty);
+
+      const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
+
+      expect(guaranteeCreatedInAcbs.GuarantorParty.PartyIdentifier).toBe(PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty);
+    });
+
+    it('adds a default value for guaranteeTypeCode before creating the new guarantee if it is not specified', async () => {
+      const { guaranteeTypeCode: _removed, ...newGuaranteeWithoutGuaranteeTypeCode } = newGuaranteeWithAllFields;
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(effectiveDateAsDate);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithoutGuaranteeTypeCode);
+
+      const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
+
+      expect(guaranteeCreatedInAcbs.GuaranteeType.GuaranteeTypeCode).toBe(PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode);
+    });
+
+    it(`replaces effectiveDate with today's date if effectiveDate is before today`, async () => {
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(today);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithAllFields);
+
+      const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
+
+      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(todayAsDateOnlyString + 'T00:00:00Z');
+    });
+
+    it(`does NOT replace effectiveDate with today's date if effectiveDate is NOT before today`, async () => {
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(effectiveDateAsDate);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithAllFields);
+
+      const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
+
+      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(effectiveDate + 'T00:00:00Z');
+    });
+
+    it('rounds the maximumLiability to 2 decimal places', async () => {
+      const maximumLiabilityWithMoreThanTwoDecimalPlaces = 1.12345;
+      const maximumLiabilityRoundedToTwoDecimalPlaces = 1.12;
+      const newGuaranteeWithMaximumLiabilityToRound = { ...newGuaranteeWithAllFields, maximumLiability: maximumLiabilityWithMoreThanTwoDecimalPlaces };
+      when(currentDateProviderGetLatestDateFromTodayAnd).calledWith(effectiveDateAsDate).mockReturnValueOnce(effectiveDateAsDate);
+
+      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithMaximumLiabilityToRound);
+
+      const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
+
+      expect(guaranteeCreatedInAcbs.GuaranteedLimit).toBeCloseTo(maximumLiabilityRoundedToTwoDecimalPlaces, 8);
+    });
+  });
+});

--- a/src/modules/deal-guarantee/deal-guarantee.service.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.ts
@@ -38,7 +38,7 @@ export class DealGuaranteeService {
       },
       EffectiveDate: effectiveDateOnlyString + 'T00:00:00Z',
       ExpirationDate: newGuarantee.guaranteeExpiryDate + 'T00:00:00Z',
-      GuaranteedLimit: Math.round(newGuarantee.maximumLiability * 100) / 100, // TODO APIM-73: Discuss rounding precision errors with team
+      GuaranteedLimit: Math.round(newGuarantee.maximumLiability * 100) / 100,
       GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
     };
 

--- a/src/modules/deal-guarantee/deal-guarantee.service.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs/acbs-authentication.service';
+import { AcbsDealGuaranteeService } from '@ukef/modules/acbs/acbs-deal-guarantee.service';
+import { AcbsCreateDealGuaranteeDto } from '@ukef/modules/acbs/dto/acbs-create-deal-guarantee.dto';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+
+import { DealGuaranteeToCreate } from './deal-guarantee-to-create.interface';
+
+@Injectable()
+export class DealGuaranteeService {
+  constructor(
+    private readonly acbsAuthenticationService: AcbsAuthenticationService,
+    private readonly acbsDealGuaranteeService: AcbsDealGuaranteeService,
+    private readonly currentDateProvider: CurrentDateProvider,
+  ) {}
+
+  async createGuaranteeForDeal(dealIdentifier: string, newGuarantee: DealGuaranteeToCreate): Promise<void> {
+    const idToken = await this.acbsAuthenticationService.getIdToken();
+
+    const effectiveDateTime = this.currentDateProvider.getLatestDateFromTodayAnd(new Date(newGuarantee.effectiveDate + 'T00:00:00Z'));
+    const effectiveDateOnlyString = effectiveDateTime.toISOString().split('T')[0];
+
+    const guaranteeToCreateInAcbs: AcbsCreateDealGuaranteeDto = {
+      LenderType: {
+        LenderTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.lenderType.lenderTypeCode,
+      },
+      SectionIdentifier: PROPERTIES.DEAL_GUARANTEE.DEFAULT.sectionIdentifier,
+      LimitType: {
+        LimitTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.limitType.limitTypeCode,
+      },
+      LimitKey: newGuarantee.limitKey,
+      GuarantorParty: {
+        PartyIdentifier: newGuarantee.guarantorParty ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty,
+      },
+      GuaranteeType: {
+        GuaranteeTypeCode: newGuarantee.guaranteeTypeCode ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
+      },
+      EffectiveDate: effectiveDateOnlyString + 'T00:00:00Z',
+      ExpirationDate: newGuarantee.guaranteeExpiryDate + 'T00:00:00Z',
+      GuaranteedLimit: Math.round(newGuarantee.maximumLiability * 100) / 100, // TODO APIM-73: Discuss rounding precision errors with team
+      GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
+    };
+
+    await this.acbsDealGuaranteeService.createGuaranteeForDeal(dealIdentifier, guaranteeToCreateInAcbs, idToken);
+  }
+}

--- a/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
+++ b/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
@@ -1,0 +1,98 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PROPERTIES } from '@ukef/constants';
+import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
+import { IsISO8601, IsNotEmpty, IsOptional, Length, Matches, Min, MinLength } from 'class-validator';
+
+export type CreateDealGuaranteeRequest = CreateDealGuaranteeRequestItem[];
+
+export class CreateDealGuaranteeRequestItem {
+  @ApiProperty({
+    description: 'The identifier of the deal to create the guarantee for.',
+    example: '00000001',
+    minLength: 1,
+    maxLength: 10,
+  })
+  @Length(1, 10)
+  // TODO APIM-73: Should we remove dealIdentifier from the request body?
+  readonly dealIdentifier: string;
+
+  // TODO APIM-73: Is it okay that I have removed portfolioIdentifier from the request body?
+
+  @ApiProperty({
+    description: `The date that this guarantee will take effect. This will be replaced by today's date if a date in the past is provided.`,
+    type: Date,
+    format: 'date',
+  })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  @IsISO8601({ strict: true })
+  readonly effectiveDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'An ACBS party identifier.',
+    minLength: 1,
+    maxLength: 10,
+    example: '00000002',
+  })
+  @Length(1, 10)
+  // TODO APIM-73: ACBS says it can be at most 8 - which is correct?
+  readonly limitKey: string;
+
+  @ApiProperty({
+    description: 'The date that this guarantee will expire on.',
+    type: Date,
+    format: 'date',
+  })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  @IsISO8601({ strict: true })
+  readonly guaranteeExpiryDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'The maximum amount the guarantor will guarantee.',
+    minimum: 0,
+  })
+  @IsNotEmpty()
+  @Min(0)
+  // TODO APIM-73: ACBS says the maximum is 1E+17 - should we validate this?
+  readonly maximumLiability: number;
+
+  @ApiProperty({
+    description: `UK GOODS (${PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty})`, // TODO APIM-73: can we improve this at all?
+    minLength: 1,
+    maxLength: 10,
+    default: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty,
+    required: false,
+  })
+  @IsOptional()
+  @Length(1, 10)
+  // TODO APIM-73: ACBS says max length is actually 8 - which is correct?
+  readonly guarantorParty?: string;
+
+  @ApiProperty({
+    description: `GOODS (${PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode})`, // TODO APIM-73: Can we improve this at all?
+    default: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
+    required: false,
+    minLength: 1,
+  })
+  @IsOptional()
+  @MinLength(1)
+  // TODO APIM-73: ACBS says max length is actually 3 - should we add this?
+  readonly guaranteeTypeCode?: string;
+
+  constructor(
+    dealIdentifier: string,
+    effectiveDate: DateOnlyString,
+    limitKey: string,
+    guaranteeExpiryDate: DateOnlyString,
+    maximumLiability: number,
+    guarantorParty?: string,
+    guaranteeTypeCode?: string,
+  ) {
+    this.dealIdentifier = dealIdentifier;
+    this.effectiveDate = effectiveDate;
+    this.limitKey = limitKey;
+    this.guaranteeExpiryDate = guaranteeExpiryDate;
+    this.maximumLiability = maximumLiability;
+    this.guarantorParty = guarantorParty;
+    this.guaranteeTypeCode = guaranteeTypeCode;
+  }
+}

--- a/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
+++ b/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
@@ -13,7 +13,6 @@ export class CreateDealGuaranteeRequestItem {
     minLength: 8,
     maxLength: 8,
   })
-  // TODO APIM-73: Should we remove dealIdentifier from the request body?
   readonly dealIdentifier: string;
 
   @ValidatedDateOnlyApiProperty({
@@ -37,7 +36,6 @@ export class CreateDealGuaranteeRequestItem {
   @ValidatedNumberApiProperty({
     description: 'The maximum amount the guarantor will guarantee.',
     minimum: 0,
-    maximum: 1e17, // TODO APIM-73: Is it okay that we lose precision at this magnitude?
   })
   readonly maximumLiability: number;
 

--- a/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
+++ b/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
@@ -1,81 +1,62 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { PROPERTIES } from '@ukef/constants';
+import { ValidatedDateOnlyApiProperty } from '@ukef/decorators/validated-date-only-api-property.decorator';
+import { ValidatedNumberApiProperty } from '@ukef/decorators/validated-number-api-property.decorator';
+import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
 import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
-import { IsISO8601, IsNotEmpty, IsOptional, Length, Matches, Min, MinLength } from 'class-validator';
 
 export type CreateDealGuaranteeRequest = CreateDealGuaranteeRequestItem[];
 
 export class CreateDealGuaranteeRequestItem {
-  @ApiProperty({
+  @ValidatedStringApiProperty({
     description: 'The identifier of the deal to create the guarantee for.',
     example: '00000001',
-    minLength: 1,
-    maxLength: 10,
+    minLength: 8,
+    maxLength: 8,
   })
-  @Length(1, 10)
   // TODO APIM-73: Should we remove dealIdentifier from the request body?
   readonly dealIdentifier: string;
 
-  // TODO APIM-73: Is it okay that I have removed portfolioIdentifier from the request body?
-
-  @ApiProperty({
+  @ValidatedDateOnlyApiProperty({
     description: `The date that this guarantee will take effect. This will be replaced by today's date if a date in the past is provided.`,
-    type: Date,
-    format: 'date',
   })
-  @Matches(/^\d{4}-\d{2}-\d{2}$/)
-  @IsISO8601({ strict: true })
   readonly effectiveDate: DateOnlyString;
 
-  @ApiProperty({
+  @ValidatedStringApiProperty({
     description: 'An ACBS party identifier.',
-    minLength: 1,
-    maxLength: 10,
+    minLength: 8,
+    maxLength: 8,
     example: '00000002',
   })
-  @Length(1, 10)
-  // TODO APIM-73: ACBS says it can be at most 8 - which is correct?
   readonly limitKey: string;
 
-  @ApiProperty({
+  @ValidatedDateOnlyApiProperty({
     description: 'The date that this guarantee will expire on.',
-    type: Date,
-    format: 'date',
   })
-  @Matches(/^\d{4}-\d{2}-\d{2}$/)
-  @IsISO8601({ strict: true })
   readonly guaranteeExpiryDate: DateOnlyString;
 
-  @ApiProperty({
+  @ValidatedNumberApiProperty({
     description: 'The maximum amount the guarantor will guarantee.',
     minimum: 0,
+    maximum: 1e17, // TODO APIM-73: Is it okay that we lose precision at this magnitude?
   })
-  @IsNotEmpty()
-  @Min(0)
-  // TODO APIM-73: ACBS says the maximum is 1E+17 - should we validate this?
   readonly maximumLiability: number;
 
-  @ApiProperty({
-    description: `UK GOODS (${PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty})`, // TODO APIM-73: can we improve this at all?
-    minLength: 1,
-    maxLength: 10,
+  @ValidatedStringApiProperty({
+    description: `The party identifier of the guarantor, the customer who is making the guarantee/obligation.`,
+    minLength: 8,
+    maxLength: 8,
     default: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty,
     required: false,
   })
-  @IsOptional()
-  @Length(1, 10)
-  // TODO APIM-73: ACBS says max length is actually 8 - which is correct?
   readonly guarantorParty?: string;
 
-  @ApiProperty({
-    description: `GOODS (${PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode})`, // TODO APIM-73: Can we improve this at all?
+  @ValidatedStringApiProperty({
+    description: `The identifier for the type of the guarantee.`,
     default: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
     required: false,
-    minLength: 1,
+    minLength: 3,
+    maxLength: 3,
   })
-  @IsOptional()
-  @MinLength(1)
-  // TODO APIM-73: ACBS says max length is actually 3 - should we add this?
   readonly guaranteeTypeCode?: string;
 
   constructor(

--- a/src/modules/deal-guarantee/dto/create-deal-guarantee-response.dto.ts
+++ b/src/modules/deal-guarantee/dto/create-deal-guarantee-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiResponseProperty } from '@nestjs/swagger';
+
+export class CreateDealGuaranteeResponse {
+  @ApiResponseProperty({ example: '00000001' })
+  readonly dealIdentifier: string;
+
+  constructor(dealIdentifier: string) {
+    this.dealIdentifier = dealIdentifier;
+  }
+}

--- a/src/modules/tfs.module.ts
+++ b/src/modules/tfs.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
 import { AuthModule } from '@ukef/modules/auth/auth.module';
+import { DealGuaranteeModule } from '@ukef/modules/deal-guarantee/deal-guarantee.module';
 import { PartyModule } from '@ukef/modules/party/party.module';
 import { PartyExternalRatingModule } from '@ukef/modules/party-external-rating/party-external-rating.module';
 
 import { AcbsExceptionTransformInterceptor } from './acbs-adapter/acbs-exception-transform.interceptor';
 
 @Module({
-  imports: [AuthModule, AcbsModule, PartyExternalRatingModule, PartyModule],
+  imports: [AuthModule, AcbsModule, DealGuaranteeModule, PartyExternalRatingModule, PartyModule],
   providers: [
     {
       provide: APP_INTERCEPTOR,

--- a/test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests.ts
@@ -1,0 +1,96 @@
+import request from 'supertest';
+
+interface RequiredDateOnlyFieldValidationApiTestOptions<RequestBodyItem> {
+  fieldName: keyof RequestBodyItem;
+  validRequestBody: RequestBodyItem[];
+  makeRequest: (body: unknown[]) => request.Test;
+  givenAnyRequestBodyWouldSucceed: () => void;
+}
+
+export function withRequiredDateOnlyFieldValidationApiTests<RequestBodyItem>({
+  fieldName: fieldNameSymbol,
+  validRequestBody,
+  makeRequest,
+  givenAnyRequestBodyWouldSucceed,
+}: RequiredDateOnlyFieldValidationApiTestOptions<RequestBodyItem>): void {
+  const fieldName = fieldNameSymbol.toString();
+
+  describe(`${fieldName} validation`, () => {
+    beforeEach(() => {
+      givenAnyRequestBodyWouldSucceed();
+    });
+
+    it(`returns a 400 response if ${fieldName} is not present`, async () => {
+      const { [fieldNameSymbol]: _removed, ...requestWithoutTheField } = validRequestBody[0];
+
+      const { status, body } = await makeRequest([requestWithoutTheField]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be a valid ISO 8601 date string`, `${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} has time part of date string`, async () => {
+      const requestWithDateInIncorrectFormat = [{ ...validRequestBody[0], [fieldName]: '2023-02-01T00:00:00Z' }];
+
+      const { status, body } = await makeRequest(requestWithDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} is not in YYYY-MM-DD date format`, async () => {
+      const requestWithDateInIncorrectFormat = [{ ...validRequestBody[0], [fieldName]: '20230201' }];
+
+      const { status, body } = await makeRequest(requestWithDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} is not a valid date`, async () => {
+      const requestWithInvalidDate = [{ ...validRequestBody[0], [fieldName]: '2023-99-10' }];
+
+      const { status, body } = await makeRequest(requestWithInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be a valid ISO 8601 date string`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} is not a real day`, async () => {
+      const requestWithInvalidDate = [{ ...validRequestBody[0], [fieldName]: '2019-02-29' }];
+
+      const { status, body } = await makeRequest(requestWithInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be a valid ISO 8601 date string`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 201 response if ${fieldName} is a valid date`, async () => {
+      const requestWithValidDate = [{ ...validRequestBody[0], [fieldName]: '2022-02-01' }];
+
+      const { status } = await makeRequest(requestWithValidDate);
+
+      expect(status).toBe(201);
+    });
+  });
+}

--- a/test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests.ts
@@ -1,0 +1,57 @@
+import request from 'supertest';
+
+interface RequiredNonNegativeFieldValidationApiTestOptions<RequestBodyItem> {
+  fieldName: keyof RequestBodyItem;
+  validRequestBody: RequestBodyItem[];
+  makeRequest: (body: unknown[]) => request.Test;
+  givenAnyRequestBodyWouldSucceed: () => void;
+}
+
+export function withRequiredNonNegativeNumberFieldValidationApiTests<RequestBodyItem>({
+  fieldName: fieldNameSymbol,
+  validRequestBody,
+  makeRequest,
+  givenAnyRequestBodyWouldSucceed,
+}: RequiredNonNegativeFieldValidationApiTestOptions<RequestBodyItem>): void {
+  const fieldName = fieldNameSymbol.toString();
+
+  describe(`${fieldName} validation`, () => {
+    beforeEach(() => {
+      givenAnyRequestBodyWouldSucceed();
+    });
+
+    it(`returns a 400 response if ${fieldName} is not present`, async () => {
+      const { [fieldNameSymbol]: _removed, ...requestWithoutField } = validRequestBody[0];
+
+      const { status, body } = await makeRequest([requestWithoutField]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must not be less than 0`, `${fieldName} should not be empty`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} is less than 0`, async () => {
+      const requestWithNegativeField = [{ ...validRequestBody[0], [fieldNameSymbol]: -0.01 }];
+
+      const { status, body } = await makeRequest(requestWithNegativeField);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must not be less than 0`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 201 response if ${fieldName} is 0`, async () => {
+      const requestWithZeroField = [{ ...validRequestBody[0], [fieldNameSymbol]: 0 }];
+
+      const { status } = await makeRequest(requestWithZeroField);
+
+      expect(status).toBe(201);
+    });
+  });
+}

--- a/test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests.ts
@@ -28,7 +28,7 @@ export function withRequiredNonNegativeNumberFieldValidationApiTests<RequestBody
       expect(status).toBe(400);
       expect(body).toStrictEqual({
         error: 'Bad Request',
-        message: [`${fieldName} must not be less than 0`, `${fieldName} should not be empty`],
+        message: [`${fieldName} should not be empty`, `${fieldName} must not be less than 0`],
         statusCode: 400,
       });
     });

--- a/test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests.ts
@@ -1,0 +1,99 @@
+import request from 'supertest';
+
+interface StringFieldValidationApiTestOptions<RequestBodyItem, RequestBodyItemKey extends keyof RequestBodyItem> {
+  fieldName: RequestBodyItemKey;
+  length: number;
+  required: boolean;
+  generateFieldValueOfLength: (length: number) => RequestBodyItem[RequestBodyItemKey];
+  validRequestBody: RequestBodyItem[];
+  makeRequest: (body: unknown[]) => request.Test;
+  givenAnyRequestBodyWouldSucceed: () => void;
+}
+
+export function withStringFieldValidationApiTests<RequestBodyItem, RequestBodyItemKey extends keyof RequestBodyItem>({
+  fieldName: fieldNameSymbol,
+  length,
+  required,
+  generateFieldValueOfLength,
+  validRequestBody,
+  makeRequest,
+  givenAnyRequestBodyWouldSucceed,
+}: StringFieldValidationApiTestOptions<RequestBodyItem, RequestBodyItemKey>): void {
+  const fieldName = fieldNameSymbol.toString();
+
+  describe(`${fieldName} validation`, () => {
+    beforeEach(() => {
+      givenAnyRequestBodyWouldSucceed();
+    });
+
+    if (required) {
+      it(`returns a 400 response if ${fieldName} is not present`, async () => {
+        const { [fieldNameSymbol]: _removed, ...requestWithField } = validRequestBody[0];
+
+        const { status, body } = await makeRequest([requestWithField]);
+
+        expect(status).toBe(400);
+        expect(body).toStrictEqual({
+          error: 'Bad Request',
+          message: [`${fieldName} must be longer than or equal to ${length} characters`],
+          statusCode: 400,
+        });
+      });
+    } else {
+      it(`returns a 201 response if ${fieldName} is not present`, async () => {
+        const { [fieldNameSymbol]: _removed, ...requestWithField } = validRequestBody[0];
+
+        const { status } = await makeRequest([requestWithField]);
+
+        expect(status).toBe(201);
+      });
+    }
+
+    it(`returns a 400 response if ${fieldName} is an empty string`, async () => {
+      const requestWithEmptyField = [{ ...validRequestBody[0], [fieldNameSymbol]: '' }];
+
+      const { status, body } = await makeRequest(requestWithEmptyField);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be longer than or equal to ${length} characters`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} has fewer than ${length} characters`, async () => {
+      const requestWithTooShortField = [{ ...validRequestBody[0], [fieldNameSymbol]: generateFieldValueOfLength(length - 1) }];
+
+      const { status, body } = await makeRequest(requestWithTooShortField);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be longer than or equal to ${length} characters`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 400 response if ${fieldName} has more than ${length} characters`, async () => {
+      const requestWithTooLongField = [{ ...validRequestBody[0], [fieldNameSymbol]: generateFieldValueOfLength(length + 1) }];
+
+      const { status, body } = await makeRequest(requestWithTooLongField);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`${fieldName} must be shorter than or equal to ${length} characters`],
+        statusCode: 400,
+      });
+    });
+
+    it(`returns a 201 response if ${fieldName} has ${length} characters`, async () => {
+      const requestWithValidField = [{ ...validRequestBody[0], [fieldNameSymbol]: generateFieldValueOfLength(length) }];
+
+      const { status } = await makeRequest(requestWithValidField);
+
+      expect(status).toBe(201);
+    });
+  });
+}

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -1,6 +1,9 @@
 import { PROPERTIES } from '@ukef/constants';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withRequiredDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests';
+import { withRequiredNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests';
+import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
@@ -9,7 +12,7 @@ import nock from 'nock';
 describe('POST /deals/{dealIdentifier}/guarantees', () => {
   const valueGenerator = new RandomValueGenerator();
 
-  const dealIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
+  const dealIdentifier = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const createDealGuaranteeUrl = `/api/v1/deals/${dealIdentifier}/guarantees`;
 
   const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
@@ -18,11 +21,11 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
   const sectionIdentifier = PROPERTIES.DEAL_GUARANTEE.DEFAULT.sectionIdentifier;
   const guaranteedPercentage = PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage;
 
-  const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
-  const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
+  const guarantorParty = valueGenerator.stringOfNumericCharacters({ length: 8 });
+  const limitKey = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const effectiveDateInFuture = '9999-01-02';
   const guaranteeExpiryDateInFuture = '9999-12-31';
-  const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters();
+  const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ length: 3 });
   const maximumLiability = 12345.6;
 
   const acbsRequestBodyToCreateDealGuarantee = {
@@ -89,7 +92,7 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
 
   it('returns a 201 response with the deal guarantee location if it has been successfully created in ACBS', async () => {
     givenAuthenticationWithTheIdpSucceeds();
-    givenRequestToCreateDealGuaranteeInAcbsSucceeds();
+    const acbsRequest = givenRequestToCreateDealGuaranteeInAcbsSucceeds();
 
     const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
 
@@ -97,456 +100,182 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     expect(body).toStrictEqual({
       dealIdentifier,
     });
+    expect(acbsRequest.isDone()).toBe(true);
   });
 
-  describe('dealIdentifier validation', () => {
-    it('returns a 400 response if the dealIdentifier in the request body is not present', async () => {
-      const { dealIdentifier: _removed, ...requestWithoutDealIdentifier } = requestBodyToCreateDealGuarantee[0];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutDealIdentifier]);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['dealIdentifier must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
+  it('sets the default guarantorParty if it is not specified in the request', async () => {
+    const { guarantorParty: _removed, ...newDealGuaranteeWithoutGuarantorParty } = requestBodyToCreateDealGuarantee[0];
+    const requestBodyWithoutGuarantorParty = [newDealGuaranteeWithoutGuarantorParty];
+    const acbsRequestBodyWithDefaultGuarantorParty = {
+      ...acbsRequestBodyToCreateDealGuarantee,
+      GuarantorParty: { PartyIdentifier: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty },
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithDefaultGuarantorParty = requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyWithDefaultGuarantorParty).reply(201, undefined, {
+      location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
     });
 
-    it('returns a 400 response if the dealIdentifier is an empty string', async () => {
-      const requestWithEmptyDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyWithoutGuarantorParty);
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyDealIdentifier);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['dealIdentifier must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
     });
-
-    it('returns a 400 response if the dealIdentifier is over 10 characters', async () => {
-      const requestWithTooLongDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '12345678901' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongDealIdentifier);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['dealIdentifier must be shorter than or equal to 10 characters'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if the dealIdentifier is at most 10 characters', async () => {
-      const requestWithTenCharacterDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '1234567890' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTenCharacterDealIdentifier);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    expect(acbsRequestWithDefaultGuarantorParty.isDone()).toBe(true);
   });
 
-  describe('limitKey validation', () => {
-    it('returns a 400 response if the limitKey in the request body is not present', async () => {
-      const { limitKey: _removed, ...requestWithoutLimitKey } = requestBodyToCreateDealGuarantee[0];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+  it('sets the default guaranteeTypeCode if it is not specified in the request', async () => {
+    const { guaranteeTypeCode: _removed, ...newDealGuaranteeWithoutGuaranteeTypeCode } = requestBodyToCreateDealGuarantee[0];
+    const requestBodyWithoutGuaranteeTypeCode = [newDealGuaranteeWithoutGuaranteeTypeCode];
+    const acbsRequestBodyWithDefaultGuaranteeTypeCode = {
+      ...acbsRequestBodyToCreateDealGuarantee,
+      GuaranteeType: {
+        GuaranteeTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
+      },
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithDefaultGuaranteeTypeCode = requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyWithDefaultGuaranteeTypeCode).reply(
+      201,
+      undefined,
+      {
+        location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
+      },
+    );
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutLimitKey]);
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyWithoutGuaranteeTypeCode);
 
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['limitKey must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
     });
-
-    it('returns a 400 response if the limitKey is an empty string', async () => {
-      const requestWithEmptyLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyLimitKey);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['limitKey must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the limitKey is over 10 characters', async () => {
-      const requestWithTooLongLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '12345678901' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongLimitKey);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['limitKey must be shorter than or equal to 10 characters'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if the limitKey is at most 10 characters', async () => {
-      const requestWithTenCharacterLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '1234567890' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTenCharacterLimitKey);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    expect(acbsRequestWithDefaultGuaranteeTypeCode.isDone()).toBe(true);
   });
 
-  describe('effectiveDate validation', () => {
-    it('returns a 400 response if the effectiveDate is not present', async () => {
-      const { effectiveDate: _removed, ...requestWithoutEffectiveDate } = requestBodyToCreateDealGuarantee[0];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+  it('rounds the maximumLiability to 2dp', async () => {
+    const requestBodyWithMaximumLiabilityToRound = [{ ...requestBodyToCreateDealGuarantee[0], maximumLiability: 1.234 }];
+    const acbsRequestBodyWithRoundedMaximumLiability = {
+      ...acbsRequestBodyToCreateDealGuarantee,
+      GuaranteedLimit: 1.23,
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithRoundedMaximumLiability = requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyWithRoundedMaximumLiability).reply(
+      201,
+      undefined,
+      {
+        location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
+      },
+    );
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutEffectiveDate]);
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyWithMaximumLiabilityToRound);
 
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['effectiveDate must be a valid ISO 8601 date string', `effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
     });
-
-    it('returns a 400 response if the effectiveDate has time part of date string', async () => {
-      const requestWithEffectiveDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2023-02-01T00:00:00Z' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateInIncorrectFormat);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: [`effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the effectiveDate is not in YYYY-MM-DD date format', async () => {
-      const requestWithEffectiveDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '20230201' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateInIncorrectFormat);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: [`effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the effectiveDate is not a valid date', async () => {
-      const requestWithEffectiveDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2023-99-10' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateAsInvalidDate);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['effectiveDate must be a valid ISO 8601 date string'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the effectiveDate is not a real day', async () => {
-      const requestWithEffectiveDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2019-02-29' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateAsInvalidDate);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['effectiveDate must be a valid ISO 8601 date string'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if the effectiveDate is a valid date', async () => {
-      const requestWithValidEffectiveDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2022-02-01' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithValidEffectiveDate);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    expect(acbsRequestWithRoundedMaximumLiability.isDone()).toBe(true);
   });
 
-  describe('guaranteeExpiryDate validation', () => {
-    it('returns a 400 response if the guaranteeExpiryDate is not present', async () => {
-      const { guaranteeExpiryDate: _removed, ...requestWithoutGuaranteeExpiryDate } = requestBodyToCreateDealGuarantee[0];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuaranteeExpiryDate]);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string', `guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
+  it(`replaces the effectiveDate with today's date if the specified effectiveDate is before today`, async () => {
+    const requestBodyWithPastEffectiveDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2000-01-01' }];
+    const acbsRequestBodyWithTodayEffectiveDate = {
+      ...acbsRequestBodyToCreateDealGuarantee,
+      EffectiveDate: new Date().toISOString().split('T')[0] + 'T00:00:00Z',
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithTodayEffectiveDate = requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyWithTodayEffectiveDate).reply(201, undefined, {
+      location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
     });
 
-    it('returns a 400 response if the guaranteeExpiryDate has time part of date string', async () => {
-      const requestWithGuaranteeExpiryDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2023-02-01T00:00:00Z' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyWithPastEffectiveDate);
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateInIncorrectFormat);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: [`guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
     });
-
-    it('returns a 400 response if the guaranteeExpiryDate is not in YYYY-MM-DD date format', async () => {
-      const requestWithGuaranteeExpiryDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '20230201' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateInIncorrectFormat);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: [`guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the guaranteeExpiryDate is not a valid date', async () => {
-      const requestWithGuaranteeExpiryDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2023-99-10' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateAsInvalidDate);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the guaranteeExpiryDate is not a real day', async () => {
-      const requestWithGuaranteeExpiryDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2019-02-29' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateAsInvalidDate);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if the guaranteeExpiryDate is a valid date', async () => {
-      const requestWithValidGuaranteeExpiryDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2022-02-01' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithValidGuaranteeExpiryDate);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    expect(acbsRequestWithTodayEffectiveDate.isDone()).toBe(true);
   });
 
-  describe('maximumLiability validation', () => {
-    it('returns a 400 response if the maximumLiability is not present', async () => {
-      const { maximumLiability: _removed, ...requestWithoutMaximumLiability } = requestBodyToCreateDealGuarantee[0];
+  withStringFieldValidationApiTests({
+    fieldName: 'dealIdentifier',
+    length: 8,
+    required: true,
+    generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutMaximumLiability]);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['maximumLiability must not be less than 0', 'maximumLiability should not be empty'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if the maximumLiability is less than 0', async () => {
-      const requestWithNegativeMaximumLiability = [{ ...requestBodyToCreateDealGuarantee[0], maximumLiability: -0.01 }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithNegativeMaximumLiability);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['maximumLiability must not be less than 0'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if the maximumLiability is 0', async () => {
-      const requestWithZeroMaximumLiability = [{ ...requestBodyToCreateDealGuarantee[0], maximumLiability: 0 }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithZeroMaximumLiability);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    },
   });
 
-  describe('guarantorParty validation', () => {
-    it('returns a 201 response if guarantorParty is not present', async () => {
-      const { guarantorParty: _removed, ...requestWithoutGuarantorTypeCode } = requestBodyToCreateDealGuarantee[0];
+  withStringFieldValidationApiTests({
+    fieldName: 'limitKey',
+    length: 8,
+    required: true,
+    generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuarantorTypeCode]);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
-
-    it('returns a 201 response if guarantorParty is present', async () => {
-      const requestWithGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '001' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorParty);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
-
-    it('returns a 400 response if guarantorParty is more than 10 characters', async () => {
-      const requestWithTooLongGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '12345678901' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongGuarantorParty);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guarantorParty must be shorter than or equal to 10 characters'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 400 response if guarantorParty is empty', async () => {
-      const requestWithEmptyGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyGuarantorParty);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guarantorParty must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
-    });
-
-    it('returns a 201 response if guarantorParty is at least 1 character', async () => {
-      const requestWithGuarantorPartyOfLength1 = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '1' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorPartyOfLength1);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
-
-    it('returns a 201 response if guarantorParty is at most 10 characters', async () => {
-      const requestWithGuarantorPartyOfLength10 = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '1234567890' }];
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorPartyOfLength10);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
+    },
   });
 
-  describe('guaranteeTypeCode validation', () => {
-    it('returns a 201 response if guaranteeTypeCode is not present', async () => {
-      const { guaranteeTypeCode: _removed, ...requestWithoutGuaranteeTypeCode } = requestBodyToCreateDealGuarantee[0];
+  withRequiredDateOnlyFieldValidationApiTests({
+    fieldName: 'effectiveDate',
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    },
+  });
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuaranteeTypeCode]);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
-
-    it('returns a 201 response if guaranteeTypeCode is present', async () => {
-      const requestWithGuaranteeTypeCode = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeTypeCode: '001' }];
+  withRequiredDateOnlyFieldValidationApiTests({
+    fieldName: 'guaranteeExpiryDate',
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    },
+  });
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeTypeCode);
-
-      expect(status).toBe(201);
-      expect(body).toStrictEqual({ dealIdentifier });
-    });
-
-    it('returns a 400 response if guaranteeTypeCode is empty', async () => {
-      const requestWithEmptyGuaranteeTypeCode = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeTypeCode: '' }];
+  withRequiredNonNegativeNumberFieldValidationApiTests({
+    fieldName: 'maximumLiability',
+    max: 1e17,
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    },
+  });
 
-      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyGuaranteeTypeCode);
+  withStringFieldValidationApiTests({
+    fieldName: 'guarantorParty',
+    length: 8,
+    required: false,
+    generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    },
+  });
 
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: ['guaranteeTypeCode must be longer than or equal to 1 characters'],
-        statusCode: 400,
-      });
-    });
+  withStringFieldValidationApiTests({
+    fieldName: 'guaranteeTypeCode',
+    length: 3,
+    required: false,
+    generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
+    validRequestBody: requestBodyToCreateDealGuarantee,
+    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    },
   });
 
   it('returns a 404 response if ACBS responds with a 400 response that is a string containing "The deal not found"', async () => {
@@ -591,17 +320,17 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
   });
 
-  // TODO APIM-73: Should we test defaults are set in the API tests also?
-
-  const givenRequestToCreateDealGuaranteeInAcbsSucceeds = (): void => {
-    requestToCreateDealGuarantee().reply(201, undefined, {
+  const givenRequestToCreateDealGuaranteeInAcbsSucceeds = (): nock.Scope => {
+    return requestToCreateDealGuarantee().reply(201, undefined, {
       location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
     });
   };
 
-  const requestToCreateDealGuarantee = (): nock.Interceptor =>
+  const requestToCreateDealGuarantee = (): nock.Interceptor => requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyToCreateDealGuarantee);
+
+  const requestToCreateDealGuaranteeInAcbsWithBody = (requestBody: nock.RequestBodyMatcher): nock.Interceptor =>
     nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
-      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, acbsRequestBodyToCreateDealGuarantee)
+      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, requestBody)
       .matchHeader('authorization', `Bearer ${idToken}`);
 
   const givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds = (): void => {

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -204,7 +204,7 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     });
 
     it('returns a 201 response if the limitKey is at most 10 characters', async () => {
-      const requestWithTenCharacterLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '1234567890' }];
+      const requestWithTenCharacterLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '1234567890' }];
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
 

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -243,7 +243,6 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
 
   withRequiredNonNegativeNumberFieldValidationApiTests({
     fieldName: 'maximumLiability',
-    max: 1e17,
     validRequestBody: requestBodyToCreateDealGuarantee,
     makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
     givenAnyRequestBodyWouldSucceed: () => {

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -1,0 +1,651 @@
+import { AUTH, PROPERTIES } from '@ukef/constants';
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+describe('POST /deals/{dealIdentifier}/guarantees', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const dealIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
+  const createDealGuaranteeUrl = `/api/v1/deals/${dealIdentifier}/guarantees`;
+
+  const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+  const lenderTypeCode = PROPERTIES.DEAL_GUARANTEE.DEFAULT.lenderType.lenderTypeCode;
+  const limitTypeCode = PROPERTIES.DEAL_GUARANTEE.DEFAULT.limitType.limitTypeCode;
+  const sectionIdentifier = PROPERTIES.DEAL_GUARANTEE.DEFAULT.sectionIdentifier;
+  const guaranteedPercentage = PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage;
+
+  const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
+  const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
+  const effectiveDateInFuture = '9999-01-02';
+  const guaranteeExpiryDateInFuture = '9999-12-31';
+  const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters();
+  const maximumLiability = 12345.6;
+
+  const acbsRequestBodyToCreateDealGuarantee = {
+    LenderType: {
+      LenderTypeCode: lenderTypeCode,
+    },
+    SectionIdentifier: sectionIdentifier,
+    LimitType: {
+      LimitTypeCode: limitTypeCode,
+    },
+    LimitKey: limitKey,
+    GuarantorParty: {
+      PartyIdentifier: guarantorParty,
+    },
+    GuaranteeType: {
+      GuaranteeTypeCode: guaranteeTypeCode,
+    },
+    EffectiveDate: effectiveDateInFuture + 'T00:00:00Z',
+    ExpirationDate: guaranteeExpiryDateInFuture + 'T00:00:00Z',
+    GuaranteedLimit: 12345.6,
+    GuaranteedPercentage: guaranteedPercentage,
+  };
+
+  const requestBodyToCreateDealGuarantee = [
+    {
+      dealIdentifier,
+      guarantorParty,
+      limitKey,
+      effectiveDate: effectiveDateInFuture,
+      guaranteeExpiryDate: guaranteeExpiryDateInFuture,
+      maximumLiability,
+      guaranteeTypeCode,
+    },
+  ];
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => givenRequestToCreateDealGuaranteeInAcbsSucceeds(),
+    makeRequest: () => api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee),
+  });
+
+  it('returns a 201 response with the deal guarantee location if it has been successfully created in ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenRequestToCreateDealGuaranteeInAcbsSucceeds();
+
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+  });
+
+  describe('dealIdentifier validation', () => {
+    it('returns a 400 response if the dealIdentifier in the request body is not present', async () => {
+      const { dealIdentifier: _removed, ...requestWithoutDealIdentifier } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutDealIdentifier]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['dealIdentifier must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the dealIdentifier is an empty string', async () => {
+      const requestWithEmptyDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyDealIdentifier);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['dealIdentifier must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the dealIdentifier is over 10 characters', async () => {
+      const requestWithTooLongDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '12345678901' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongDealIdentifier);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['dealIdentifier must be shorter than or equal to 10 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if the dealIdentifier is at most 10 characters', async () => {
+      const requestWithTenCharacterDealIdentifier = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '1234567890' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTenCharacterDealIdentifier);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('limitKey validation', () => {
+    it('returns a 400 response if the limitKey in the request body is not present', async () => {
+      const { limitKey: _removed, ...requestWithoutLimitKey } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutLimitKey]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['limitKey must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the limitKey is an empty string', async () => {
+      const requestWithEmptyLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyLimitKey);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['limitKey must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the limitKey is over 10 characters', async () => {
+      const requestWithTooLongLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], limitKey: '12345678901' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongLimitKey);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['limitKey must be shorter than or equal to 10 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if the limitKey is at most 10 characters', async () => {
+      const requestWithTenCharacterLimitKey = [{ ...requestBodyToCreateDealGuarantee[0], dealIdentifier: '1234567890' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTenCharacterLimitKey);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('effectiveDate validation', () => {
+    it('returns a 400 response if the effectiveDate is not present', async () => {
+      const { effectiveDate: _removed, ...requestWithoutEffectiveDate } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutEffectiveDate]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['effectiveDate must be a valid ISO 8601 date string', `effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the effectiveDate has time part of date string', async () => {
+      const requestWithEffectiveDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2023-02-01T00:00:00Z' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the effectiveDate is not in YYYY-MM-DD date format', async () => {
+      const requestWithEffectiveDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '20230201' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`effectiveDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the effectiveDate is not a valid date', async () => {
+      const requestWithEffectiveDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2023-99-10' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateAsInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['effectiveDate must be a valid ISO 8601 date string'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the effectiveDate is not a real day', async () => {
+      const requestWithEffectiveDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2019-02-29' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEffectiveDateAsInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['effectiveDate must be a valid ISO 8601 date string'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if the effectiveDate is a valid date', async () => {
+      const requestWithValidEffectiveDate = [{ ...requestBodyToCreateDealGuarantee[0], effectiveDate: '2022-02-01' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithValidEffectiveDate);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('guaranteeExpiryDate validation', () => {
+    it('returns a 400 response if the guaranteeExpiryDate is not present', async () => {
+      const { guaranteeExpiryDate: _removed, ...requestWithoutGuaranteeExpiryDate } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuaranteeExpiryDate]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string', `guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the guaranteeExpiryDate has time part of date string', async () => {
+      const requestWithGuaranteeExpiryDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2023-02-01T00:00:00Z' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the guaranteeExpiryDate is not in YYYY-MM-DD date format', async () => {
+      const requestWithGuaranteeExpiryDateInIncorrectFormat = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '20230201' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateInIncorrectFormat);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: [`guaranteeExpiryDate must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the guaranteeExpiryDate is not a valid date', async () => {
+      const requestWithGuaranteeExpiryDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2023-99-10' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateAsInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the guaranteeExpiryDate is not a real day', async () => {
+      const requestWithGuaranteeExpiryDateAsInvalidDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2019-02-29' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeExpiryDateAsInvalidDate);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guaranteeExpiryDate must be a valid ISO 8601 date string'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if the guaranteeExpiryDate is a valid date', async () => {
+      const requestWithValidGuaranteeExpiryDate = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeExpiryDate: '2022-02-01' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithValidGuaranteeExpiryDate);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('maximumLiability validation', () => {
+    it('returns a 400 response if the maximumLiability is not present', async () => {
+      const { maximumLiability: _removed, ...requestWithoutMaximumLiability } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutMaximumLiability]);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['maximumLiability must not be less than 0', 'maximumLiability should not be empty'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the maximumLiability is less than 0', async () => {
+      const requestWithNegativeMaximumLiability = [{ ...requestBodyToCreateDealGuarantee[0], maximumLiability: -0.01 }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithNegativeMaximumLiability);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['maximumLiability must not be less than 0'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if the maximumLiability is 0', async () => {
+      const requestWithZeroMaximumLiability = [{ ...requestBodyToCreateDealGuarantee[0], maximumLiability: 0 }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithZeroMaximumLiability);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('guarantorParty validation', () => {
+    it('returns a 201 response if guarantorParty is not present', async () => {
+      const { guarantorParty: _removed, ...requestWithoutGuarantorTypeCode } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuarantorTypeCode]);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+
+    it('returns a 201 response if guarantorParty is present', async () => {
+      const requestWithGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '001' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorParty);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+
+    it('returns a 400 response if guarantorParty is more than 10 characters', async () => {
+      const requestWithTooLongGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '12345678901' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithTooLongGuarantorParty);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guarantorParty must be shorter than or equal to 10 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if guarantorParty is empty', async () => {
+      const requestWithEmptyGuarantorParty = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyGuarantorParty);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guarantorParty must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 201 response if guarantorParty is at least 1 character', async () => {
+      const requestWithGuarantorPartyOfLength1 = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '1' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorPartyOfLength1);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+
+    it('returns a 201 response if guarantorParty is at most 10 characters', async () => {
+      const requestWithGuarantorPartyOfLength10 = [{ ...requestBodyToCreateDealGuarantee[0], guarantorParty: '1234567890' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuarantorPartyOfLength10);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+  });
+
+  describe('guaranteeTypeCode validation', () => {
+    it('returns a 201 response if guaranteeTypeCode is not present', async () => {
+      const { guaranteeTypeCode: _removed, ...requestWithoutGuaranteeTypeCode } = requestBodyToCreateDealGuarantee[0];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, [requestWithoutGuaranteeTypeCode]);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+
+    it('returns a 201 response if guaranteeTypeCode is present', async () => {
+      const requestWithGuaranteeTypeCode = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeTypeCode: '001' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithGuaranteeTypeCode);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({ dealIdentifier });
+    });
+
+    it('returns a 400 response if guaranteeTypeCode is empty', async () => {
+      const requestWithEmptyGuaranteeTypeCode = [{ ...requestBodyToCreateDealGuarantee[0], guaranteeTypeCode: '' }];
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+      const { status, body } = await api.post(createDealGuaranteeUrl, requestWithEmptyGuaranteeTypeCode);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({
+        error: 'Bad Request',
+        message: ['guaranteeTypeCode must be longer than or equal to 1 characters'],
+        statusCode: 400,
+      });
+    });
+  });
+
+  it('returns a 401 response when the API Key is missing', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+
+    const { status, body } = await api.postWithoutAuth(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(401);
+    expect(body).toStrictEqual({ message: 'Unauthorized', statusCode: 401 });
+  });
+
+  it('returns a 401 response when the Strategy is randomised', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    const apiKey = ENVIRONMENT_VARIABLES.API_KEY;
+    const randomisedApiStrategy = valueGenerator.word();
+
+    const { status, body } = await api.postWithoutAuth(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee, randomisedApiStrategy, apiKey);
+
+    expect(status).toBe(401);
+    expect(body).toStrictEqual({ message: 'Unauthorized', statusCode: 401 });
+  });
+
+  it('returns a 401 response when the API Key is incorrect', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    const strategy = AUTH.STRATEGY;
+    const randomisedApiKey = valueGenerator.string();
+    const { status, body } = await api.postWithoutAuth(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee, strategy, randomisedApiKey);
+
+    expect(status).toBe(401);
+    expect(body).toStrictEqual({ message: 'Unauthorized', statusCode: 401 });
+  });
+
+  it('returns a 401 response when the API Key is empty', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
+    const strategy = AUTH.STRATEGY;
+
+    const { status, body } = await api.postWithoutAuth(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee, strategy, '');
+
+    expect(status).toBe(401);
+    expect(body).toStrictEqual({ message: 'Unauthorized', statusCode: 401 });
+  });
+
+  it('returns a 404 response if ACBS responds with a 400 response that is a string containing "The deal not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToCreateDealGuarantee().reply(400, 'The deal not found or user does not have access');
+
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(404);
+    expect(body).toStrictEqual({ message: 'Not found', statusCode: 404 });
+  });
+
+  it('returns a 400 response if ACBS responds with a 400 response that is not a string', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsErrorMessage = { Message: 'error message' };
+    requestToCreateDealGuarantee().reply(400, acbsErrorMessage);
+
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'Bad request', error: JSON.stringify(acbsErrorMessage), statusCode: 400 });
+  });
+
+  it('returns a 400 response if ACBS responds with a 400 response that is a string that does not contain "The deal not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsErrorMessage = 'ACBS error message';
+    requestToCreateDealGuarantee().reply(400, acbsErrorMessage);
+
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
+  });
+
+  it('returns a 500 response if ACBS responds with an error code that is not 400"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToCreateDealGuarantee().reply(401, 'Unauthorized');
+
+    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyToCreateDealGuarantee);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+  });
+
+  // TODO APIM-73: Should we test defaults are set in the API tests also?
+
+  const givenRequestToCreateDealGuaranteeInAcbsSucceeds = (): void => {
+    requestToCreateDealGuarantee().reply(201, undefined, {
+      location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
+    });
+  };
+
+  const requestToCreateDealGuarantee = (): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, acbsRequestBodyToCreateDealGuarantee)
+      .matchHeader('authorization', `Bearer ${idToken}`);
+
+  const givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds = (): void => {
+    const requestBodyPlaceholder = '*';
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .filteringRequestBody(() => requestBodyPlaceholder)
+      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, requestBodyPlaceholder)
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .reply(201, undefined, {
+        location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
+      });
+  };
+});

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -10,6 +10,39 @@ paths:
       responses:
         '200':
           description: ''
+  /api/v1/deals/{dealIdentifier}/guarantees:
+    post:
+      operationId: DealGuaranteeController_createGuaranteeForDeal
+      summary: Create a new guarantee for a deal.
+      parameters:
+        - name: dealIdentifier
+          required: true
+          in: path
+          description: The identifier of the deal in ACBS.
+          example: '00000001'
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateDealGuaranteeRequestItem'
+      responses:
+        '201':
+          description: The guarantee has been successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDealGuaranteeResponse'
+        '400':
+          description: Bad request.
+        '404':
+          description: The deal was not found.
+        '500':
+          description: An internal server error has occurred.
   /api/v1/parties/{partyIdentifier}/external-ratings:
     get:
       operationId: PartyExternalRatingController_getExternalRatingsForParty
@@ -97,6 +130,61 @@ components:
       in: header
       name: x-api-key
   schemas:
+    CreateDealGuaranteeRequestItem:
+      type: object
+      properties:
+        dealIdentifier:
+          type: string
+          description: The identifier of the deal to create the guarantee for.
+          example: '00000001'
+          minLength: 1
+          maxLength: 10
+        effectiveDate:
+          format: date
+          type: string
+          description: >-
+            The date that this guarantee will take effect. This will be replaced
+            by today's date if a date in the past is provided.
+        limitKey:
+          type: string
+          description: An ACBS party identifier.
+          minLength: 1
+          maxLength: 10
+          example: '00000002'
+        guaranteeExpiryDate:
+          format: date
+          type: string
+          description: The date that this guarantee will expire on.
+        maximumLiability:
+          type: number
+          description: The maximum amount the guarantor will guarantee.
+          minimum: 0
+        guarantorParty:
+          type: string
+          description: UK GOODS (00000141)
+          minLength: 1
+          maxLength: 10
+          default: '00000141'
+        guaranteeTypeCode:
+          type: string
+          description: GOODS (450)
+          default: '450'
+          minLength: 1
+      required:
+        - dealIdentifier
+        - effectiveDate
+        - limitKey
+        - guaranteeExpiryDate
+        - maximumLiability
+    CreateDealGuaranteeResponse:
+      type: object
+      properties:
+        dealIdentifier:
+          type: string
+          readOnly: true
+          example: '00000001'
+      required:
+        - dealIdentifier
     GetPartyExternalRatingResponseRatingEntity:
       type: object
       properties:

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -137,8 +137,8 @@ components:
           type: string
           description: The identifier of the deal to create the guarantee for.
           example: '00000001'
-          minLength: 1
-          maxLength: 10
+          minLength: 8
+          maxLength: 8
         effectiveDate:
           format: date
           type: string
@@ -148,9 +148,9 @@ components:
         limitKey:
           type: string
           description: An ACBS party identifier.
-          minLength: 1
-          maxLength: 10
           example: '00000002'
+          minLength: 8
+          maxLength: 8
         guaranteeExpiryDate:
           format: date
           type: string
@@ -159,17 +159,21 @@ components:
           type: number
           description: The maximum amount the guarantor will guarantee.
           minimum: 0
+          maximum: 100000000000000000
         guarantorParty:
           type: string
-          description: UK GOODS (00000141)
-          minLength: 1
-          maxLength: 10
+          description: >-
+            The party identifier of the guarantor, the customer who is making
+            the guarantee/obligation.
+          minLength: 8
+          maxLength: 8
           default: '00000141'
         guaranteeTypeCode:
           type: string
-          description: GOODS (450)
+          description: The identifier for the type of the guarantee.
+          minLength: 3
+          maxLength: 3
           default: '450'
-          minLength: 1
       required:
         - dealIdentifier
         - effectiveDate

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -159,7 +159,6 @@ components:
           type: number
           description: The maximum amount the guarantor will guarantee.
           minimum: 0
-          maximum: 100000000000000000
         guarantorParty:
           type: string
           description: >-

--- a/test/party/get-parties-by-search-text.api-test.ts
+++ b/test/party/get-parties-by-search-text.api-test.ts
@@ -9,7 +9,7 @@ describe('GET /parties?searchText={searchText}', () => {
   const valueGenerator = new RandomValueGenerator();
   const idToken = valueGenerator.string();
   const sessionId = valueGenerator.string();
-  const searchText = valueGenerator.stringOfNumericCharacters(3);
+  const searchText = valueGenerator.stringOfNumericCharacters({ minLength: 3 });
 
   const partyAlternateIdentifierA = searchText + '0';
   const industryClassificationCodeA = valueGenerator.stringOfNumericCharacters();

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -13,18 +13,18 @@ export class RandomValueGenerator {
     return this.chance.string();
   }
 
-  word(): string {
-    return this.chance.word();
+  word(options?: { length?: number }): string {
+    return this.chance.word({ length: options?.length });
   }
 
   httpsUrl(): string {
     return this.chance.url({ protocol: 'https' });
   }
 
-  stringOfNumericCharacters(options?: { minLength?: number; maxLength?: number }): string {
+  stringOfNumericCharacters(options?: { length?: number; minLength?: number; maxLength?: number }): string {
     const minLength = options && options.minLength ? options.minLength : 0;
     const maxLength = options && options.maxLength ? options.maxLength : Math.max(20, minLength * 2);
-    const length = this.chance.integer({ min: minLength, max: maxLength });
+    const length = options && options.length ? options.length : this.chance.integer({ min: minLength, max: maxLength });
 
     return this.chance.string({ length, pool: '0123456789' });
   }

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -1,3 +1,4 @@
+import { DateString } from '@ukef/helpers/date-string.type';
 import { Chance } from 'chance';
 
 export class RandomValueGenerator {
@@ -20,24 +21,32 @@ export class RandomValueGenerator {
     return this.chance.url({ protocol: 'https' });
   }
 
-  stringOfNumericCharacters(minLength?: number): string {
-    const stringOptions: Partial<Chance.StringOptions> = { pool: '0123456789' };
-    if (minLength) {
-      const length = this.chance.integer({ min: minLength, max: Math.max(20, minLength * 2) });
-      stringOptions.length = length;
-    }
-    return this.chance.string(stringOptions);
+  stringOfNumericCharacters(options?: { minLength?: number; maxLength?: number }): string {
+    const minLength = options && options.minLength ? options.minLength : 0;
+    const maxLength = options && options.maxLength ? options.maxLength : Math.max(20, minLength * 2);
+    const length = this.chance.integer({ min: minLength, max: maxLength });
+
+    return this.chance.string({ length, pool: '0123456789' });
   }
 
   probabilityFloat(): number {
     return this.chance.floating({ min: 0, max: 1 });
   }
 
-  nonnegativeFloat(): number {
-    return this.chance.floating({ min: 0 });
+  nonnegativeFloat(options?: { max?: number }): number {
+    const min = 0;
+    return options && options.max ? this.chance.floating({ min, max: options.max }) : this.chance.floating({ min });
   }
 
   date(): Date {
     return this.chance.date();
+  }
+
+  dateTimeString(): DateString {
+    return this.date().toISOString();
+  }
+
+  dateOnlyString(): DateString {
+    return this.dateTimeString().split('T')[0];
   }
 }


### PR DESCRIPTION
## Introduction
Add the `POST /deals/{dealIdentifier}/guarantees` endpoint

## Resolution
I've added the endpoint with the following logic:
1. The request body is an array containing an object of the following shape
    ```
    {
      "dealIdentifier": "00000001",
      "effectiveDate": "2023-03-17",
      "limitKey": "00000002",
      "guaranteeExpiryDate": "2023-03-17",
      "maximumLiability": 0,
      "guarantorParty": "00000141",
      "guaranteeTypeCode": "450"
    }
    ```
    where `guarantorParty` and `guaranteeTypeCode` are optional and have defaults
1. We validate the below, returning a 400 if any rule fails
    - `dealIdentifier` exists and has length between 1 and 10
    - `effectiveDate` exists, is a real date, and is in `yyyy-mm-dd` format
    - `limitKey` exists and has length between 1 and 10
    - `guaranteeExpiryDate` exists, is a real date, and is in `yyyy-mm-dd` format
    - `maximumLiability` exists and is not less than 0
    - `guarantorParty` has length between 1 and 10 if it is present
    - `guaranteeTypeCode` has length more than 0 if it is present
1. We get an id token for ACBS from the IdP
1. We transform the request body, adding some defaults
    - the most interesting parts are that we round `maximumLiability` to 2dp and replace `effectiveDate` with today's date if it was in the past
1. We POST the transformed request to ACBS
    - If the response from ACBS is a 201, we return a 201 with the `dealIdentifier`
    - If the response from ACBS is a 400 and is a string that contains "The deal not found", we return a 404
    - If the response from ACBS is a 400 but isn't a string / doesn't contain "The deal not found", we return a 400 and also return the error message from ACBS
    - If the response from ACBS is anything else, we return a 500    


## Misc
- There are still some outstanding questions which I have left TODOs for
- I've added `dealIdentifier` in the URL to better match Gabriel's API specifications
- I've removed `portfolioIdentifier` from the request body because it wasn't used by the Mulesoft code at all
- The response body has changed from `{ "dealGuaranteeeLocation": "<an incorrect path>" }` to `{ "dealIdentifier": "<the deal identifier>" }`
- The error handling is slightly different than Mulesoft's error handling was: Mulesoft never returned a 404 and would also return a `200 [ ]` response if ACBS returned a 200 instead of a 201 - I couldn't see how ACBS would ever return a 200 though 