### PR TITLE
refactor: commonise acbs http service

### DIFF
--- a/src/modules/acbs/acbs-deal-guarantee.service.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.ts
@@ -3,34 +3,33 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
-import { AxiosResponse } from 'axios';
-import { lastValueFrom } from 'rxjs';
 
+import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateDealGuaranteeDto } from './dto/acbs-create-deal-guarantee.dto';
-import { wrapAcbsHttpPostError } from './wrap-acbs-http-error';
+import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
 export class AcbsDealGuaranteeService {
+  private readonly acbsHttpService: AcbsHttpService;
+
   constructor(
     @Inject(AcbsConfig.KEY)
-    private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
-    private readonly httpService: HttpService,
-  ) {}
+    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    httpService: HttpService,
+  ) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
 
   async createGuaranteeForDeal(dealIdentifier: string, newDealGuarantee: AcbsCreateDealGuaranteeDto, idToken: string): Promise<void> {
     const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
-    await lastValueFrom(
-      this.httpService
-        .post<never>(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`, newDealGuarantee, {
-          baseURL: this.config.baseUrl,
-          headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
-        })
-        .pipe(
-          wrapAcbsHttpPostError<AxiosResponse<never, any>, any>({
-            resourceIdentifier: dealIdentifier,
-            messageForUnknownException: `Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`,
-          }),
-        ),
-    );
+    await this.acbsHttpService.post<AcbsCreateDealGuaranteeDto>({
+      path: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee`,
+      requestBody: newDealGuarantee,
+      idToken,
+      onError: createWrapAcbsHttpPostErrorCallback({
+        resourceIdentifier: dealIdentifier,
+        messageForUnknownException: `Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`,
+      }),
+    });
   }
 }

--- a/src/modules/acbs/acbs-deal-party.service.ts
+++ b/src/modules/acbs/acbs-deal-party.service.ts
@@ -2,35 +2,32 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
-import { lastValueFrom } from 'rxjs';
 
+import { AcbsHttpService } from './acbs-http.service';
 import { AcbsGetDealPartyResponseDto } from './dto/acbs-get-deal-party-response.dto';
-import { wrapAcbsHttpError } from './wrap-acbs-http-error';
+import { createWrapAcbsHttpErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
 export class AcbsDealPartyService {
+  private readonly acbsHttpService: AcbsHttpService;
+
   constructor(
     @Inject(AcbsConfig.KEY)
-    private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
-    private readonly httpService: HttpService,
-  ) {}
+    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    httpService: HttpService,
+  ) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
 
-  async getDealPartiesForDeal(portfolio: string, dealIdentifier: string, authToken: string): Promise<AcbsGetDealPartyResponseDto[]> {
-    const { data: dealPartiesInAcbs } = await lastValueFrom(
-      this.httpService
-        .get<AcbsGetDealPartyResponseDto>(`/Portfolio/${portfolio}/Deal/${dealIdentifier}/DealParty`, {
-          baseURL: this.config.baseUrl,
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        })
-        .pipe(
-          wrapAcbsHttpError({
-            resourceIdentifier: dealIdentifier,
-            messageForUnknownException: `Failed to get the deal investors for the deal with id ${dealIdentifier}.`,
-          }),
-        ),
-    );
+  async getDealPartiesForDeal(portfolio: string, dealIdentifier: string, idToken: string): Promise<AcbsGetDealPartyResponseDto[]> {
+    const { data: dealPartiesInAcbs } = await this.acbsHttpService.get<AcbsGetDealPartyResponseDto[]>({
+      path: `/Portfolio/${portfolio}/Deal/${dealIdentifier}/DealParty`,
+      idToken,
+      onError: createWrapAcbsHttpErrorCallback({
+        resourceIdentifier: dealIdentifier,
+        messageForUnknownException: `Failed to get the deal investors for the deal with id ${dealIdentifier}.`,
+      }),
+    });
 
     return dealPartiesInAcbs;
   }

--- a/src/modules/acbs/acbs-facility-party.service.ts
+++ b/src/modules/acbs/acbs-facility-party.service.ts
@@ -3,30 +3,29 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
-import { lastValueFrom } from 'rxjs';
 
+import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateFacilityPartyDto } from './dto/acbs-create-facility-party.dto';
-import { wrapAcbsHttpPostError } from './wrap-acbs-http-error';
+import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
 export class AcbsFacilityPartyService {
-  constructor(@Inject(AcbsConfig.KEY) private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, private readonly httpService: HttpService) {}
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(@Inject(AcbsConfig.KEY) config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, httpService: HttpService) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
 
   async createPartyForFacility(facilityIdentifier: string, newFacilityParty: AcbsCreateFacilityPartyDto, idToken: string): Promise<void> {
     const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
-
-    await lastValueFrom(
-      this.httpService
-        .post<never>(`/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty`, newFacilityParty, {
-          baseURL: this.config.baseUrl,
-          headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
-        })
-        .pipe(
-          wrapAcbsHttpPostError({
-            resourceIdentifier: facilityIdentifier,
-            messageForUnknownException: `Failed to create a party for facility ${facilityIdentifier} in ACBS.`,
-          }),
-        ),
-    );
+    await this.acbsHttpService.post<AcbsCreateFacilityPartyDto>({
+      path: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty`,
+      requestBody: newFacilityParty,
+      idToken,
+      onError: createWrapAcbsHttpPostErrorCallback({
+        resourceIdentifier: facilityIdentifier,
+        messageForUnknownException: `Failed to create a party for facility ${facilityIdentifier} in ACBS.`,
+      }),
+    });
   }
 }

--- a/src/modules/acbs/acbs-http.service.ts
+++ b/src/modules/acbs/acbs-http.service.ts
@@ -1,0 +1,51 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigType } from '@nestjs/config';
+import AcbsConfig from '@ukef/config/acbs.config';
+import { AxiosResponse } from 'axios';
+import { catchError, lastValueFrom } from 'rxjs';
+
+export class AcbsHttpService {
+  constructor(private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, private readonly httpService: HttpService) {}
+
+  async get<ResponseBody>({
+    path,
+    idToken,
+    onError,
+  }: {
+    path: string;
+    idToken: string;
+    onError: (error: Error) => never;
+  }): Promise<AxiosResponse<ResponseBody, unknown>> {
+    return await lastValueFrom(
+      this.httpService
+        .get<ResponseBody>(path, {
+          baseURL: this.config.baseUrl,
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+          },
+        })
+        .pipe(catchError(onError)),
+    );
+  }
+
+  async post<RequestBody>({
+    path,
+    requestBody,
+    idToken,
+    onError,
+  }: {
+    path: string;
+    requestBody: RequestBody;
+    idToken: string;
+    onError: (error: Error) => never;
+  }): Promise<void> {
+    await lastValueFrom(
+      this.httpService
+        .post<never>(path, requestBody, {
+          baseURL: this.config.baseUrl,
+          headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+        })
+        .pipe(catchError(onError)),
+    );
+  }
+}

--- a/src/modules/acbs/acbs-party-external-rating.service.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.ts
@@ -2,35 +2,32 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
-import { lastValueFrom } from 'rxjs';
 
+import { AcbsHttpService } from './acbs-http.service';
 import { AcbsPartyExternalRatingsResponseDto } from './dto/acbs-party-external-ratings-response.dto';
-import { wrapAcbsHttpError } from './wrap-acbs-http-error';
+import { createWrapAcbsHttpErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
 export class AcbsPartyExternalRatingService {
+  private readonly acbsHttpService: AcbsHttpService;
+
   constructor(
     @Inject(AcbsConfig.KEY)
-    private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
-    private readonly httpService: HttpService,
-  ) {}
+    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    httpService: HttpService,
+  ) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
 
-  async getExternalRatingsForParty(partyIdentifier: string, authToken: string): Promise<AcbsPartyExternalRatingsResponseDto> {
-    const { data: externalRatingsInAcbs } = await lastValueFrom(
-      this.httpService
-        .get<AcbsPartyExternalRatingsResponseDto>(`/Party/${partyIdentifier}/PartyExternalRating`, {
-          baseURL: this.config.baseUrl,
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        })
-        .pipe(
-          wrapAcbsHttpError({
-            resourceIdentifier: partyIdentifier,
-            messageForUnknownException: `Failed to get the external ratings for the party with id ${partyIdentifier}.`,
-          }),
-        ),
-    );
+  async getExternalRatingsForParty(partyIdentifier: string, idToken: string): Promise<AcbsPartyExternalRatingsResponseDto> {
+    const { data: externalRatingsInAcbs } = await this.acbsHttpService.get<AcbsPartyExternalRatingsResponseDto>({
+      path: `/Party/${partyIdentifier}/PartyExternalRating`,
+      idToken,
+      onError: createWrapAcbsHttpErrorCallback({
+        resourceIdentifier: partyIdentifier,
+        messageForUnknownException: `Failed to get the external ratings for the party with id ${partyIdentifier}.`,
+      }),
+    });
 
     return externalRatingsInAcbs;
   }

--- a/src/modules/acbs/acbs-party.service.ts
+++ b/src/modules/acbs/acbs-party.service.ts
@@ -2,29 +2,32 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
-import { lastValueFrom } from 'rxjs';
 
+import { AcbsHttpService } from './acbs-http.service';
 import { AcbsGetPartyResponseDto } from './dto/acbs-get-party-response.dto';
-import { wrapAcbsHttpError } from './wrap-acbs-http-error';
+import { createWrapAcbsHttpErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
 export class AcbsPartyService {
-  constructor(@Inject(AcbsConfig.KEY) private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, private readonly httpService: HttpService) {}
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(
+    @Inject(AcbsConfig.KEY)
+    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    httpService: HttpService,
+  ) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
 
   async getPartyByIdentifier(partyIdentifier: string, idToken: string): Promise<AcbsGetPartyResponseDto> {
-    const { data: party } = await lastValueFrom(
-      this.httpService
-        .get<AcbsGetPartyResponseDto>(`/Party/${partyIdentifier}`, {
-          baseURL: this.config.baseUrl,
-          headers: { Authorization: `Bearer ${idToken}` },
-        })
-        .pipe(
-          wrapAcbsHttpError({
-            resourceIdentifier: partyIdentifier,
-            messageForUnknownException: `Failed to get the party with identifier ${partyIdentifier}.`,
-          }),
-        ),
-    );
+    const { data: party } = await this.acbsHttpService.get<AcbsGetPartyResponseDto>({
+      path: `/Party/${partyIdentifier}`,
+      idToken,
+      onError: createWrapAcbsHttpErrorCallback({
+        resourceIdentifier: partyIdentifier,
+        messageForUnknownException: `Failed to get the party with identifier ${partyIdentifier}.`,
+      }),
+    });
     return party;
   }
 }

--- a/src/modules/acbs/wrap-acbs-http-error-callback.ts
+++ b/src/modules/acbs/wrap-acbs-http-error-callback.ts
@@ -1,35 +1,25 @@
 import { AxiosError } from 'axios';
-import { catchError, ObservableInput, ObservedValueOf, OperatorFunction } from 'rxjs';
 
 import { AcbsException } from './exception/acbs.exception';
 import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
 import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
 import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
 
-export function wrapAcbsHttpError<T, O extends ObservableInput<any>>({
-  resourceIdentifier,
-  messageForUnknownException,
-}: {
-  resourceIdentifier: string;
-  messageForUnknownException: string;
-}): OperatorFunction<T, T | ObservedValueOf<O>> {
-  return catchError((error: Error) => {
+type AcbsHttpErrorCallback = (error: Error) => never;
+
+export const createWrapAcbsHttpErrorCallback =
+  ({ resourceIdentifier, messageForUnknownException }: { resourceIdentifier: string; messageForUnknownException: string }): AcbsHttpErrorCallback =>
+  (error: Error) => {
     if (error instanceof AxiosError && error.response && typeof error.response.data === 'string' && error.response.data.includes('Party not found')) {
       throw new AcbsResourceNotFoundException(`Party with identifier ${resourceIdentifier} was not found by ACBS.`, error);
     }
 
     throw new AcbsException(messageForUnknownException, error);
-  });
-}
+  };
 
-export function wrapAcbsHttpPostError<T, O extends ObservableInput<any>>({
-  resourceIdentifier,
-  messageForUnknownException,
-}: {
-  resourceIdentifier: string;
-  messageForUnknownException: string;
-}): OperatorFunction<T, T | ObservedValueOf<O>> {
-  return catchError((error: Error) => {
+export const createWrapAcbsHttpPostErrorCallback =
+  ({ resourceIdentifier, messageForUnknownException }: { resourceIdentifier: string; messageForUnknownException: string }): AcbsHttpErrorCallback =>
+  (error: Error) => {
     if (!(error instanceof AxiosError) || !error.response || error.response.status !== 400) {
       throw new AcbsUnexpectedException(messageForUnknownException, error);
     }
@@ -49,5 +39,4 @@ export function wrapAcbsHttpPostError<T, O extends ObservableInput<any>>({
       error,
       typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data),
     );
-  });
-}
+  };


### PR DESCRIPTION
## Introduction

We have multiple usages of HttpService that have duplicated code that can be commonised.

## Resolution

I've created an `AcbsHttpService` that wraps `HttpService` to provide the commonised code.

I didn't need to create any additional unit tests for `AcbsHttpService` as it is tested by the unit tests for the services that use it

The services that use this class still inject `AcbsConfig` and `HttpService` in their constructors, but they create an `AcbsHttpService` from this which they use in their methods.

We could inject `AcbsHttpService` instead of `AcbsConfig` and `HttpService` - I haven't done that in this PR but it might be worth doing in the future.