### PR TITLE
refactor: commonise date string conversions

### DIFF
--- a/src/constants/date-formats.constant.ts
+++ b/src/constants/date-formats.constant.ts
@@ -1,0 +1,6 @@
+export const DATE_FORMATS = {
+  DATE_ONLY_STRING: {
+    regex: /^\d{4}-\d{2}-\d{2}$/,
+    description: 'YYYY-MM-DD',
+  },
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,4 +10,5 @@
 export * from './acbs.constant';
 export * from './application.constant';
 export * from './auth.constant';
+export * from './date-formats.constant';
 export * from './properties.constant';

--- a/src/decorators/validated-date-only-api-property.decorator.ts
+++ b/src/decorators/validated-date-only-api-property.decorator.ts
@@ -1,5 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
+import { DATE_FORMATS } from '@ukef/constants';
 import { IsISO8601, Matches } from 'class-validator';
 
 export const ValidatedDateOnlyApiProperty = ({ description }: { description: string }) =>
@@ -10,5 +11,5 @@ export const ValidatedDateOnlyApiProperty = ({ description }: { description: str
       format: 'date',
     }),
     IsISO8601({ strict: true }),
-    Matches(/^\d{4}-\d{2}-\d{2}$/),
+    Matches(DATE_FORMATS.DATE_ONLY_STRING.regex),
   );

--- a/src/modules/date/date-string.transformations.test.ts
+++ b/src/modules/date/date-string.transformations.test.ts
@@ -1,0 +1,52 @@
+import { DateStringTransformations } from './date-string.transformations';
+
+describe('DateStringTransformations', () => {
+  const transformations = new DateStringTransformations();
+
+  describe('dateOnlyStringToDateString', () => {
+    it('converts a valid DateOnlyString to an ISO DateString', () => {
+      expect(transformations.dateOnlyStringToDateString('1987-04-23')).toBe('1987-04-23T00:00:00Z');
+    });
+
+    it.each([['abc'], ['19870423'], ['87-04-23'], ['1987-04-23T12:34:56Z'], [null], [undefined]])(
+      'throws a TypeError if the DateOnlyString is not in YYYY-MM-DD format (%s)',
+      (invalidInput) => {
+        const convertingTheInvalidInput = () => transformations.dateOnlyStringToDateString(invalidInput);
+
+        expect(convertingTheInvalidInput).toThrow(TypeError);
+        expect(convertingTheInvalidInput).toThrow(`${invalidInput} is not a valid DateOnlyString as it is not in YYYY-MM-DD format.`);
+      },
+    );
+  });
+
+  describe('removeTime', () => {
+    it('removes the time part of a string', () => {
+      expect(transformations.removeTime('1987-04-23T12:34:56Z')).toBe('1987-04-23');
+    });
+
+    it.each([
+      { description: 'null', input: null },
+      { description: 'undefined', input: undefined },
+      { description: 'empty', input: '' },
+    ])('throws a TypeError if the string is $description', ({ input }) => {
+      const convertingTheInvalidInput = () => transformations.removeTime(input);
+
+      expect(convertingTheInvalidInput).toThrow(TypeError);
+      expect(convertingTheInvalidInput).toThrow(`Cannot remove the time from ${input}.`);
+    });
+  });
+
+  describe('removeTimeIfExists', () => {
+    it('removes the time part of a string', () => {
+      expect(transformations.removeTimeIfExists('1987-04-23T12:34:56Z')).toBe('1987-04-23');
+    });
+
+    it.each([
+      { description: 'null', input: null },
+      { description: 'undefined', input: undefined },
+      { description: 'empty', input: '' },
+    ])('returns the original string if the string is $description', ({ input }) => {
+      expect(transformations.removeTimeIfExists(input)).toBe(input);
+    });
+  });
+});

--- a/src/modules/date/date-string.transformations.test.ts
+++ b/src/modules/date/date-string.transformations.test.ts
@@ -1,17 +1,17 @@
 import { DateStringTransformations } from './date-string.transformations';
 
 describe('DateStringTransformations', () => {
-  const transformations = new DateStringTransformations();
+  const dateStringTransformations = new DateStringTransformations();
 
-  describe('dateOnlyStringToDateString', () => {
+  describe('addTimeToDateOnlyString', () => {
     it('converts a valid DateOnlyString to an ISO DateString', () => {
-      expect(transformations.dateOnlyStringToDateString('1987-04-23')).toBe('1987-04-23T00:00:00Z');
+      expect(dateStringTransformations.addTimeToDateOnlyString('1987-04-23')).toBe('1987-04-23T00:00:00Z');
     });
 
     it.each([['abc'], ['19870423'], ['87-04-23'], ['1987-04-23T12:34:56Z'], [null], [undefined]])(
       'throws a TypeError if the DateOnlyString is not in YYYY-MM-DD format (%s)',
       (invalidInput) => {
-        const convertingTheInvalidInput = () => transformations.dateOnlyStringToDateString(invalidInput);
+        const convertingTheInvalidInput = () => dateStringTransformations.addTimeToDateOnlyString(invalidInput);
 
         expect(convertingTheInvalidInput).toThrow(TypeError);
         expect(convertingTheInvalidInput).toThrow(`${invalidInput} is not a valid DateOnlyString as it is not in YYYY-MM-DD format.`);
@@ -21,7 +21,7 @@ describe('DateStringTransformations', () => {
 
   describe('removeTime', () => {
     it('removes the time part of a string', () => {
-      expect(transformations.removeTime('1987-04-23T12:34:56Z')).toBe('1987-04-23');
+      expect(dateStringTransformations.removeTime('1987-04-23T12:34:56Z')).toBe('1987-04-23');
     });
 
     it.each([
@@ -29,7 +29,7 @@ describe('DateStringTransformations', () => {
       { description: 'undefined', input: undefined },
       { description: 'empty', input: '' },
     ])('throws a TypeError if the string is $description', ({ input }) => {
-      const convertingTheInvalidInput = () => transformations.removeTime(input);
+      const convertingTheInvalidInput = () => dateStringTransformations.removeTime(input);
 
       expect(convertingTheInvalidInput).toThrow(TypeError);
       expect(convertingTheInvalidInput).toThrow(`Cannot remove the time from ${input}.`);
@@ -38,7 +38,7 @@ describe('DateStringTransformations', () => {
 
   describe('removeTimeIfExists', () => {
     it('removes the time part of a string', () => {
-      expect(transformations.removeTimeIfExists('1987-04-23T12:34:56Z')).toBe('1987-04-23');
+      expect(dateStringTransformations.removeTimeIfExists('1987-04-23T12:34:56Z')).toBe('1987-04-23');
     });
 
     it.each([
@@ -46,7 +46,7 @@ describe('DateStringTransformations', () => {
       { description: 'undefined', input: undefined },
       { description: 'empty', input: '' },
     ])('returns the original string if the string is $description', ({ input }) => {
-      expect(transformations.removeTimeIfExists(input)).toBe(input);
+      expect(dateStringTransformations.removeTimeIfExists(input)).toBe(input);
     });
   });
 });

--- a/src/modules/date/date-string.transformations.ts
+++ b/src/modules/date/date-string.transformations.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { DATE_FORMATS } from '@ukef/constants';
+import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
+import { DateString } from '@ukef/helpers/date-string.type';
+import { matches } from 'class-validator';
+
+@Injectable()
+export class DateStringTransformations {
+  /**
+   * Remove time part from DateTime string.
+   */
+  removeTime(dateTime: string): DateString {
+    if (!dateTime) {
+      throw new TypeError(`Cannot remove the time from ${dateTime}.`);
+    }
+    return dateTime.split('T')[0] as DateString;
+  }
+
+  /**
+   * Check if dateTime input is not null or empty before removing time.
+   */
+  removeTimeIfExists(dateTime: string): DateString {
+    return (dateTime ? this.removeTime(dateTime) : dateTime) as DateString;
+  }
+
+  dateOnlyStringToDateString(dateOnlyString: DateOnlyString): DateString {
+    if (!matches(dateOnlyString, DATE_FORMATS.DATE_ONLY_STRING.regex)) {
+      throw new TypeError(`${dateOnlyString} is not a valid DateOnlyString as it is not in ${DATE_FORMATS.DATE_ONLY_STRING.description} format.`);
+    }
+    return dateOnlyString + 'T00:00:00Z';
+  }
+}

--- a/src/modules/date/date-string.transformations.ts
+++ b/src/modules/date/date-string.transformations.ts
@@ -9,21 +9,21 @@ export class DateStringTransformations {
   /**
    * Remove time part from DateTime string.
    */
-  removeTime(dateTime: string): DateString {
+  removeTime(dateTime: DateString): DateOnlyString {
     if (!dateTime) {
       throw new TypeError(`Cannot remove the time from ${dateTime}.`);
     }
-    return dateTime.split('T')[0] as DateString;
+    return dateTime.split('T')[0];
   }
 
   /**
    * Check if dateTime input is not null or empty before removing time.
    */
-  removeTimeIfExists(dateTime: string): DateString {
-    return (dateTime ? this.removeTime(dateTime) : dateTime) as DateString;
+  removeTimeIfExists(dateTime: DateString): DateOnlyString {
+    return dateTime ? this.removeTime(dateTime) : dateTime;
   }
 
-  dateOnlyStringToDateString(dateOnlyString: DateOnlyString): DateString {
+  addTimeToDateOnlyString(dateOnlyString: DateOnlyString): DateString {
     if (!matches(dateOnlyString, DATE_FORMATS.DATE_ONLY_STRING.regex)) {
       throw new TypeError(`${dateOnlyString} is not a valid DateOnlyString as it is not in ${DATE_FORMATS.DATE_ONLY_STRING.description} format.`);
     }

--- a/src/modules/date/date.module.ts
+++ b/src/modules/date/date.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { CurrentDateProvider } from './current-date.provider';
+import { DateStringTransformations } from './date-string.transformations';
 
 @Module({
-  providers: [CurrentDateProvider],
-  exports: [CurrentDateProvider],
+  providers: [CurrentDateProvider, DateStringTransformations],
+  exports: [CurrentDateProvider, DateStringTransformations],
 })
 export class DateModule {}

--- a/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
@@ -14,7 +14,7 @@ describe('DealGuaranteeController', () => {
   let dealGuaranteeServiceCreateGuaranteeForDeal: jest.Mock;
 
   beforeEach(() => {
-    dealGuaranteeService = new DealGuaranteeService(null, null, null);
+    dealGuaranteeService = new DealGuaranteeService(null, null, null, null);
 
     dealGuaranteeServiceCreateGuaranteeForDeal = jest.fn();
     dealGuaranteeService.createGuaranteeForDeal = dealGuaranteeServiceCreateGuaranteeForDeal;

--- a/src/modules/deal-guarantee/deal-guarantee.service.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.test.ts
@@ -16,7 +16,7 @@ jest.mock('@ukef/modules/acbs/acbs-authentication.service');
 
 describe('DealGuaranteeService', () => {
   const valueGenerator = new RandomValueGenerator();
-  const transformations = new DateStringTransformations();
+  const dateStringTransformations = new DateStringTransformations();
   const idToken = valueGenerator.string();
 
   let acbsAuthenticationService: AcbsAuthenticationService;
@@ -40,7 +40,7 @@ describe('DealGuaranteeService', () => {
     currentDateProviderGetLatestDateFromTodayAnd = jest.fn();
     currentDateProvider.getLatestDateFromTodayAnd = currentDateProviderGetLatestDateFromTodayAnd;
 
-    service = new DealGuaranteeService(acbsAuthenticationService, acbsDealGuaranteeService, currentDateProvider, transformations);
+    service = new DealGuaranteeService(acbsAuthenticationService, acbsDealGuaranteeService, currentDateProvider, dateStringTransformations);
 
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
   });
@@ -51,9 +51,9 @@ describe('DealGuaranteeService', () => {
     const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
     const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
     const effectiveDate = valueGenerator.dateOnlyString();
-    const effectiveDateAsDate = new Date(transformations.dateOnlyStringToDateString(effectiveDate));
+    const effectiveDateAsDate = new Date(dateStringTransformations.addTimeToDateOnlyString(effectiveDate));
     const today = valueGenerator.date();
-    const todayAsDateOnlyString = transformations.removeTime(today.toISOString());
+    const todayAsDateOnlyString = dateStringTransformations.removeTime(today.toISOString());
     const expirationDate = valueGenerator.dateOnlyString();
     const maximumLiabilityWithOneDecimalPlace = Number(valueGenerator.nonnegativeFloat().toFixed(1));
 
@@ -83,8 +83,8 @@ describe('DealGuaranteeService', () => {
         GuaranteeType: {
           GuaranteeTypeCode: guaranteeTypeCode,
         },
-        EffectiveDate: transformations.dateOnlyStringToDateString(effectiveDate),
-        ExpirationDate: transformations.dateOnlyStringToDateString(expirationDate),
+        EffectiveDate: dateStringTransformations.addTimeToDateOnlyString(effectiveDate),
+        ExpirationDate: dateStringTransformations.addTimeToDateOnlyString(expirationDate),
         GuaranteedLimit: maximumLiabilityWithOneDecimalPlace,
         GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
       };
@@ -124,7 +124,7 @@ describe('DealGuaranteeService', () => {
 
       const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
 
-      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(transformations.dateOnlyStringToDateString(todayAsDateOnlyString));
+      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(dateStringTransformations.addTimeToDateOnlyString(todayAsDateOnlyString));
     });
 
     it(`does NOT replace effectiveDate with today's date if effectiveDate is NOT before today`, async () => {
@@ -134,7 +134,7 @@ describe('DealGuaranteeService', () => {
 
       const guaranteeCreatedInAcbs: AcbsCreateDealGuaranteeDto = acbsDealGuaranteeServiceCreateGuaranteeForDeal.mock.calls[0][1];
 
-      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(transformations.dateOnlyStringToDateString(effectiveDate));
+      expect(guaranteeCreatedInAcbs.EffectiveDate).toBe(dateStringTransformations.addTimeToDateOnlyString(effectiveDate));
     });
 
     it('rounds the maximumLiability to 2 decimal places', async () => {

--- a/src/modules/deal-guarantee/deal-guarantee.service.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.ts
@@ -21,7 +21,7 @@ export class DealGuaranteeService {
     const idToken = await this.acbsAuthenticationService.getIdToken();
 
     const effectiveDateTime = this.currentDateProvider.getLatestDateFromTodayAnd(
-      new Date(this.dateStringTransformations.dateOnlyStringToDateString(newGuarantee.effectiveDate)),
+      new Date(this.dateStringTransformations.addTimeToDateOnlyString(newGuarantee.effectiveDate)),
     );
     const effectiveDateOnlyString = this.dateStringTransformations.removeTime(effectiveDateTime.toISOString());
 
@@ -40,8 +40,8 @@ export class DealGuaranteeService {
       GuaranteeType: {
         GuaranteeTypeCode: newGuarantee.guaranteeTypeCode ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
       },
-      EffectiveDate: this.dateStringTransformations.dateOnlyStringToDateString(effectiveDateOnlyString),
-      ExpirationDate: this.dateStringTransformations.dateOnlyStringToDateString(newGuarantee.guaranteeExpiryDate),
+      EffectiveDate: this.dateStringTransformations.addTimeToDateOnlyString(effectiveDateOnlyString),
+      ExpirationDate: this.dateStringTransformations.addTimeToDateOnlyString(newGuarantee.guaranteeExpiryDate),
       GuaranteedLimit: Math.round(newGuarantee.maximumLiability * 100) / 100,
       GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
     };

--- a/src/modules/deal-guarantee/deal-guarantee.service.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.ts
@@ -5,6 +5,7 @@ import { AcbsDealGuaranteeService } from '@ukef/modules/acbs/acbs-deal-guarantee
 import { AcbsCreateDealGuaranteeDto } from '@ukef/modules/acbs/dto/acbs-create-deal-guarantee.dto';
 import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
 
+import { DateStringTransformations } from '../date/date-string.transformations';
 import { DealGuaranteeToCreate } from './deal-guarantee-to-create.interface';
 
 @Injectable()
@@ -13,13 +14,16 @@ export class DealGuaranteeService {
     private readonly acbsAuthenticationService: AcbsAuthenticationService,
     private readonly acbsDealGuaranteeService: AcbsDealGuaranteeService,
     private readonly currentDateProvider: CurrentDateProvider,
+    private readonly dateStringTransformations: DateStringTransformations,
   ) {}
 
   async createGuaranteeForDeal(dealIdentifier: string, newGuarantee: DealGuaranteeToCreate): Promise<void> {
     const idToken = await this.acbsAuthenticationService.getIdToken();
 
-    const effectiveDateTime = this.currentDateProvider.getLatestDateFromTodayAnd(new Date(newGuarantee.effectiveDate + 'T00:00:00Z'));
-    const effectiveDateOnlyString = effectiveDateTime.toISOString().split('T')[0];
+    const effectiveDateTime = this.currentDateProvider.getLatestDateFromTodayAnd(
+      new Date(this.dateStringTransformations.dateOnlyStringToDateString(newGuarantee.effectiveDate)),
+    );
+    const effectiveDateOnlyString = this.dateStringTransformations.removeTime(effectiveDateTime.toISOString());
 
     const guaranteeToCreateInAcbs: AcbsCreateDealGuaranteeDto = {
       LenderType: {
@@ -36,8 +40,8 @@ export class DealGuaranteeService {
       GuaranteeType: {
         GuaranteeTypeCode: newGuarantee.guaranteeTypeCode ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
       },
-      EffectiveDate: effectiveDateOnlyString + 'T00:00:00Z',
-      ExpirationDate: newGuarantee.guaranteeExpiryDate + 'T00:00:00Z',
+      EffectiveDate: this.dateStringTransformations.dateOnlyStringToDateString(effectiveDateOnlyString),
+      ExpirationDate: this.dateStringTransformations.dateOnlyStringToDateString(newGuarantee.guaranteeExpiryDate),
       GuaranteedLimit: Math.round(newGuarantee.maximumLiability * 100) / 100,
       GuaranteedPercentage: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteedPercentage,
     };

--- a/src/modules/party/party.controller.test.ts
+++ b/src/modules/party/party.controller.test.ts
@@ -17,7 +17,7 @@ describe('PartyController', () => {
   let partyServiceGetPartyByIdentifier: jest.Mock;
 
   beforeEach(() => {
-    partyService = new PartyService({ baseUrl: valueGenerator.httpsUrl() }, null, null, null);
+    partyService = new PartyService({ baseUrl: valueGenerator.httpsUrl() }, null, null, null, null);
 
     partyServiceGetPartyByIdentifier = jest.fn();
     partyService.getPartyByIdentifier = partyServiceGetPartyByIdentifier;

--- a/src/modules/party/party.module.ts
+++ b/src/modules/party/party.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
 
+import { DateModule } from '../date/date.module';
 import { PartyController } from './party.controller';
 import { PartyService } from './party.service';
 @Module({
@@ -16,6 +17,7 @@ import { PartyService } from './party.service';
       }),
     }),
     AcbsModule,
+    DateModule,
   ],
   controllers: [PartyController],
   providers: [PartyService],

--- a/src/modules/party/party.service.get-party-by-identifier.test.ts
+++ b/src/modules/party/party.service.get-party-by-identifier.test.ts
@@ -5,6 +5,7 @@ import { when } from 'jest-when';
 import { AcbsAuthenticationService } from '../acbs/acbs-authentication.service';
 import { AcbsPartyService } from '../acbs/acbs-party.service';
 import { AcbsGetPartyResponseDto } from '../acbs/dto/acbs-get-party-response.dto';
+import { DateStringTransformations } from '../date/date-string.transformations';
 import { Party } from './party.interface';
 import { PartyService } from './party.service';
 
@@ -32,7 +33,7 @@ describe('PartyService', () => {
     const acbsAuthenticationServiceGetIdToken = jest.fn();
     acbsAuthenticationService.getIdToken = acbsAuthenticationServiceGetIdToken;
 
-    service = new PartyService({ baseUrl }, null, acbsAuthenticationService, acbsPartyService);
+    service = new PartyService({ baseUrl }, null, acbsAuthenticationService, acbsPartyService, new DateStringTransformations());
 
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
   });

--- a/src/modules/party/party.service.test.ts
+++ b/src/modules/party/party.service.test.ts
@@ -5,6 +5,7 @@ import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
+import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsGetPartiesBySearchTextResponseElement } from './dto/acbs-get-parties-by-search-text-response-element.dto';
 
 describe('PartyService', () => {
@@ -71,7 +72,7 @@ describe('PartyService', () => {
     httpServiceGet = jest.fn();
     httpService.get = httpServiceGet;
 
-    partyService = new PartyService(config, httpService, null, null);
+    partyService = new PartyService(config, httpService, null, null, new DateStringTransformations());
   });
 
   describe('successful request', () => {

--- a/src/modules/party/party.service.ts
+++ b/src/modules/party/party.service.ts
@@ -6,6 +6,7 @@ import { AcbsAuthenticationService } from '@ukef/modules/acbs/acbs-authenticatio
 import { AcbsPartyService } from '@ukef/modules/acbs/acbs-party.service';
 import { lastValueFrom } from 'rxjs';
 
+import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsGetPartiesBySearchTextResponseElement } from './dto/acbs-get-parties-by-search-text-response-element.dto';
 import { GetPartiesBySearchTextResponseElement } from './dto/get-parties-by-search-text-response-element.dto';
 import { GetPartiesBySearchTextException } from './exception/get-parties-by-search-text.exception';
@@ -21,6 +22,7 @@ export class PartyService {
     private readonly httpService: HttpService,
     private readonly acbsAuthenticationService: AcbsAuthenticationService,
     private readonly acbsPartyService: AcbsPartyService,
+    private readonly dateStringTransformations: DateStringTransformations,
   ) {}
 
   async getPartiesBySearchText(token: string, searchText: string): Promise<GetPartiesBySearchTextResponseElement[]> {
@@ -55,7 +57,7 @@ export class PartyService {
           name3: element.PartyName3,
           smeType: element.MinorityClass.MinorityClassCode,
           citizenshipClass: element.CitizenshipClass.CitizenshipClassCode,
-          officerRiskDate: element.OfficerRiskDate ? element.OfficerRiskDate.slice(0, 10) : null,
+          officerRiskDate: this.dateStringTransformations.removeTimeIfExists(element.OfficerRiskDate),
           countryCode: element.PrimaryAddress.Country.CountryCode,
         })),
       )
@@ -77,7 +79,7 @@ export class PartyService {
       name3: partyInAcbs.PartyName3,
       smeType: partyInAcbs.MinorityClass.MinorityClassCode,
       citizenshipClass: partyInAcbs.CitizenshipClass.CitizenshipClassCode,
-      officerRiskDate: partyInAcbs.OfficerRiskDate && partyInAcbs.OfficerRiskDate.split('T')[0],
+      officerRiskDate: this.dateStringTransformations.removeTimeIfExists(partyInAcbs.OfficerRiskDate),
       countryCode: partyInAcbs.PrimaryAddress.Country.CountryCode,
     };
   }

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -1,4 +1,5 @@
 import { PROPERTIES } from '@ukef/constants';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
 import { withRequiredDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests';
@@ -11,6 +12,7 @@ import nock from 'nock';
 
 describe('POST /deals/{dealIdentifier}/guarantees', () => {
   const valueGenerator = new RandomValueGenerator();
+  const transformations = new DateStringTransformations();
 
   const dealIdentifier = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const createDealGuaranteeUrl = `/api/v1/deals/${dealIdentifier}/guarantees`;
@@ -43,8 +45,8 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     GuaranteeType: {
       GuaranteeTypeCode: guaranteeTypeCode,
     },
-    EffectiveDate: effectiveDateInFuture + 'T00:00:00Z',
-    ExpirationDate: guaranteeExpiryDateInFuture + 'T00:00:00Z',
+    EffectiveDate: transformations.dateOnlyStringToDateString(effectiveDateInFuture),
+    ExpirationDate: transformations.dateOnlyStringToDateString(guaranteeExpiryDateInFuture),
     GuaranteedLimit: 12345.6,
     GuaranteedPercentage: guaranteedPercentage,
   };

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -12,7 +12,7 @@ import nock from 'nock';
 
 describe('POST /deals/{dealIdentifier}/guarantees', () => {
   const valueGenerator = new RandomValueGenerator();
-  const transformations = new DateStringTransformations();
+  const dateStringTransformations = new DateStringTransformations();
 
   const dealIdentifier = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const createDealGuaranteeUrl = `/api/v1/deals/${dealIdentifier}/guarantees`;
@@ -45,8 +45,8 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     GuaranteeType: {
       GuaranteeTypeCode: guaranteeTypeCode,
     },
-    EffectiveDate: transformations.dateOnlyStringToDateString(effectiveDateInFuture),
-    ExpirationDate: transformations.dateOnlyStringToDateString(guaranteeExpiryDateInFuture),
+    EffectiveDate: dateStringTransformations.addTimeToDateOnlyString(effectiveDateInFuture),
+    ExpirationDate: dateStringTransformations.addTimeToDateOnlyString(guaranteeExpiryDateInFuture),
     GuaranteedLimit: 12345.6,
     GuaranteedPercentage: guaranteedPercentage,
   };

--- a/test/support/generator/party-generator.ts
+++ b/test/support/generator/party-generator.ts
@@ -1,10 +1,13 @@
 import { AcbsGetPartyResponseDto } from '@ukef/modules/acbs/dto/acbs-get-party-response.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetPartyByIdentifierResponse } from '@ukef/modules/party/dto/get-party-by-response.dto';
 import { Party } from '@ukef/modules/party/party.interface';
 
 import { AbstractGenerator } from './abstract-generator';
 
 export class PartyGenerator extends AbstractGenerator<PartyValues, GenerateResult, GenerateOptions> {
+  private readonly transformations: DateStringTransformations = new DateStringTransformations();
+
   protected generateValues(): PartyValues {
     return {
       alternateIdentifier: this.valueGenerator.stringOfNumericCharacters(),
@@ -40,7 +43,7 @@ export class PartyGenerator extends AbstractGenerator<PartyValues, GenerateResul
       name3: v.name3,
       smeType: v.smeType,
       citizenshipClass: v.citizenshipClass,
-      officerRiskDate: v.officerRiskDate.toISOString().split('T')[0],
+      officerRiskDate: this.transformations.removeTime(v.officerRiskDate.toISOString()),
       countryCode: v.countryCode,
     }));
 

--- a/test/support/generator/party-generator.ts
+++ b/test/support/generator/party-generator.ts
@@ -6,7 +6,7 @@ import { Party } from '@ukef/modules/party/party.interface';
 import { AbstractGenerator } from './abstract-generator';
 
 export class PartyGenerator extends AbstractGenerator<PartyValues, GenerateResult, GenerateOptions> {
-  private readonly transformations: DateStringTransformations = new DateStringTransformations();
+  private readonly dateStringTransformations: DateStringTransformations = new DateStringTransformations();
 
   protected generateValues(): PartyValues {
     return {
@@ -43,7 +43,7 @@ export class PartyGenerator extends AbstractGenerator<PartyValues, GenerateResul
       name3: v.name3,
       smeType: v.smeType,
       citizenshipClass: v.citizenshipClass,
-      officerRiskDate: this.transformations.removeTime(v.officerRiskDate.toISOString()),
+      officerRiskDate: this.dateStringTransformations.removeTime(v.officerRiskDate.toISOString()),
       countryCode: v.countryCode,
     }));
 

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -1,12 +1,15 @@
 import { DateString } from '@ukef/helpers/date-string.type';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { Chance } from 'chance';
 
 export class RandomValueGenerator {
   private static readonly seed = 0;
   private readonly chance: Chance.Chance;
+  private readonly transformations: DateStringTransformations;
 
   constructor() {
     this.chance = new Chance(RandomValueGenerator.seed);
+    this.transformations = new DateStringTransformations();
   }
 
   string(): string {
@@ -47,6 +50,6 @@ export class RandomValueGenerator {
   }
 
   dateOnlyString(): DateString {
-    return this.dateTimeString().split('T')[0];
+    return this.transformations.removeTime(this.dateTimeString());
   }
 }

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -5,11 +5,11 @@ import { Chance } from 'chance';
 export class RandomValueGenerator {
   private static readonly seed = 0;
   private readonly chance: Chance.Chance;
-  private readonly transformations: DateStringTransformations;
+  private readonly dateStringTransformations: DateStringTransformations;
 
   constructor() {
     this.chance = new Chance(RandomValueGenerator.seed);
-    this.transformations = new DateStringTransformations();
+    this.dateStringTransformations = new DateStringTransformations();
   }
 
   string(): string {
@@ -50,6 +50,6 @@ export class RandomValueGenerator {
   }
 
   dateOnlyString(): DateString {
-    return this.transformations.removeTime(this.dateTimeString());
+    return this.dateStringTransformations.removeTime(this.dateTimeString());
   }
 }


### PR DESCRIPTION
## Introduction

In a few different places in the code, we do the same date string conversions:
- removing the time part of a date time string
- adding the time part to a date only string

We should commonise this logic

## Resolution

@avaitonis had already done some of this work in [his open PR](https://github.com/UK-Export-Finance/tfs-api/pull/28) where he added a `DateStringTransformations` class. I've:
- moved it to the DateModule, so it can be dependency injected into other modules
- added some unit tests
- added a new method for adding the time part  to a date only string
- used the class in existing code 