### PR TITLE
feat(APIM-74): add acbs service to create deals

### DIFF
--- a/src/modules/acbs/acbs-deal-guarantee.service.test.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.test.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { PROPERTIES } from '@ukef/constants';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { generateAcbsCreateDealGuaranteeDtoUsing } from '@ukef-test/support/requests/acbs-create-deal-guarantee-dto';
 import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
@@ -32,37 +33,7 @@ describe('AcbsDealGuaranteeService', () => {
   });
 
   describe('createGuaranteeForDeal', () => {
-    const lenderTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
-    const sectionIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 2 });
-    const limitTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 2 });
-    const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
-    const guarantorPartyIdentifier = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
-    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
-    const effectiveDate = valueGenerator.dateTimeString();
-    const expirationDate = valueGenerator.dateTimeString();
-    const guaranteedLimit = valueGenerator.nonnegativeFloat();
-    const guaranteedPercentage = valueGenerator.nonnegativeFloat({ max: 100 });
-
-    const newDealGuarantee = {
-      LenderType: {
-        LenderTypeCode: lenderTypeCode,
-      },
-      SectionIdentifier: sectionIdentifier,
-      LimitType: {
-        LimitTypeCode: limitTypeCode,
-      },
-      LimitKey: limitKey,
-      GuarantorParty: {
-        PartyIdentifier: guarantorPartyIdentifier,
-      },
-      GuaranteeType: {
-        GuaranteeTypeCode: guaranteeTypeCode,
-      },
-      EffectiveDate: effectiveDate,
-      ExpirationDate: expirationDate,
-      GuaranteedLimit: guaranteedLimit,
-      GuaranteedPercentage: guaranteedPercentage,
-    };
+    const newDealGuarantee = generateAcbsCreateDealGuaranteeDtoUsing(valueGenerator);
 
     it('sends a POST to ACBS with the specified parameters', async () => {
       when(httpServicePost)

--- a/src/modules/acbs/acbs-deal-guarantee.service.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.ts
@@ -6,6 +6,7 @@ import { PROPERTIES } from '@ukef/constants';
 
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateDealGuaranteeDto } from './dto/acbs-create-deal-guarantee.dto';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
 import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
@@ -27,8 +28,15 @@ export class AcbsDealGuaranteeService {
       requestBody: newDealGuarantee,
       idToken,
       onError: createWrapAcbsHttpPostErrorCallback({
-        resourceIdentifier: dealIdentifier,
-        messageForUnknownException: `Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`,
+        messageForUnknownError: `Failed to create a guarantee for deal ${dealIdentifier} in ACBS.`,
+        knownErrors: [
+          {
+            substringToFind: 'The deal not found',
+            throwError: (error) => {
+              throw new AcbsResourceNotFoundException(`Deal with identifier ${dealIdentifier} was not found by ACBS.`, error);
+            },
+          },
+        ],
       }),
     });
   }

--- a/src/modules/acbs/acbs-deal.service.test.ts
+++ b/src/modules/acbs/acbs-deal.service.test.ts
@@ -1,0 +1,108 @@
+import { HttpService } from '@nestjs/axios';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { generateAcbsCreateDealDtoUsing } from '@ukef-test/support/requests/acbs-create-deal-dto';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsDealService } from './acbs-deal.service';
+import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
+import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
+
+describe('AcbsDealService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const randomPortfolioIdentifier = valueGenerator.string({ length: 2 });
+  const dealIdentifier = valueGenerator.stringOfNumericCharacters({ length: 10 });
+
+  let httpService: HttpService;
+  let service: AcbsDealService;
+
+  let httpServicePost: jest.Mock;
+
+  const newDeal = generateAcbsCreateDealDtoUsing(valueGenerator, { dealIdentifier });
+  const expectedHttpServicePostArgs = [
+    `/Portfolio/${randomPortfolioIdentifier}/Deal`,
+    newDeal,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    },
+  ];
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServicePost = jest.fn();
+    httpService.post = httpServicePost;
+
+    service = new AcbsDealService({ baseUrl }, httpService);
+  });
+
+  describe('createDeal', () => {
+    it('sends a POST to ACBS with the specified parameters', async () => {
+      when(httpServicePost)
+        .calledWith(...expectedHttpServicePostArgs)
+        .mockReturnValueOnce(
+          of({
+            data: '',
+            status: 201,
+            statusText: 'Created',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      await service.createDeal(randomPortfolioIdentifier, newDeal, idToken);
+
+      expect(httpServicePost).toHaveBeenCalledTimes(1);
+      expect(httpServicePost).toHaveBeenCalledWith(...expectedHttpServicePostArgs);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 error', async () => {
+      const axiosError = new AxiosError();
+      const errorString = valueGenerator.string();
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(...expectedHttpServicePostArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createDealPromise = service.createDeal(randomPortfolioIdentifier, newDeal, idToken);
+
+      await expect(createDealPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(createDealPromise).rejects.toThrow(`Failed to create a deal with identifier ${dealIdentifier} in ACBS.`);
+      await expect(createDealPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(createDealPromise).rejects.toHaveProperty('errorBody', errorString);
+    });
+
+    it('throws an AcbsUnexpectedException if ACBS responds with an error code that is not 400', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePost)
+        .calledWith(...expectedHttpServicePostArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const createDealPromise = service.createDeal(randomPortfolioIdentifier, newDeal, idToken);
+
+      await expect(createDealPromise).rejects.toBeInstanceOf(AcbsUnexpectedException);
+      await expect(createDealPromise).rejects.toThrow(`Failed to create a deal with identifier ${dealIdentifier} in ACBS.`);
+      await expect(createDealPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-deal.service.ts
+++ b/src/modules/acbs/acbs-deal.service.ts
@@ -25,8 +25,8 @@ export class AcbsDealService {
       requestBody: newDeal,
       idToken,
       onError: createWrapAcbsHttpPostErrorCallback({
-        resourceIdentifier: undefined,
-        messageForUnknownException: `Failed to create a deal with identifier ${newDeal.DealIdentifier} in ACBS.`,
+        messageForUnknownError: `Failed to create a deal with identifier ${newDeal.DealIdentifier} in ACBS.`,
+        knownErrors: [],
       }),
     });
   }

--- a/src/modules/acbs/acbs-deal.service.ts
+++ b/src/modules/acbs/acbs-deal.service.ts
@@ -1,0 +1,33 @@
+import { HttpService } from '@nestjs/axios';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import AcbsConfig from '@ukef/config/acbs.config';
+
+import { AcbsHttpService } from './acbs-http.service';
+import { AcbsCreateDealDto } from './dto/acbs-create-deal.dto';
+import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-callback';
+
+@Injectable()
+export class AcbsDealService {
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(
+    @Inject(AcbsConfig.KEY)
+    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    httpService: HttpService,
+  ) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
+
+  async createDeal(portfolioIdentifier: string, newDeal: AcbsCreateDealDto, idToken: string): Promise<void> {
+    await this.acbsHttpService.post<AcbsCreateDealDto>({
+      path: `/Portfolio/${portfolioIdentifier}/Deal`,
+      requestBody: newDeal,
+      idToken,
+      onError: createWrapAcbsHttpPostErrorCallback({
+        resourceIdentifier: undefined,
+        messageForUnknownException: `Failed to create a deal with identifier ${newDeal.DealIdentifier} in ACBS.`,
+      }),
+    });
+  }
+}

--- a/src/modules/acbs/acbs-facility-party.service.test.ts
+++ b/src/modules/acbs/acbs-facility-party.service.test.ts
@@ -26,8 +26,8 @@ describe('AcbsFacilityPartyService', () => {
   const lenderTypeCode = valueGenerator.stringOfNumericCharacters();
   const currencyCode = TEST_CURRENCIES.A_TEST_CURRENCY;
   const limitAmount = valueGenerator.nonnegativeFloat();
-  const customerAdvisedIndicator = valueGenerator.bool();
-  const limitRevolvingIndicator = valueGenerator.bool();
+  const customerAdvisedIndicator = valueGenerator.boolean();
+  const limitRevolvingIndicator = valueGenerator.boolean();
 
   const newFacilityParty = {
     FacilityStatus: {

--- a/src/modules/acbs/acbs-facility-party.service.test.ts
+++ b/src/modules/acbs/acbs-facility-party.service.test.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { PROPERTIES } from '@ukef/constants';
-import { TEST_CURRENCIES } from '@ukef-test/support/constants/test-currency.constant';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { generateAcbsCreateFacilityPartyDtoUsing } from '@ukef-test/support/requests/acbs-create-facility-party-dto';
 import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
@@ -18,37 +18,7 @@ describe('AcbsFacilityPartyService', () => {
   const facilityIdentifier = valueGenerator.stringOfNumericCharacters();
   const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
 
-  const sectionIdentifier = valueGenerator.stringOfNumericCharacters({ minLength: 1, maxLength: 2 });
-  const facilityStatusCode = valueGenerator.character();
-  const involvedPartyIdentifier = valueGenerator.stringOfNumericCharacters();
-  const effectiveDate = valueGenerator.dateTimeString();
-  const expirationDate = valueGenerator.dateTimeString();
-  const lenderTypeCode = valueGenerator.stringOfNumericCharacters();
-  const currencyCode = TEST_CURRENCIES.A_TEST_CURRENCY;
-  const limitAmount = valueGenerator.nonnegativeFloat();
-  const customerAdvisedIndicator = valueGenerator.boolean();
-  const limitRevolvingIndicator = valueGenerator.boolean();
-
-  const newFacilityParty = {
-    FacilityStatus: {
-      FacilityStatusCode: facilityStatusCode,
-    },
-    InvolvedParty: {
-      PartyIdentifier: involvedPartyIdentifier,
-    },
-    EffectiveDate: effectiveDate,
-    ExpirationDate: expirationDate,
-    LenderType: {
-      LenderTypeCode: lenderTypeCode,
-    },
-    SectionIdentifier: sectionIdentifier,
-    Currency: {
-      CurrencyCode: currencyCode,
-    },
-    LimitAmount: limitAmount,
-    CustomerAdvisedIndicator: customerAdvisedIndicator,
-    LimitRevolvingIndicator: limitRevolvingIndicator,
-  };
+  const newFacilityParty = generateAcbsCreateFacilityPartyDtoUsing(valueGenerator);
 
   let httpService: HttpService;
   let service: AcbsFacilityPartyService;

--- a/src/modules/acbs/acbs-facility-party.service.ts
+++ b/src/modules/acbs/acbs-facility-party.service.ts
@@ -6,6 +6,7 @@ import { PROPERTIES } from '@ukef/constants';
 
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateFacilityPartyDto } from './dto/acbs-create-facility-party.dto';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
 import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-callback';
 
 @Injectable()
@@ -23,8 +24,15 @@ export class AcbsFacilityPartyService {
       requestBody: newFacilityParty,
       idToken,
       onError: createWrapAcbsHttpPostErrorCallback({
-        resourceIdentifier: facilityIdentifier,
-        messageForUnknownException: `Failed to create a party for facility ${facilityIdentifier} in ACBS.`,
+        messageForUnknownError: `Failed to create a party for facility ${facilityIdentifier} in ACBS.`,
+        knownErrors: [
+          {
+            substringToFind: 'The facility not found',
+            throwError: (error) => {
+              throw new AcbsResourceNotFoundException(`Facility with identifier ${facilityIdentifier} was not found by ACBS.`, error);
+            },
+          },
+        ],
       }),
     });
   }

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { TestController } from './acbs.controller';
 import { AcbsAuthenticationService } from './acbs-authentication.service';
+import { AcbsDealService } from './acbs-deal.service';
 import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
 import { AcbsDealPartyService } from './acbs-deal-party.service';
 import { AcbsFacilityPartyService } from './acbs-facility-party.service';
@@ -26,6 +27,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsAuthenticationService,
     AcbsPartyService,
     AcbsPartyExternalRatingService,
+    AcbsDealService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
     AcbsFacilityPartyService,
@@ -34,6 +36,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsAuthenticationService,
     AcbsPartyService,
     AcbsPartyExternalRatingService,
+    AcbsDealService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
     AcbsFacilityPartyService,

--- a/src/modules/acbs/dto/acbs-create-deal.dto.ts
+++ b/src/modules/acbs/dto/acbs-create-deal.dto.ts
@@ -1,0 +1,145 @@
+import { DateString } from '@ukef/helpers/date-string.type';
+
+export interface AcbsCreateDealDto {
+  DealIdentifier: string;
+  DealOrigination: {
+    DealOriginationCode: string;
+  };
+  IsDealSyndicationIndicator: boolean;
+  DealInitialStatus: {
+    DealInitialStatusCode: string;
+  };
+  DealOverallStatus: {
+    DealStatusCode: string;
+  };
+  DealType: {
+    DealTypeCode: string;
+  };
+  DealReviewFrequencyType: {
+    DealReviewFrequencyTypeCode: string;
+  };
+  PreviousDealPortfolioIdentifier: string;
+  DealLegallyBindingIndicator: boolean;
+  DealUserDefinedList5: {
+    DealUserDefinedList5Code: string;
+  };
+  DealDefaultPaymentInstruction: null;
+  DealExternalReferences: never[];
+  PortfolioIdentifier: string;
+  Description: string;
+  Currency: {
+    CurrencyCode: string;
+    IsActiveIndicator: boolean;
+  };
+  OriginalEffectiveDate: DateString;
+  BookingDate: DateString | null;
+  FinalAvailableDate: DateString | null;
+  IsFinalAvailableDateMaximum: boolean;
+  ExpirationDate: DateString | null;
+  IsExpirationDateMaximum: boolean;
+  LimitAmount: number;
+  WithheldAmount: number;
+  MemoLimitAmount: number;
+  BookingClass: {
+    BookingClassCode: string;
+  };
+  TargetClosingDate: DateString;
+  MemoUsedAmount: number;
+  MemoAvailableAmount: number;
+  MemoWithheldAmount: number;
+  OriginalApprovalDate: DateString;
+  CurrentOfficer: {
+    LineOfficerIdentifier: string;
+  };
+  SecondaryOfficer: {
+    LineOfficerIdentifier: string;
+  };
+  GeneralLedgerUnit: {
+    GeneralLedgerUnitIdentifier: string;
+  };
+  ServicingUnit: {
+    ServicingUnitIdentifier: string;
+  };
+  ServicingUnitSection: {
+    ServicingUnitSectionIdentifier: string;
+  };
+  AgentBankPartyIdentifier: string;
+  IndustryClassification: {
+    IndustryClassificationCode: string;
+  };
+  RiskCountry: {
+    CountryCode: string;
+  };
+  PurposeType: {
+    PurposeTypeCode: string;
+  };
+  CapitalClass: {
+    CapitalClassCode: string;
+  };
+  CapitalConversionFactor: {
+    CapitalConversionFactorCode: string;
+  };
+  FinancialFXRate: number;
+  FinancialFXRateOperand: string;
+  FinancialRateFXRateGroup: string;
+  FinancialFrequencyCode: string;
+  FinancialBusinessDayAdjustment: string;
+  FinancialDueMonthEndIndicator: boolean;
+  FinancialCalendar: {
+    CalendarIdentifier: string;
+  };
+  FinancialLockMTMRateIndicator: boolean;
+  FinancialNextValuationDate: DateString;
+  CustomerFXRateGroup: string;
+  CustomerFrequencyCode: string;
+  CustomerBusinessDayAdjustment: string;
+  CustomerDueMonthEndIndicator: boolean;
+  CustomerCalendar: {
+    CalendarIdentifier: string;
+  };
+  CustomerLockMTMRateIndicator: boolean;
+  CustomerNextValuationDate: DateString;
+  LimitRevolvingIndicator: boolean;
+  ServicingUser: {
+    UserAcbsIdentifier: string;
+    UserName: string;
+  };
+  AdministrativeUser: {
+    UserAcbsIdentifier: string;
+    UserName: string;
+  };
+  CreditReviewRiskType: {
+    CreditReviewRiskTypeCode: string;
+  };
+  NextReviewDate: DateString;
+  IsNextReviewDateZero: boolean;
+  OfficerRiskRatingType: {
+    OfficerRiskRatingTypeCode: string;
+  };
+  OfficerRiskDate: DateString;
+  IsOfficerRiskDateZero: boolean;
+  IsCreditReviewRiskDateZero: boolean;
+  RegulatorRiskDate: DateString | null;
+  IsRegulatorRiskDateZero: boolean;
+  MultiCurrencyArrangementIndicator: boolean;
+  IsUserDefinedDate1Zero: boolean;
+  IsUserDefinedDate2Zero: boolean;
+  IsUserDefinedDate3Zero: boolean;
+  IsUserDefinedDate4Zero: boolean;
+  SharedNationalCredit: string;
+  DefaultReason: {
+    DefaultReasonCode: string;
+  };
+  AccountStructure: {
+    AccountStructureCode: string;
+  };
+  LenderType: {
+    LenderTypeCode: string;
+  };
+  BorrowerParty: {
+    PartyIdentifier: string;
+  };
+  RiskMitigation: {
+    RiskMitigationCode: string;
+  };
+}

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -34,9 +34,9 @@ export class RandomValueGenerator {
   }
 
   stringOfNumericCharacters(options?: { length?: number; minLength?: number; maxLength?: number }): string {
-    const minLength = options && options.minLength ? options.minLength : 0;
-    const maxLength = options && options.maxLength ? options.maxLength : Math.max(20, minLength * 2);
-    const length = options && options.length ? options.length : this.chance.integer({ min: minLength, max: maxLength });
+    const minLength = options && (options.minLength || options.minLength === 0) ? options.minLength : 0;
+    const maxLength = options && (options.maxLength || options.maxLength === 0) ? options.maxLength : Math.max(20, minLength * 2);
+    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: minLength, max: maxLength });
 
     return this.chance.string({ length, pool: '0123456789' });
   }

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -18,11 +18,20 @@ export class RandomValueGenerator {
   }
 
   string(options?: { length?: number; minLength?: number; maxLength?: number }): string {
-    const minLength = options && options.minLength ? options.minLength : 0;
-    const maxLength = options && options.maxLength ? options.maxLength : Math.max(20, minLength * 2);
-    const length = options && options.length ? options.length : this.chance.integer({ min: minLength, max: maxLength });
-
+    const length = this.getStringLengthFromOptions(options);
     return this.chance.string({ length });
+  }
+
+  stringOfNumericCharacters(options?: { length?: number; minLength?: number; maxLength?: number }): string {
+    const length = this.getStringLengthFromOptions(options);
+    return this.chance.string({ length, pool: '0123456789' });
+  }
+
+  private getStringLengthFromOptions(options?: { length?: number; minLength?: number; maxLength?: number }): number {
+    const minLength = options && (options.minLength || options.minLength === 0) ? options.minLength : 0;
+    const maxLength = options && (options.maxLength || options.maxLength === 0) ? options.maxLength : Math.max(20, minLength * 2);
+    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: minLength, max: maxLength });
+    return length;
   }
 
   word(options?: { length?: number }): string {
@@ -31,14 +40,6 @@ export class RandomValueGenerator {
 
   httpsUrl(): string {
     return this.chance.url({ protocol: 'https' });
-  }
-
-  stringOfNumericCharacters(options?: { length?: number; minLength?: number; maxLength?: number }): string {
-    const minLength = options && (options.minLength || options.minLength === 0) ? options.minLength : 0;
-    const maxLength = options && (options.maxLength || options.maxLength === 0) ? options.maxLength : Math.max(20, minLength * 2);
-    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: minLength, max: maxLength });
-
-    return this.chance.string({ length, pool: '0123456789' });
   }
 
   character(): string {
@@ -75,9 +76,5 @@ export class RandomValueGenerator {
 
   dateOnlyString(): DateOnlyString {
     return this.dateStringTransformations.removeTime(this.dateTimeString());
-  }
-
-  bool(): boolean {
-    return this.chance.bool();
   }
 }

--- a/test/support/requests/acbs-create-deal-dto.ts
+++ b/test/support/requests/acbs-create-deal-dto.ts
@@ -1,0 +1,147 @@
+import { AcbsCreateDealDto } from '@ukef/modules/acbs/dto/acbs-create-deal.dto';
+
+import { RandomValueGenerator } from '../generator/random-value-generator';
+
+export const generateAcbsCreateDealDtoUsing = (valueGenerator: RandomValueGenerator, { dealIdentifier }: { dealIdentifier: string }): AcbsCreateDealDto => ({
+  DealIdentifier: dealIdentifier,
+  DealOrigination: {
+    DealOriginationCode: valueGenerator.string(),
+  },
+  IsDealSyndicationIndicator: valueGenerator.boolean(),
+  DealInitialStatus: {
+    DealInitialStatusCode: valueGenerator.string(),
+  },
+  DealOverallStatus: {
+    DealStatusCode: valueGenerator.string(),
+  },
+  DealType: {
+    DealTypeCode: valueGenerator.string(),
+  },
+  DealReviewFrequencyType: {
+    DealReviewFrequencyTypeCode: valueGenerator.string(),
+  },
+  PreviousDealPortfolioIdentifier: valueGenerator.string(),
+  DealLegallyBindingIndicator: valueGenerator.boolean(),
+  DealUserDefinedList5: {
+    DealUserDefinedList5Code: valueGenerator.string(),
+  },
+  DealDefaultPaymentInstruction: null,
+  DealExternalReferences: [],
+  PortfolioIdentifier: valueGenerator.string(),
+  Description: valueGenerator.string(),
+  Currency: {
+    CurrencyCode: valueGenerator.string(),
+    IsActiveIndicator: valueGenerator.boolean(),
+  },
+  OriginalEffectiveDate: valueGenerator.string(),
+  BookingDate: valueGenerator.string(),
+  FinalAvailableDate: valueGenerator.string(),
+  IsFinalAvailableDateMaximum: valueGenerator.boolean(),
+  ExpirationDate: valueGenerator.string(),
+  IsExpirationDateMaximum: valueGenerator.boolean(),
+  LimitAmount: valueGenerator.nonnegativeFloat(),
+  WithheldAmount: valueGenerator.nonnegativeFloat(),
+  MemoLimitAmount: valueGenerator.nonnegativeFloat(),
+  BookingClass: {
+    BookingClassCode: valueGenerator.string(),
+  },
+  TargetClosingDate: valueGenerator.string(),
+  MemoUsedAmount: valueGenerator.nonnegativeFloat(),
+  MemoAvailableAmount: valueGenerator.nonnegativeFloat(),
+  MemoWithheldAmount: valueGenerator.nonnegativeFloat(),
+  OriginalApprovalDate: valueGenerator.string(),
+  CurrentOfficer: {
+    LineOfficerIdentifier: valueGenerator.string(),
+  },
+  SecondaryOfficer: {
+    LineOfficerIdentifier: valueGenerator.string(),
+  },
+  GeneralLedgerUnit: {
+    GeneralLedgerUnitIdentifier: valueGenerator.string(),
+  },
+  ServicingUnit: {
+    ServicingUnitIdentifier: valueGenerator.string(),
+  },
+  ServicingUnitSection: {
+    ServicingUnitSectionIdentifier: valueGenerator.string(),
+  },
+  AgentBankPartyIdentifier: valueGenerator.string(),
+  IndustryClassification: {
+    IndustryClassificationCode: valueGenerator.string(),
+  },
+  RiskCountry: {
+    CountryCode: valueGenerator.string(),
+  },
+  PurposeType: {
+    PurposeTypeCode: valueGenerator.string(),
+  },
+  CapitalClass: {
+    CapitalClassCode: valueGenerator.string(),
+  },
+  CapitalConversionFactor: {
+    CapitalConversionFactorCode: valueGenerator.string(),
+  },
+  FinancialFXRate: valueGenerator.nonnegativeFloat(),
+  FinancialFXRateOperand: valueGenerator.string(),
+  FinancialRateFXRateGroup: valueGenerator.string(),
+  FinancialFrequencyCode: valueGenerator.string(),
+  FinancialBusinessDayAdjustment: valueGenerator.string(),
+  FinancialDueMonthEndIndicator: valueGenerator.boolean(),
+  FinancialCalendar: {
+    CalendarIdentifier: valueGenerator.string(),
+  },
+  FinancialLockMTMRateIndicator: valueGenerator.boolean(),
+  FinancialNextValuationDate: valueGenerator.string(),
+  CustomerFXRateGroup: valueGenerator.string(),
+  CustomerFrequencyCode: valueGenerator.string(),
+  CustomerBusinessDayAdjustment: valueGenerator.string(),
+  CustomerDueMonthEndIndicator: valueGenerator.boolean(),
+  CustomerCalendar: {
+    CalendarIdentifier: valueGenerator.string(),
+  },
+  CustomerLockMTMRateIndicator: valueGenerator.boolean(),
+  CustomerNextValuationDate: valueGenerator.string(),
+  LimitRevolvingIndicator: valueGenerator.boolean(),
+  ServicingUser: {
+    UserAcbsIdentifier: valueGenerator.string(),
+    UserName: valueGenerator.string(),
+  },
+  AdministrativeUser: {
+    UserAcbsIdentifier: valueGenerator.string(),
+    UserName: valueGenerator.string(),
+  },
+  CreditReviewRiskType: {
+    CreditReviewRiskTypeCode: valueGenerator.string(),
+  },
+  NextReviewDate: valueGenerator.string(),
+  IsNextReviewDateZero: valueGenerator.boolean(),
+  OfficerRiskRatingType: {
+    OfficerRiskRatingTypeCode: valueGenerator.string(),
+  },
+  OfficerRiskDate: valueGenerator.string(),
+  IsOfficerRiskDateZero: valueGenerator.boolean(),
+  IsCreditReviewRiskDateZero: valueGenerator.boolean(),
+  RegulatorRiskDate: valueGenerator.string(),
+  IsRegulatorRiskDateZero: valueGenerator.boolean(),
+  MultiCurrencyArrangementIndicator: valueGenerator.boolean(),
+  IsUserDefinedDate1Zero: valueGenerator.boolean(),
+  IsUserDefinedDate2Zero: valueGenerator.boolean(),
+  IsUserDefinedDate3Zero: valueGenerator.boolean(),
+  IsUserDefinedDate4Zero: valueGenerator.boolean(),
+  SharedNationalCredit: valueGenerator.string(),
+  DefaultReason: {
+    DefaultReasonCode: valueGenerator.string(),
+  },
+  AccountStructure: {
+    AccountStructureCode: valueGenerator.string(),
+  },
+  LenderType: {
+    LenderTypeCode: valueGenerator.string(),
+  },
+  BorrowerParty: {
+    PartyIdentifier: valueGenerator.string(),
+  },
+  RiskMitigation: {
+    RiskMitigationCode: valueGenerator.string(),
+  },
+});

--- a/test/support/requests/acbs-create-deal-guarantee-dto.ts
+++ b/test/support/requests/acbs-create-deal-guarantee-dto.ts
@@ -1,0 +1,22 @@
+import { RandomValueGenerator } from '../generator/random-value-generator';
+
+export const generateAcbsCreateDealGuaranteeDtoUsing = (valueGenerator: RandomValueGenerator) => ({
+  LenderType: {
+    LenderTypeCode: valueGenerator.stringOfNumericCharacters({ maxLength: 3 }),
+  },
+  SectionIdentifier: valueGenerator.stringOfNumericCharacters({ maxLength: 2 }),
+  LimitType: {
+    LimitTypeCode: valueGenerator.stringOfNumericCharacters({ maxLength: 2 }),
+  },
+  LimitKey: valueGenerator.stringOfNumericCharacters({ maxLength: 8 }),
+  GuarantorParty: {
+    PartyIdentifier: valueGenerator.stringOfNumericCharacters({ maxLength: 8 }),
+  },
+  GuaranteeType: {
+    GuaranteeTypeCode: valueGenerator.stringOfNumericCharacters({ maxLength: 3 }),
+  },
+  EffectiveDate: valueGenerator.dateTimeString(),
+  ExpirationDate: valueGenerator.dateTimeString(),
+  GuaranteedLimit: valueGenerator.nonnegativeFloat(),
+  GuaranteedPercentage: valueGenerator.nonnegativeFloat({ max: 100 }),
+});

--- a/test/support/requests/acbs-create-facility-party-dto.ts
+++ b/test/support/requests/acbs-create-facility-party-dto.ts
@@ -1,0 +1,25 @@
+import { AcbsCreateFacilityPartyDto } from '@ukef/modules/acbs/dto/acbs-create-facility-party.dto';
+
+import { TEST_CURRENCIES } from '../constants/test-currency.constant';
+import { RandomValueGenerator } from '../generator/random-value-generator';
+
+export const generateAcbsCreateFacilityPartyDtoUsing = (valueGenerator: RandomValueGenerator): AcbsCreateFacilityPartyDto => ({
+  FacilityStatus: {
+    FacilityStatusCode: valueGenerator.character(),
+  },
+  InvolvedParty: {
+    PartyIdentifier: valueGenerator.stringOfNumericCharacters(),
+  },
+  EffectiveDate: valueGenerator.dateTimeString(),
+  ExpirationDate: valueGenerator.dateTimeString(),
+  LenderType: {
+    LenderTypeCode: valueGenerator.stringOfNumericCharacters(),
+  },
+  SectionIdentifier: valueGenerator.stringOfNumericCharacters({ minLength: 1, maxLength: 2 }),
+  Currency: {
+    CurrencyCode: TEST_CURRENCIES.A_TEST_CURRENCY,
+  },
+  LimitAmount: valueGenerator.nonnegativeFloat(),
+  CustomerAdvisedIndicator: valueGenerator.boolean(),
+  LimitRevolvingIndicator: valueGenerator.boolean(),
+});


### PR DESCRIPTION
## Introduction

As part of APIM-74 (migrating the `POST /deals` endpoint), we want to create an ACBS service that can create deals in ACBS.
Note that this is only part of APIM-74, a later PR will complete the ticket.

## Resolution

I've created an AcbsDealService with unit tests. This will POST a request body to ACBS. If ACBS returns a 400 error then the service with throw an `AcbsBadRequestException`, if ACBS returns a non-400 error then the service will throw an `AcbsUnexpectedException`.

This is a bit different from the existing ACBS POST calls which can also throw an `AcbsResourceNotFoundException` if ACBS returns a 400 error with a known string message (like 'Deal not found'). To make that clear, I've refactored how we handle POST errors so that the code states specifically _which_ POST calls expect _which_ error messages.

## Misc

- I fixed a bug in the `RandomValueGenerator` where trying to passing the `length: 0` option when generating a `stringOfNumericCharacters` wouldn't work because 0 is falsey.
- I pulled out the randomly-valued ACBS requests from unit tests into the `test/support/requests` folder. Abhi suggested something similar to this in a previous PR and it seemed useful here because the request to create a deal takes up around 140 lines