### PR TITLE
feat: add global auth definition to swagger

### DIFF
--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import basicAuth from 'express-basic-auth';
 
+import { AUTH } from './constants';
+
 export const SwaggerDocs = (app: INestApplication) => {
   const configService = app.get(ConfigService);
   const logger = new Logger();
@@ -12,7 +14,19 @@ export const SwaggerDocs = (app: INestApplication) => {
   const docVersion: string = configService.get<string>('doc.version');
   const docPrefix: string = configService.get<string>('doc.prefix');
 
-  const documentBuild = new DocumentBuilder().setTitle(docName).setDescription(docDesc).setVersion(docVersion).build();
+  const securityName = 'ApiKeyHeader';
+
+  const documentBuild = new DocumentBuilder()
+    .setTitle(docName)
+    .setDescription(docDesc)
+    .setVersion(docVersion)
+    .addSecurity(securityName, {
+      type: 'apiKey',
+      in: 'header',
+      name: AUTH.STRATEGY,
+    })
+    .addSecurityRequirements(securityName)
+    .build();
 
   app.use(
     ['/docs', '/docs-json', '/docs-yaml'],

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -91,6 +91,11 @@ info:
 tags: []
 servers: []
 components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: x-api-key
   schemas:
     GetPartyExternalRatingResponseRatingEntity:
       type: object
@@ -242,5 +247,7 @@ components:
         - citizenshipClass
         - officerRiskDate
         - countryCode
+security:
+  - ApiKeyHeader: []
 "
 `;


### PR DESCRIPTION
## Introduction
Since we added global authentication to TFS, all requests sent from the Swagger UI will fail authentication because they will not include the API Key header

## Resolution
The fix is to document the security scheme in the swagger specification and document that it is applied globally. This improves our documentation and also allow you to set the value of the header when using Swagger UI 