### PR TITLE
refactor: make export consistent in constant files

### DIFF
--- a/src/constants/acbs.constant.ts
+++ b/src/constants/acbs.constant.ts
@@ -1,7 +1,5 @@
-const ACBS = {
+export const ACBS = {
   AUTHENTICATION: {
     SESSION_ID_COOKIE_NAME: 'JSESSIONID',
   },
 };
-
-export { ACBS };

--- a/src/constants/application.constant.ts
+++ b/src/constants/application.constant.ts
@@ -1,5 +1,3 @@
-const APPLICATION = {
+export const APPLICATION = {
   NAME: 'tfs',
 };
-
-export { APPLICATION };

--- a/src/constants/properties.constant.ts
+++ b/src/constants/properties.constant.ts
@@ -1,4 +1,4 @@
-const PROPERTIES = {
+export const PROPERTIES = {
   GLOBAL: {
     portfolioIdentifier: 'E1',
   },
@@ -17,5 +17,3 @@ const PROPERTIES = {
     },
   },
 };
-
-export { PROPERTIES };


### PR DESCRIPTION
## Introduction

In PR 29, we raised that we should make the exports consistent in our constant files (see the conversation [here](https://github.com/UK-Export-Finance/tfs-api/pull/29#discussion_r1147178859))

## Resolution

I've changed all constant files to
```
export const <constant name> = { ... };
```
instead of 
```
const <constant name> = { ... };
export { const };
```