### PR TITLE
feat(APIM-75): add endpoint to post a deal investor

### DIFF
--- a/src/constants/properties.constant.ts
+++ b/src/constants/properties.constant.ts
@@ -134,4 +134,23 @@ export const PROPERTIES = {
       limitRevolvingIndicator: true,
     },
   },
+  DEAL_INVESTOR: {
+    DEFAULT: {
+      sectionIdentifier: '00',
+      lenderType: {
+        lenderTypeCode: '500',
+      },
+      involvedParty: {
+        partyIdentifier: '00000000',
+      },
+      dealStatus: {
+        dealStatusCode: 'A',
+      },
+      customerAdvisedIndicator: true,
+      userDefinedCode1: 'N',
+      limitRevolvingIndicator: true,
+      expirationDate: null,
+      contractPercentage: 100,
+    },
+  },
 };

--- a/src/decorators/validated-date-only-api-property.decorator.ts
+++ b/src/decorators/validated-date-only-api-property.decorator.ts
@@ -1,15 +1,32 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { DATE_FORMATS } from '@ukef/constants';
-import { IsISO8601, Matches } from 'class-validator';
+import { DateOnlyString } from '@ukef/helpers';
+import { IsISO8601, IsOptional, Matches } from 'class-validator';
 
-export const ValidatedDateOnlyApiProperty = ({ description }: { description: string }) =>
-  applyDecorators(
+interface Options {
+  description: string;
+  example?: DateOnlyString;
+  required?: boolean;
+  default?: DateOnlyString | null;
+}
+
+export const ValidatedDateOnlyApiProperty = ({ description, example, required, default: theDefault }: Options) => {
+  const decoratorsToApply = [
     ApiProperty({
       description,
       type: Date,
       format: 'date',
+      example,
+      default: theDefault,
     }),
     IsISO8601({ strict: true }),
     Matches(DATE_FORMATS.DATE_ONLY_STRING.regex),
-  );
+  ];
+
+  const isRequiredProperty = required ?? true;
+  if (!isRequiredProperty) {
+    decoratorsToApply.push(IsOptional());
+  }
+  return applyDecorators(...decoratorsToApply);
+};

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -1,25 +1,30 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, Length } from 'class-validator';
+import { IsOptional, Length, Matches } from 'class-validator';
 
 interface Options {
   description: string;
-  minLength: number;
-  maxLength: number;
-  example?: string;
+  length?: number;
+  minLength?: number;
+  maxLength?: number;
   required?: boolean;
+  pattern?: RegExp;
+  example?: string;
   default?: string;
 }
 
-export const ValidatedStringApiProperty = ({ description, minLength, maxLength, example, required, default: theDefault }: Options) => {
+export const ValidatedStringApiProperty = ({ description, length, minLength, maxLength, required, pattern, example, default: theDefault }: Options) => {
+  minLength = length ?? minLength;
+  maxLength = length ?? maxLength;
   const decoratorsToApply = [
     ApiProperty({
       type: 'string',
       description,
-      example,
       minLength,
       maxLength,
       required,
+      pattern: pattern && pattern.toString(),
+      example,
       default: theDefault,
     }),
     Length(minLength, maxLength),
@@ -28,6 +33,9 @@ export const ValidatedStringApiProperty = ({ description, minLength, maxLength, 
   const isRequiredProperty = required ?? true;
   if (!isRequiredProperty) {
     decoratorsToApply.push(IsOptional());
+  }
+  if (pattern) {
+    decoratorsToApply.push(Matches(pattern));
   }
   return applyDecorators(...decoratorsToApply);
 };

--- a/src/modules/acbs/dto/acbs-create-deal-investor-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-create-deal-investor-request.dto.ts
@@ -1,0 +1,24 @@
+import { DateString } from '@ukef/helpers';
+
+export interface AcbsCreateDealInvestorRequest {
+  SectionIdentifier: string;
+  EffectiveDate: DateString;
+  ExpirationDate: DateString | null;
+  IsExpirationDateMaximum: boolean;
+  LenderType: {
+    LenderTypeCode: string;
+  };
+  InvolvedParty: {
+    PartyIdentifier: string;
+  };
+  Currency: {
+    CurrencyCode: string;
+  };
+  CustomerAdvisedIndicator: boolean;
+  DealStatus: {
+    DealStatusCode: string;
+  };
+  UserDefinedCode1: string;
+  ContractPercentage: number;
+  LimitRevolvingIndicator: boolean;
+}

--- a/src/modules/date/date-string.transformations.ts
+++ b/src/modules/date/date-string.transformations.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { DATE_FORMATS } from '@ukef/constants';
-import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
+import { DateOnlyString } from '@ukef/helpers';
 import { DateString } from '@ukef/helpers/date-string.type';
 import { matches } from 'class-validator';
 

--- a/src/modules/deal-investor/deal-investor.controller.test.ts
+++ b/src/modules/deal-investor/deal-investor.controller.test.ts
@@ -1,25 +1,36 @@
-import { DealInvestorGenerator } from '@ukef-test/support/generator/deal-investor-generator';
+import { UkefId } from '@ukef/helpers';
+import { CreateDealInvestorGenerator } from '@ukef-test/support/generator/create-deal-investor-generator';
+import { GetDealInvestorGenerator } from '@ukef-test/support/generator/get-deal-investor-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
+import { CurrentDateProvider } from '../date/current-date.provider';
+import { DateStringTransformations } from '../date/date-string.transformations';
 import { DealInvestorController } from './deal-investor.controller';
 import { DealInvestorService } from './deal-investor.service';
+import { CreateDealInvestorResponse } from './dto/create-deal-investor-response.dto';
 
 jest.mock('./deal-investor.service');
 
 describe('DealInvestorController', () => {
   const valueGenerator = new RandomValueGenerator();
+  const currentDateProvider = new CurrentDateProvider();
+  const dateStringTransformations = new DateStringTransformations();
 
   let controller: DealInvestorController;
   let dealInvestorService: DealInvestorService;
 
   let dealInvestorServiceGetDealInvestors: jest.Mock;
+  let dealInvestorServiceCreateInvestorForDeal: jest.Mock;
 
   beforeEach(() => {
-    dealInvestorService = new DealInvestorService(null, null, null);
+    dealInvestorService = new DealInvestorService(null, null, null, null);
 
     dealInvestorServiceGetDealInvestors = jest.fn();
     dealInvestorService.getDealInvestors = dealInvestorServiceGetDealInvestors;
+
+    dealInvestorServiceCreateInvestorForDeal = jest.fn();
+    dealInvestorService.createInvestorForDeal = dealInvestorServiceCreateInvestorForDeal;
 
     controller = new DealInvestorController(dealInvestorService);
   });
@@ -28,7 +39,7 @@ describe('DealInvestorController', () => {
     const dealIdentifier = valueGenerator.ukefId();
     const portfolioIdentifier = valueGenerator.string();
 
-    const { dealInvestorsFromService } = new DealInvestorGenerator(valueGenerator).generate({
+    const { dealInvestorsFromService } = new GetDealInvestorGenerator(valueGenerator).generate({
       numberToGenerate: 2,
       dealIdentifier,
       portfolioIdentifier,
@@ -59,6 +70,41 @@ describe('DealInvestorController', () => {
       const dealInvestors = await controller.getDealInvestors({ dealIdentifier: dealIdentifier });
 
       expect(dealInvestors).toStrictEqual(expectedDealInvestorsWithNewKey);
+    });
+  });
+
+  describe('createInvestorForDeal', () => {
+    const dealIdentifier: UkefId = valueGenerator.ukefId();
+
+    const { requestBodyToCreateDealInvestor } = new CreateDealInvestorGenerator(valueGenerator, currentDateProvider, dateStringTransformations).generate({
+      numberToGenerate: 2,
+      dealIdentifier: dealIdentifier,
+    });
+
+    it('creates an investor for the deal with the service from the request body', async () => {
+      await controller.createInvestorForDeal(dealIdentifier, requestBodyToCreateDealInvestor);
+
+      expect(dealInvestorServiceCreateInvestorForDeal).toHaveBeenCalledWith(dealIdentifier, requestBodyToCreateDealInvestor[0]);
+    });
+
+    it('returns the deal identifier if creating the investor succeeds', async () => {
+      const response = await controller.createInvestorForDeal(dealIdentifier, requestBodyToCreateDealInvestor);
+
+      expect(response).toStrictEqual(new CreateDealInvestorResponse(dealIdentifier));
+    });
+
+    it('does NOT include unexpected keys from the request body', async () => {
+      const requestBodyToCreateDealInvestorPlusUnexpectedKeys = [
+        {
+          ...requestBodyToCreateDealInvestor[0],
+          unexpectedKey: 'unexpected value',
+        },
+        requestBodyToCreateDealInvestor[1],
+      ];
+
+      await controller.createInvestorForDeal(dealIdentifier, requestBodyToCreateDealInvestorPlusUnexpectedKeys);
+
+      expect(dealInvestorServiceCreateInvestorForDeal).toHaveBeenCalledWith(dealIdentifier, requestBodyToCreateDealInvestor[0]);
     });
   });
 });

--- a/src/modules/deal-investor/deal-investor.controller.ts
+++ b/src/modules/deal-investor/deal-investor.controller.ts
@@ -1,8 +1,19 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { Body, Controller, Get, Param, ParseArrayPipe, Post } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+} from '@nestjs/swagger';
 
 import { DealInvestorService } from './deal-investor.service';
-import { DealInvestorResponseDto } from './dto/deal-investor-response.dto';
+import { CreateDealInvestorRequest, CreateDealInvestorRequestItem } from './dto/create-deal-investor-request.dto';
+import { CreateDealInvestorResponse } from './dto/create-deal-investor-response.dto';
+import { GetDealInvestorResponseDto } from './dto/deal-investor-response.dto';
 import { GetDealsInvestorsParamsDto } from './dto/get-deals-investors-params.dto';
 
 @Controller()
@@ -15,7 +26,7 @@ export class DealInvestorController {
   })
   @ApiOkResponse({
     description: 'The deal investors have been successfully retrieved.',
-    type: DealInvestorResponseDto,
+    type: GetDealInvestorResponseDto,
     isArray: true,
   })
   @ApiNotFoundResponse({
@@ -24,7 +35,51 @@ export class DealInvestorController {
   @ApiInternalServerErrorResponse({
     description: 'An internal server error has occurred.',
   })
-  getDealInvestors(@Param() params: GetDealsInvestorsParamsDto): Promise<DealInvestorResponseDto[]> {
+  getDealInvestors(@Param() params: GetDealsInvestorsParamsDto): Promise<GetDealInvestorResponseDto[]> {
     return this.dealInvestorService.getDealInvestors(params.dealIdentifier);
+  }
+
+  @Post('deals/:dealIdentifier/investors')
+  @ApiOperation({
+    summary: 'Create a new investor for a deal.',
+  })
+  @ApiParam({
+    name: 'dealIdentifier',
+    required: true,
+    type: 'string',
+    description: 'The identifier of the deal in ACBS.',
+    example: '0020900111',
+  })
+  @ApiBody({
+    type: CreateDealInvestorRequestItem,
+    isArray: true,
+  })
+  @ApiCreatedResponse({
+    description: 'The investor has been successfully created.',
+  })
+  @ApiNotFoundResponse({
+    description: 'The deal was not found.',
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad request.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An internal server error has occurred.',
+  })
+  async createInvestorForDeal(
+    @Param('dealIdentifier') dealIdentifier: string,
+    @Body(new ParseArrayPipe({ items: CreateDealInvestorRequestItem })) newInvestorRequest: CreateDealInvestorRequest,
+  ): Promise<CreateDealInvestorResponse> {
+    const newInvestor = newInvestorRequest[0];
+    const investorToCreate: CreateDealInvestorRequestItem = {
+      dealIdentifier: newInvestor.dealIdentifier,
+      lenderType: newInvestor.lenderType,
+      effectiveDate: newInvestor.effectiveDate,
+      expiryDate: newInvestor.expiryDate,
+      dealStatus: newInvestor.dealStatus,
+      currency: newInvestor.currency,
+    };
+    await this.dealInvestorService.createInvestorForDeal(dealIdentifier, investorToCreate);
+    return new CreateDealInvestorResponse(dealIdentifier);
   }
 }

--- a/src/modules/deal-investor/deal-investor.service.create-investor.test.ts
+++ b/src/modules/deal-investor/deal-investor.service.create-investor.test.ts
@@ -1,0 +1,107 @@
+import { PROPERTIES } from '@ukef/constants';
+import { UkefId } from '@ukef/helpers';
+import { AcbsDealPartyService } from '@ukef/modules/acbs/acbs-deal-party.service';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { CreateDealInvestorGenerator } from '@ukef-test/support/generator/create-deal-investor-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { AcbsCreateDealInvestorRequest } from '../acbs/dto/acbs-create-deal-investor-request.dto';
+import { CurrentDateProvider } from '../date/current-date.provider';
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { DealInvestorService } from './deal-investor.service';
+
+jest.mock('@ukef/modules/acbs/acbs-deal-party.service');
+jest.mock('../acbs-authentication/acbs-authentication.service');
+
+describe('DealInvestorService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const currentDateProvider = new CurrentDateProvider();
+  const dateStringTransformations = new DateStringTransformations();
+  const idToken = valueGenerator.string();
+  const todayAsDateOnlyString = new Date().toISOString().split('T')[0];
+
+  let acbsDealPartyService: AcbsDealPartyService;
+  let service: DealInvestorService;
+
+  let acbsDealPartyServiceCreateInvestorForDeal: jest.Mock;
+
+  beforeEach(() => {
+    acbsDealPartyService = new AcbsDealPartyService(null, null);
+
+    acbsDealPartyServiceCreateInvestorForDeal = jest.fn();
+    acbsDealPartyService.createInvestorForDeal = acbsDealPartyServiceCreateInvestorForDeal;
+
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    const acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    service = new DealInvestorService(acbsAuthenticationService, acbsDealPartyService, currentDateProvider, dateStringTransformations);
+  });
+
+  describe('createInvestorForDeal', () => {
+    const dealIdentifier: UkefId = valueGenerator.ukefId();
+
+    const { acbsRequestBodyToCreateDealInvestor, requestBodyToCreateDealInvestor } = new CreateDealInvestorGenerator(
+      valueGenerator,
+      currentDateProvider,
+      dateStringTransformations,
+    ).generate({
+      numberToGenerate: 2,
+      dealIdentifier: dealIdentifier,
+    });
+
+    it('creates an investor in ACBS with a transformation of the requested new investor', async () => {
+      await service.createInvestorForDeal(dealIdentifier, requestBodyToCreateDealInvestor[0]);
+
+      expect(acbsDealPartyServiceCreateInvestorForDeal).toHaveBeenCalledWith(dealIdentifier, acbsRequestBodyToCreateDealInvestor, idToken);
+    });
+
+    it('adds a default value for lenderType before creating the new investor if it is not specified', async () => {
+      const { lenderType: _removed, ...newInvestorWithoutLenderType } = requestBodyToCreateDealInvestor[0];
+
+      await service.createInvestorForDeal(dealIdentifier, newInvestorWithoutLenderType);
+
+      const investorCreatedInAcbs: AcbsCreateDealInvestorRequest = acbsDealPartyServiceCreateInvestorForDeal.mock.calls[0][1];
+
+      expect(investorCreatedInAcbs.LenderType.LenderTypeCode).toBe(PROPERTIES.DEAL_INVESTOR.DEFAULT.lenderType.lenderTypeCode);
+    });
+
+    it('adds a default value for expiryDate before creating the new investor if it is not specified', async () => {
+      const { expiryDate: _removed, ...newInvestorWithoutExpiryDate } = requestBodyToCreateDealInvestor[0];
+
+      await service.createInvestorForDeal(dealIdentifier, newInvestorWithoutExpiryDate);
+
+      const investorCreatedInAcbs: AcbsCreateDealInvestorRequest = acbsDealPartyServiceCreateInvestorForDeal.mock.calls[0][1];
+
+      expect(investorCreatedInAcbs.ExpirationDate).toBe(PROPERTIES.DEAL_INVESTOR.DEFAULT.expirationDate);
+    });
+
+    it('adds a default value for dealStatus before creating the new investor if it is not specified', async () => {
+      const { dealStatus: _removed, ...newInvestorWithoutDealStatus } = requestBodyToCreateDealInvestor[0];
+
+      await service.createInvestorForDeal(dealIdentifier, newInvestorWithoutDealStatus);
+
+      const investorCreatedInAcbs: AcbsCreateDealInvestorRequest = acbsDealPartyServiceCreateInvestorForDeal.mock.calls[0][1];
+
+      expect(investorCreatedInAcbs.DealStatus.DealStatusCode).toBe(PROPERTIES.DEAL_INVESTOR.DEFAULT.dealStatus.dealStatusCode);
+    });
+
+    it(`replaces effectiveDate with today's date if effectiveDate is after today`, async () => {
+      await service.createInvestorForDeal(dealIdentifier, { ...requestBodyToCreateDealInvestor[0], effectiveDate: '9999-01-01' });
+
+      const investorCreatedInAcbs: AcbsCreateDealInvestorRequest = acbsDealPartyServiceCreateInvestorForDeal.mock.calls[0][1];
+
+      expect(investorCreatedInAcbs.EffectiveDate).toBe(todayAsDateOnlyString + 'T00:00:00Z');
+    });
+
+    it(`does NOT replace effectiveDate with today's date if effectiveDate is NOT after today`, async () => {
+      await service.createInvestorForDeal(dealIdentifier, { ...requestBodyToCreateDealInvestor[0], effectiveDate: '2023-03-30' });
+
+      const investorCreatedInAcbs: AcbsCreateDealInvestorRequest = acbsDealPartyServiceCreateInvestorForDeal.mock.calls[0][1];
+
+      expect(investorCreatedInAcbs.EffectiveDate).toBe('2023-03-30T00:00:00Z');
+    });
+  });
+});

--- a/src/modules/deal-investor/deal-investor.service.get-investors.test.ts
+++ b/src/modules/deal-investor/deal-investor.service.get-investors.test.ts
@@ -3,10 +3,11 @@ import { AcbsDealPartyService } from '@ukef/modules/acbs/acbs-deal-party.service
 import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
-import { DealInvestorGenerator } from '@ukef-test/support/generator/deal-investor-generator';
+import { GetDealInvestorGenerator } from '@ukef-test/support/generator/get-deal-investor-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
+import { CurrentDateProvider } from '../date/current-date.provider';
 import { DealInvestorService } from './deal-investor.service';
 
 jest.mock('@ukef/modules/acbs/acbs-deal-party.service');
@@ -34,15 +35,16 @@ describe('DealInvestorService', () => {
     const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
 
+    const currentDateProvider = new CurrentDateProvider();
     const dateStringTransformations = new DateStringTransformations();
 
-    service = new DealInvestorService(acbsAuthenticationService, acbsDealPartyService, dateStringTransformations);
+    service = new DealInvestorService(acbsAuthenticationService, acbsDealPartyService, currentDateProvider, dateStringTransformations);
   });
 
   describe('getDealInvestors', () => {
     const dealIdentifier = valueGenerator.ukefId();
 
-    const { dealInvestorsInAcbs, dealInvestorsFromService } = new DealInvestorGenerator(valueGenerator).generate({
+    const { dealInvestorsInAcbs, dealInvestorsFromService } = new GetDealInvestorGenerator(valueGenerator).generate({
       numberToGenerate: 2,
       dealIdentifier,
       portfolioIdentifier,

--- a/src/modules/deal-investor/deal-investor.service.ts
+++ b/src/modules/deal-investor/deal-investor.service.ts
@@ -6,13 +6,17 @@ import { AcbsResourceNotFoundException } from '@ukef/modules/acbs/exception/acbs
 import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 
+import { AcbsCreateDealInvestorRequest } from '../acbs/dto/acbs-create-deal-investor-request.dto';
+import { CurrentDateProvider } from '../date/current-date.provider';
 import { DealInvestor } from './deal-investor.interface';
+import { CreateDealInvestorRequestItem } from './dto/create-deal-investor-request.dto';
 
 @Injectable()
 export class DealInvestorService {
   constructor(
     private readonly acbsAuthenticationService: AcbsAuthenticationService,
     private readonly acbsDealPartyService: AcbsDealPartyService,
+    private readonly currentDateProvider: CurrentDateProvider,
     private readonly dateStringTransformations: DateStringTransformations,
   ) {}
 
@@ -32,5 +36,44 @@ export class DealInvestorService {
       isExpiryDateMaximum: investorInAcbs.IsExpirationDateMaximum,
       maximumLiability: investorInAcbs.LimitAmount,
     }));
+  }
+
+  async createInvestorForDeal(dealIdentifier: string, newInvestor: CreateDealInvestorRequestItem): Promise<void> {
+    const idToken = await this.acbsAuthenticationService.getIdToken();
+
+    const effectiveDateTime = this.currentDateProvider.getEarliestDateFromTodayAnd(
+      new Date(this.dateStringTransformations.addTimeToDateOnlyString(newInvestor.effectiveDate)),
+    );
+    const effectiveDateString = this.dateStringTransformations.getDateStringFromDate(effectiveDateTime);
+
+    const expiryDateOnlyString = newInvestor.expiryDate;
+    const expirationDateString = expiryDateOnlyString
+      ? this.dateStringTransformations.addTimeToDateOnlyString(expiryDateOnlyString)
+      : PROPERTIES.DEAL_INVESTOR.DEFAULT.expirationDate;
+
+    const investorToCreateInAcbs: AcbsCreateDealInvestorRequest = {
+      SectionIdentifier: PROPERTIES.DEAL_INVESTOR.DEFAULT.sectionIdentifier,
+      EffectiveDate: effectiveDateString,
+      ExpirationDate: expirationDateString,
+      IsExpirationDateMaximum: newInvestor.expiryDate ? false : true,
+      LenderType: {
+        LenderTypeCode: newInvestor.lenderType ?? PROPERTIES.DEAL_INVESTOR.DEFAULT.lenderType.lenderTypeCode,
+      },
+      InvolvedParty: {
+        PartyIdentifier: PROPERTIES.DEAL_INVESTOR.DEFAULT.involvedParty.partyIdentifier,
+      },
+      Currency: {
+        CurrencyCode: newInvestor.currency,
+      },
+      CustomerAdvisedIndicator: PROPERTIES.DEAL_INVESTOR.DEFAULT.customerAdvisedIndicator,
+      DealStatus: {
+        DealStatusCode: newInvestor.dealStatus ?? PROPERTIES.DEAL_INVESTOR.DEFAULT.dealStatus.dealStatusCode,
+      },
+      UserDefinedCode1: PROPERTIES.DEAL_INVESTOR.DEFAULT.userDefinedCode1,
+      ContractPercentage: PROPERTIES.DEAL_INVESTOR.DEFAULT.contractPercentage,
+      LimitRevolvingIndicator: PROPERTIES.DEAL_INVESTOR.DEFAULT.limitRevolvingIndicator,
+    };
+
+    await this.acbsDealPartyService.createInvestorForDeal(dealIdentifier, investorToCreateInAcbs, idToken);
   }
 }

--- a/src/modules/deal-investor/dto/create-deal-investor-request.dto.ts
+++ b/src/modules/deal-investor/dto/create-deal-investor-request.dto.ts
@@ -1,0 +1,56 @@
+import { ValidatedDateOnlyApiProperty } from '@ukef/decorators/validated-date-only-api-property.decorator';
+import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
+import { DateString, UkefId } from '@ukef/helpers';
+
+export type CreateDealInvestorRequest = CreateDealInvestorRequestItem[];
+
+export class CreateDealInvestorRequestItem {
+  @ValidatedStringApiProperty({
+    description: "'The identifier of the deal to create the investor for. It will be a 10-digit code beginning with either '0020', '0030', or '0040'.",
+    example: '0020900111',
+    length: 10,
+    pattern: /00\d{8}/,
+  })
+  readonly dealIdentifier: UkefId;
+
+  @ValidatedStringApiProperty({
+    description: 'The lender type code for the investor party of the deal.',
+    example: '500',
+    minLength: 0,
+    maxLength: 3,
+    required: false,
+    default: '500',
+  })
+  readonly lenderType?: string;
+
+  @ValidatedDateOnlyApiProperty({
+    description: "The effective date on the deal investor record. If the date provided is in the future, it will be replaced by today's date.",
+    example: '2023-03-24',
+  })
+  readonly effectiveDate: DateString;
+
+  @ValidatedDateOnlyApiProperty({
+    description: 'The expiry date on the deal investor record. If the value is not provided or is null then the maximum expiry date will be set.',
+    example: '2023-03-24',
+    required: false,
+    default: null,
+  })
+  readonly expiryDate?: DateString | null;
+
+  @ValidatedStringApiProperty({
+    description: "A code for the status of the deal on which the sub-limit is created, e.g., 'A' for 'ACTIVE/PENDING', 'B' for 'ACTIVE' etc.",
+    example: 'A',
+    minLength: 0,
+    maxLength: 1,
+    required: false,
+    default: 'A',
+  })
+  readonly dealStatus?: string;
+
+  @ValidatedStringApiProperty({
+    description: 'The deal currency code.',
+    example: 'USD',
+    length: 3,
+  })
+  readonly currency: string;
+}

--- a/src/modules/deal-investor/dto/create-deal-investor-response.dto.ts
+++ b/src/modules/deal-investor/dto/create-deal-investor-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiResponseProperty } from '@nestjs/swagger';
+
+export class CreateDealInvestorResponse {
+  @ApiResponseProperty({ example: '0020900111' })
+  readonly dealIdentifier: string;
+
+  constructor(dealIdentifier: string) {
+    this.dealIdentifier = dealIdentifier;
+  }
+}

--- a/src/modules/deal-investor/dto/deal-investor-response.dto.ts
+++ b/src/modules/deal-investor/dto/deal-investor-response.dto.ts
@@ -3,12 +3,12 @@ import { ENUMS, EXAMPLES, PROPERTIES } from '@ukef/constants';
 import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
 import { IsEnum } from 'class-validator';
 
-class DealInvestorDtoLenderType {
+class GetDealInvestorDtoLenderType {
   @ApiProperty({ description: 'Lender type: 100 for Exporter or 500 for UKEF record.', example: ENUMS.LENDER_TYPE_CODES.ECGD })
   @IsEnum(ENUMS.LENDER_TYPE_CODES)
   LenderTypeCode: string;
 }
-export class DealInvestorResponseDto {
+export class GetDealInvestorResponseDto {
   @ApiResponseProperty({ example: EXAMPLES.DEAL_ID })
   dealIdentifier: string;
 
@@ -17,7 +17,7 @@ export class DealInvestorResponseDto {
   portfolioIdentifier: string;
 
   @ApiResponseProperty()
-  lenderType: DealInvestorDtoLenderType;
+  lenderType: GetDealInvestorDtoLenderType;
 
   @ApiProperty({ type: Date, nullable: false })
   effectiveDate: DateOnlyString;

--- a/test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests.ts
@@ -1,37 +1,75 @@
 import request from 'supertest';
 
-interface RequiredDateOnlyFieldValidationApiTestOptions<RequestBodyItem> {
+interface DateOnlyFieldValidationApiTestOptions<RequestBodyItem> {
   fieldName: keyof RequestBodyItem;
+  required?: boolean;
+  nullable?: boolean;
   validRequestBody: RequestBodyItem[];
   makeRequest: (body: unknown[]) => request.Test;
   givenAnyRequestBodyWouldSucceed: () => void;
 }
 
-export function withRequiredDateOnlyFieldValidationApiTests<RequestBodyItem>({
+export function withDateOnlyFieldValidationApiTests<RequestBodyItem>({
   fieldName: fieldNameSymbol,
+  required,
+  nullable,
   validRequestBody,
   makeRequest,
   givenAnyRequestBodyWouldSucceed,
-}: RequiredDateOnlyFieldValidationApiTestOptions<RequestBodyItem>): void {
+}: DateOnlyFieldValidationApiTestOptions<RequestBodyItem>): void {
   const fieldName = fieldNameSymbol.toString();
+  required = required ?? true;
 
   describe(`${fieldName} validation`, () => {
     beforeEach(() => {
       givenAnyRequestBodyWouldSucceed();
     });
 
-    it(`returns a 400 response if ${fieldName} is not present`, async () => {
-      const { [fieldNameSymbol]: _removed, ...requestWithoutTheField } = validRequestBody[0];
+    if (required) {
+      it(`returns a 400 response if ${fieldName} is not present`, async () => {
+        const { [fieldNameSymbol]: _removed, ...requestWithoutTheField } = validRequestBody[0];
 
-      const { status, body } = await makeRequest([requestWithoutTheField]);
+        const { status, body } = await makeRequest([requestWithoutTheField]);
 
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({
-        error: 'Bad Request',
-        message: [`${fieldName} must be a valid ISO 8601 date string`, `${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
-        statusCode: 400,
+        expect(status).toBe(400);
+        expect(body).toStrictEqual({
+          error: 'Bad Request',
+          message: [`${fieldName} must be a valid ISO 8601 date string`, `${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+          statusCode: 400,
+        });
       });
-    });
+    } else {
+      it(`returns a 201 response if ${fieldName} is not present`, async () => {
+        const { [fieldNameSymbol]: _removed, ...requestWithField } = validRequestBody[0];
+
+        const { status } = await makeRequest([requestWithField]);
+
+        expect(status).toBe(201);
+      });
+    }
+
+    if (nullable) {
+      it(`returns a 201 response if ${fieldName} is null`, async () => {
+        const requestWithNullDate = [{ ...validRequestBody[0], [fieldName]: null }];
+
+        const { status } = await makeRequest(requestWithNullDate);
+
+        expect(status).toBe(201);
+      });
+    } else {
+      it(`returns a 400 response if ${fieldName} is null`, async () => {
+        const requestWithNullDate = [{ ...validRequestBody[0], [fieldName]: null }];
+
+        const { status, body } = await makeRequest(requestWithNullDate);
+
+        expect(status).toBe(400);
+        expect(body).toStrictEqual({
+          error: 'Bad Request',
+          message: [`${fieldName} must be a valid ISO 8601 date string`, `${fieldName} must match /^\\d{4}-\\d{2}-\\d{2}$/ regular expression`],
+          statusCode: 400,
+        });
+      });
+    }
 
     it(`returns a 400 response if ${fieldName} has time part of date string`, async () => {
       const requestWithDateInIncorrectFormat = [{ ...validRequestBody[0], [fieldName]: '2023-02-01T00:00:00Z' }];

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -2,7 +2,7 @@ import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withRequiredDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withRequiredNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
@@ -225,7 +225,7 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     },
   });
 
-  withRequiredDateOnlyFieldValidationApiTests({
+  withDateOnlyFieldValidationApiTests({
     fieldName: 'effectiveDate',
     validRequestBody: requestBodyToCreateDealGuarantee,
     makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
@@ -235,7 +235,7 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     },
   });
 
-  withRequiredDateOnlyFieldValidationApiTests({
+  withDateOnlyFieldValidationApiTests({
     fieldName: 'guaranteeExpiryDate',
     validRequestBody: requestBodyToCreateDealGuarantee,
     makeRequest: (body) => api.post(createDealGuaranteeUrl, body),

--- a/test/deal-investor/get-deal-investors-by-deal-identifier.api-test.ts
+++ b/test/deal-investor/get-deal-investors-by-deal-identifier.api-test.ts
@@ -3,7 +3,7 @@ import { UkefId } from '@ukef/helpers';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
-import { DealInvestorGenerator } from '@ukef-test/support/generator/deal-investor-generator';
+import { GetDealInvestorGenerator } from '@ukef-test/support/generator/get-deal-investor-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import nock from 'nock';
 
@@ -15,7 +15,7 @@ describe('GET /deals/{dealIdentifier}/investors', () => {
 
   let api: Api;
 
-  const { dealInvestorsInAcbs, dealInvestorsFromService } = new DealInvestorGenerator(valueGenerator).generate({
+  const { dealInvestorsInAcbs, dealInvestorsFromService } = new GetDealInvestorGenerator(valueGenerator).generate({
     numberToGenerate: 2,
     dealIdentifier,
     portfolioIdentifier,

--- a/test/deal-investor/post-deal-investors.api-test.ts
+++ b/test/deal-investor/post-deal-investors.api-test.ts
@@ -1,0 +1,311 @@
+import { PROPERTIES } from '@ukef/constants';
+import { UkefId } from '@ukef/helpers';
+import { AcbsCreateDealInvestorRequest } from '@ukef/modules/acbs/dto/acbs-create-deal-investor-request.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
+import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { CreateDealInvestorGenerator } from '@ukef-test/support/generator/create-deal-investor-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+import { CurrentDateProvider } from '../../src/modules/date/current-date.provider';
+
+describe('POST /deals/{dealIdentifier}/investors', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const currentDateProvider = new CurrentDateProvider();
+  const dateStringTransformations = new DateStringTransformations();
+
+  const dealIdentifier: UkefId = valueGenerator.ukefId();
+  const createDealInvestorUrl = `/api/v1/deals/${dealIdentifier}/investors`;
+
+  const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+
+  const { acbsRequestBodyToCreateDealInvestor, requestBodyToCreateDealInvestor } = new CreateDealInvestorGenerator(
+    valueGenerator,
+    currentDateProvider,
+    dateStringTransformations,
+  ).generate({
+    numberToGenerate: 2,
+    dealIdentifier: dealIdentifier,
+  });
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => givenRequestToCreateDealInvestorInAcbsSucceeds(),
+    makeRequest: () => api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor),
+    successStatusCode: 201,
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToCreateDealInvestorInAcbsSucceeds();
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.postWithoutAuth(createDealInvestorUrl, requestBodyToCreateDealInvestor, incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  it('returns a 201 response with the deal identifier if the deal investor has been successfully created in ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequest = givenRequestToCreateDealInvestorInAcbsSucceeds();
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+    expect(acbsRequest.isDone()).toBe(true);
+  });
+
+  it('sets the default lenderType if it is not specified in the request', async () => {
+    const { lenderType: _removed, ...newDealInvestorWithoutLenderType } = requestBodyToCreateDealInvestor[0];
+    const requestBodyWithoutLenderType = [newDealInvestorWithoutLenderType];
+    const acbsRequestBodyWithDefaultLenderType = {
+      ...acbsRequestBodyToCreateDealInvestor,
+      LenderType: { LenderTypeCode: PROPERTIES.DEAL_INVESTOR.DEFAULT.lenderType.lenderTypeCode },
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithDefaultLenderType = requestToCreateDealInvestorInAcbsWithBody(acbsRequestBodyWithDefaultLenderType).reply(201);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyWithoutLenderType);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+    expect(acbsRequestWithDefaultLenderType.isDone()).toBe(true);
+  });
+
+  it('sets the default expiryDate if it is not specified in the request', async () => {
+    const { expiryDate: _removed, ...newDealInvestorWithoutExpiryDate } = requestBodyToCreateDealInvestor[0];
+    const requestBodyWithoutExpiryDate = [newDealInvestorWithoutExpiryDate];
+    const acbsRequestBodyWithDefaultExpirationDate = {
+      ...acbsRequestBodyToCreateDealInvestor,
+      ExpirationDate: PROPERTIES.DEAL_INVESTOR.DEFAULT.expirationDate,
+      IsExpirationDateMaximum: true,
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithDefaultExpirationDate = requestToCreateDealInvestorInAcbsWithBody(acbsRequestBodyWithDefaultExpirationDate).reply(201);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyWithoutExpiryDate);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+    expect(acbsRequestWithDefaultExpirationDate.isDone()).toBe(true);
+  });
+
+  it('sets the default dealStatus if it is not specified in the request', async () => {
+    const { dealStatus: _removed, ...newDealInvestorWithoutDealStatus } = requestBodyToCreateDealInvestor[0];
+    const requestBodyWithoutDealStatus = [newDealInvestorWithoutDealStatus];
+    const acbsRequestBodyWithDefaultDealStatus = {
+      ...acbsRequestBodyToCreateDealInvestor,
+      DealStatus: {
+        DealStatusCode: PROPERTIES.DEAL_INVESTOR.DEFAULT.dealStatus.dealStatusCode,
+      },
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithDefaultDealStatus = requestToCreateDealInvestorInAcbsWithBody(acbsRequestBodyWithDefaultDealStatus).reply(201);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyWithoutDealStatus);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+    expect(acbsRequestWithDefaultDealStatus.isDone()).toBe(true);
+  });
+
+  it(`replaces the effectiveDate with today's date if the specified effectiveDate is after today`, async () => {
+    const requestBodyWithFutureEffectiveDate = [{ ...requestBodyToCreateDealInvestor[0], effectiveDate: '9999-01-01' }];
+    const acbsRequestBodyWithTodayEffectiveDate = {
+      ...acbsRequestBodyToCreateDealInvestor,
+      EffectiveDate: dateStringTransformations.getDateStringFromDate(new Date()),
+    };
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsRequestWithTodayEffectiveDate = requestToCreateDealInvestorInAcbsWithBody(acbsRequestBodyWithTodayEffectiveDate).reply(201);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyWithFutureEffectiveDate);
+
+    expect(status).toBe(201);
+    expect(body).toStrictEqual({
+      dealIdentifier,
+    });
+    expect(acbsRequestWithTodayEffectiveDate.isDone()).toBe(true);
+  });
+
+  withStringFieldValidationApiTests({
+    fieldName: 'dealIdentifier',
+    length: 10,
+    pattern: '/00\\d{8}/',
+    generateFieldValueOfLength: (length: number) => valueGenerator.ukefId(length - 4),
+    generateFieldValueThatDoesNotMatchRegex: () => '1000000000' as UkefId,
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  withStringFieldValidationApiTests({
+    fieldName: 'lenderType',
+    minLength: 0,
+    maxLength: 3,
+    required: false,
+    generateFieldValueOfLength: (length: number) => valueGenerator.string({ length }),
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  withDateOnlyFieldValidationApiTests({
+    fieldName: 'effectiveDate',
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  withDateOnlyFieldValidationApiTests({
+    fieldName: 'expiryDate',
+    required: false,
+    nullable: true,
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  withStringFieldValidationApiTests({
+    fieldName: 'dealStatus',
+    minLength: 0,
+    maxLength: 1,
+    required: false,
+    generateFieldValueOfLength: (length: number) => valueGenerator.string({ length }),
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  withStringFieldValidationApiTests({
+    fieldName: 'currency',
+    length: 3,
+    generateFieldValueOfLength: (length: number) => valueGenerator.string({ length }),
+    validRequestBody: requestBodyToCreateDealInvestor,
+    makeRequest: (body) => api.post(createDealInvestorUrl, body),
+    givenAnyRequestBodyWouldSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds();
+    },
+  });
+
+  it('returns a 404 response if ACBS responds with a 400 response that is a string containing "The deal not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToCreateDealInvestor().reply(400, 'The deal not found or user does not have access');
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(404);
+    expect(body).toStrictEqual({ message: 'Not found', statusCode: 404 });
+  });
+
+  it('returns a 400 response if ACBS responds with a 400 response that is not a string', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsErrorMessage = { Message: 'error message' };
+    requestToCreateDealInvestor().reply(400, acbsErrorMessage);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'Bad request', error: JSON.stringify(acbsErrorMessage), statusCode: 400 });
+  });
+
+  it('returns a 400 response if ACBS responds with a 400 response that is a string that does not contain "The deal not found"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    const acbsErrorMessage = 'ACBS error message';
+    requestToCreateDealInvestor().reply(400, acbsErrorMessage);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
+  });
+
+  it('returns a 500 response if ACBS responds with an error code that is not 400"', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToCreateDealInvestor().reply(401, 'Unauthorized');
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+  });
+
+  it('returns a 500 response if creating the deal investor in ACBS times out', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToCreateDealInvestor()
+      .delay(ENVIRONMENT_VARIABLES.ACBS_TIMEOUT + 500)
+      .reply(201);
+
+    const { status, body } = await api.post(createDealInvestorUrl, requestBodyToCreateDealInvestor);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  const givenRequestToCreateDealInvestorInAcbsSucceeds = (): nock.Scope => {
+    return requestToCreateDealInvestor().reply(201);
+  };
+
+  const requestToCreateDealInvestor = (): nock.Interceptor => requestToCreateDealInvestorInAcbsWithBody(acbsRequestBodyToCreateDealInvestor);
+
+  const requestToCreateDealInvestorInAcbsWithBody = (requestBody: AcbsCreateDealInvestorRequest): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealParty`, JSON.stringify(requestBody))
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .matchHeader('Content-Type', 'application/json');
+
+  const givenAnyRequestBodyToCreateDealInvestorInAcbsSucceeds = (): void => {
+    const requestBodyPlaceholder = '*';
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .filteringRequestBody(() => requestBodyPlaceholder)
+      .post(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealParty`, requestBodyPlaceholder)
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .matchHeader('Content-Type', 'application/json')
+      .reply(201);
+  };
+});

--- a/test/deal/post-deal.api-test.ts
+++ b/test/deal/post-deal.api-test.ts
@@ -2,7 +2,7 @@ import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withRequiredDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withRequiredNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
@@ -176,7 +176,7 @@ describe('POST /deals', () => {
     },
   });
 
-  withRequiredDateOnlyFieldValidationApiTests({
+  withDateOnlyFieldValidationApiTests({
     fieldName: 'guaranteeCommencementDate',
     validRequestBody: requestBodyToCreateDeal,
     makeRequest: (body) => api.post(createDealUrl, body),

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -87,9 +87,37 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DealInvestorResponseDto'
+                  $ref: '#/components/schemas/GetDealInvestorResponseDto'
         '404':
           description: The specified deal, or the investors for that deal, were not found.
+        '500':
+          description: An internal server error has occurred.
+    post:
+      operationId: DealInvestorController_createInvestorForDeal
+      summary: Create a new investor for a deal.
+      parameters:
+        - name: dealIdentifier
+          required: true
+          in: path
+          description: The identifier of the deal in ACBS.
+          example: '0020900111'
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateDealInvestorRequestItem'
+      responses:
+        '201':
+          description: The investor has been successfully created.
+        '400':
+          description: Bad request.
+        '404':
+          description: The deal was not found.
         '500':
           description: An internal server error has occurred.
   /api/v1/facilities/{facilityIdentifier}/investors:
@@ -251,17 +279,17 @@ components:
         dealIdentifier:
           type: string
           description: The identifier of the deal to create.
-          example: '0020900035'
           minLength: 10
           maxLength: 10
+          example: '0020900035'
         currency:
           type: string
           description: >-
             The currency code of the primary currency of the deal, from the
             Currency Definition Table.
-          example: GBP
           minLength: 3
           maxLength: 3
+          example: GBP
         dealValue:
           type: number
           description: The value of the deal.
@@ -277,9 +305,9 @@ components:
         obligorPartyIdentifier:
           type: string
           description: The obligor party identifier.
-          example: '00000001'
           minLength: 8
           maxLength: 8
+          example: '00000001'
         obligorName:
           type: string
           description: The obligor party name, which is party name1 attribute.
@@ -288,9 +316,9 @@ components:
         obligorIndustryClassification:
           type: string
           description: The obligor party industry classification.
-          example: '1405'
           minLength: 0
           maxLength: 10
+          example: '1405'
       required:
         - dealIdentifier
         - currency
@@ -313,9 +341,9 @@ components:
         dealIdentifier:
           type: string
           description: The identifier of the deal to create the guarantee for.
-          example: '00000001'
           minLength: 8
           maxLength: 8
+          example: '00000001'
         effectiveDate:
           format: date
           type: string
@@ -325,9 +353,9 @@ components:
         limitKey:
           type: string
           description: An ACBS party identifier.
-          example: '00000002'
           minLength: 8
           maxLength: 8
+          example: '00000002'
         guaranteeExpiryDate:
           format: date
           type: string
@@ -365,7 +393,7 @@ components:
           example: '00000001'
       required:
         - dealIdentifier
-    DealInvestorDtoLenderType:
+    GetDealInvestorDtoLenderType:
       type: object
       properties:
         LenderTypeCode:
@@ -374,7 +402,7 @@ components:
           example: '500'
       required:
         - LenderTypeCode
-    DealInvestorResponseDto:
+    GetDealInvestorResponseDto:
       type: object
       properties:
         dealIdentifier:
@@ -388,7 +416,7 @@ components:
         lenderType:
           readOnly: true
           allOf:
-            - $ref: '#/components/schemas/DealInvestorDtoLenderType'
+            - $ref: '#/components/schemas/GetDealInvestorDtoLenderType'
         effectiveDate:
           format: date-time
           type: string
@@ -413,15 +441,69 @@ components:
         - expiryDate
         - isExpiryDateMaximum
         - maximumLiability
+    CreateDealInvestorRequestItem:
+      type: object
+      properties:
+        dealIdentifier:
+          type: string
+          description: >-
+            'The identifier of the deal to create the investor for. It will be a
+            10-digit code beginning with either '0020', '0030', or '0040'.
+          minLength: 10
+          maxLength: 10
+          pattern: /00\\d{8}/
+          example: '0020900111'
+        lenderType:
+          type: string
+          description: The lender type code for the investor party of the deal.
+          minLength: 0
+          maxLength: 3
+          example: '500'
+          default: '500'
+        effectiveDate:
+          format: date
+          type: string
+          description: >-
+            The effective date on the deal investor record. If the date provided
+            is in the future, it will be replaced by today's date.
+          example: '2023-03-24'
+        expiryDate:
+          format: date
+          type: string
+          description: >-
+            The expiry date on the deal investor record. If the value is not
+            provided or is null then the maximum expiry date will be set.
+          example: '2023-03-24'
+          default: null
+        dealStatus:
+          type: string
+          description: >-
+            A code for the status of the deal on which the sub-limit is created,
+            e.g., 'A' for 'ACTIVE/PENDING', 'B' for 'ACTIVE' etc.
+          minLength: 0
+          maxLength: 1
+          example: A
+          default: A
+        currency:
+          type: string
+          description: The deal currency code.
+          minLength: 3
+          maxLength: 3
+          example: USD
+      required:
+        - dealIdentifier
+        - effectiveDate
+        - expiryDate
+        - currency
     CreateFacilityInvestorRequestItem:
       type: object
       properties:
         facilityIdentifier:
           type: string
           description: The identifier of the facility to create the investor for.
-          example: '0000000001'
           minLength: 10
           maxLength: 10
+          example: '0000000001'
         effectiveDate:
           format: date
           type: string
@@ -435,9 +517,9 @@ components:
           description: >-
             The code of the currency for this investor, Currency in the Currency
             Definition Table.
-          example: USD
           minLength: 3
           maxLength: 3
+          example: USD
         maximumLiability:
           type: number
           description: The investor's share of the current limit amount.

--- a/test/facility-investor/post-facility-investor.api-test.ts
+++ b/test/facility-investor/post-facility-investor.api-test.ts
@@ -2,7 +2,7 @@ import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withRequiredDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-date-only-field-validation-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withRequiredNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/required-non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
@@ -168,7 +168,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
   });
 
-  withRequiredDateOnlyFieldValidationApiTests({
+  withDateOnlyFieldValidationApiTests({
     fieldName: 'effectiveDate',
     validRequestBody: requestBodyToCreateFacilityInvestor,
     makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
@@ -178,7 +178,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     },
   });
 
-  withRequiredDateOnlyFieldValidationApiTests({
+  withDateOnlyFieldValidationApiTests({
     fieldName: 'guaranteeExpiryDate',
     validRequestBody: requestBodyToCreateFacilityInvestor,
     makeRequest: (body) => api.post(createFacilityInvestorUrl, body),

--- a/test/support/generator/create-deal-investor-generator.ts
+++ b/test/support/generator/create-deal-investor-generator.ts
@@ -1,0 +1,89 @@
+import { PROPERTIES } from '@ukef/constants';
+import { UkefId } from '@ukef/helpers';
+import { AcbsCreateDealInvestorRequest } from '@ukef/modules/acbs/dto/acbs-create-deal-investor-request.dto';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { CreateDealInvestorRequest, CreateDealInvestorRequestItem } from '@ukef/modules/deal-investor/dto/create-deal-investor-request.dto';
+
+import { AbstractGenerator } from './abstract-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class CreateDealInvestorGenerator extends AbstractGenerator<CreateDealInvestorRequestItem, GenerateResult, GenerateOptions> {
+  constructor(
+    protected readonly valueGenerator: RandomValueGenerator,
+    protected readonly currentDateProvider: CurrentDateProvider,
+    protected readonly dateStringTransformations: DateStringTransformations,
+  ) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): CreateDealInvestorRequestItem {
+    return {
+      dealIdentifier: this.valueGenerator.ukefId(),
+      lenderType: this.valueGenerator.string({ minLength: 0, maxLength: 3 }),
+      effectiveDate: this.valueGenerator.dateOnlyString(),
+      expiryDate: this.valueGenerator.dateOnlyString(),
+      dealStatus: this.valueGenerator.string({ minLength: 0, maxLength: 1 }),
+      currency: this.valueGenerator.string({ length: 3 }),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: CreateDealInvestorRequest, { dealIdentifier }: GenerateOptions): GenerateResult {
+    const firstDealInvestor = values[0];
+
+    const effectiveDateTime = this.currentDateProvider.getEarliestDateFromTodayAnd(
+      new Date(this.dateStringTransformations.addTimeToDateOnlyString(firstDealInvestor.effectiveDate)),
+    );
+    const effectiveDateString = this.dateStringTransformations.getDateStringFromDate(effectiveDateTime);
+
+    const expiryDateOnlyString = firstDealInvestor.expiryDate;
+    const expirationDateString = expiryDateOnlyString
+      ? this.dateStringTransformations.addTimeToDateOnlyString(expiryDateOnlyString)
+      : PROPERTIES.DEAL_INVESTOR.DEFAULT.expirationDate;
+
+    const acbsRequestBodyToCreateDealInvestor: AcbsCreateDealInvestorRequest = {
+      SectionIdentifier: PROPERTIES.DEAL_INVESTOR.DEFAULT.sectionIdentifier,
+      EffectiveDate: effectiveDateString,
+      ExpirationDate: expirationDateString,
+      IsExpirationDateMaximum: firstDealInvestor.expiryDate ? false : true,
+      LenderType: {
+        LenderTypeCode: firstDealInvestor.lenderType ?? PROPERTIES.DEAL_INVESTOR.DEFAULT.lenderType.lenderTypeCode,
+      },
+      InvolvedParty: {
+        PartyIdentifier: PROPERTIES.DEAL_INVESTOR.DEFAULT.involvedParty.partyIdentifier,
+      },
+      Currency: {
+        CurrencyCode: firstDealInvestor.currency,
+      },
+      CustomerAdvisedIndicator: PROPERTIES.DEAL_INVESTOR.DEFAULT.customerAdvisedIndicator,
+      DealStatus: {
+        DealStatusCode: firstDealInvestor.dealStatus ?? PROPERTIES.DEAL_INVESTOR.DEFAULT.dealStatus.dealStatusCode,
+      },
+      UserDefinedCode1: PROPERTIES.DEAL_INVESTOR.DEFAULT.userDefinedCode1,
+      ContractPercentage: PROPERTIES.DEAL_INVESTOR.DEFAULT.contractPercentage,
+      LimitRevolvingIndicator: PROPERTIES.DEAL_INVESTOR.DEFAULT.limitRevolvingIndicator,
+    };
+
+    const requestBodyToCreateDealInvestor = values.map((v, index) => ({
+      dealIdentifier: index === 0 ? dealIdentifier : v.dealIdentifier,
+      lenderType: v.lenderType,
+      effectiveDate: v.effectiveDate,
+      expiryDate: v.expiryDate,
+      dealStatus: v.dealStatus,
+      currency: v.currency,
+    }));
+
+    return {
+      acbsRequestBodyToCreateDealInvestor,
+      requestBodyToCreateDealInvestor,
+    };
+  }
+}
+interface GenerateOptions {
+  dealIdentifier?: UkefId;
+}
+
+interface GenerateResult {
+  acbsRequestBodyToCreateDealInvestor: AcbsCreateDealInvestorRequest;
+  requestBodyToCreateDealInvestor: CreateDealInvestorRequest;
+}

--- a/test/support/generator/get-deal-investor-generator.ts
+++ b/test/support/generator/get-deal-investor-generator.ts
@@ -3,7 +3,7 @@ import { DealInvestor } from '@ukef/modules/deal-investor/deal-investor.interfac
 
 import { AbstractGenerator } from './abstract-generator';
 
-export class DealInvestorGenerator extends AbstractGenerator<DealInvestor, GenerateResult, GenerateOptions> {
+export class GetDealInvestorGenerator extends AbstractGenerator<DealInvestor, GenerateResult, GenerateOptions> {
   protected generateValues(): DealInvestor {
     return {
       dealIdentifier: this.valueGenerator.ukefId(),

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -70,8 +70,8 @@ export class RandomValueGenerator {
   }
 
   // UKEF id example 0030000321. It should be used for Deal and Facility IDs.
-  ukefId(): UkefId {
-    return (UKEFID.MAIN_ID_PREFIX.DEV + this.stringOfNumericCharacters({ length: 6 })) as UkefId;
+  ukefId(lengthExcludingPrefix?: number): UkefId {
+    return (UKEFID.MAIN_ID_PREFIX.DEV + this.stringOfNumericCharacters({ length: lengthExcludingPrefix ?? 6 })) as UkefId;
   }
 
   dateTimeString(): DateString {


### PR DESCRIPTION
## Introduction
Add the `POST /deals/{dealIdentifier}/investors` endpoint

## Resolution
I've added the endpoint with the following logic:
1. The request body is an array containing an object of the following shape
    ```
    {
      "portfolioIdentifier": "E1",
      "dealIdentifier": "0020900111",
      "lenderType": "500",
      "effectiveDate": "2023-03-31",
      "expiryDate": "2023-03-31",
      "dealStatus": "A",
      "currency": "USD",
    }
    ```
    where `portfolioIdentifier`, `lenderType`, `expiryDate` and `dealStatus` are optional and have defaults
1. We validate the below, returning a 400 if any rule fails
    - `portfolioIdentifier` has length between 0 and 2 if it is present
    - `dealIdentifier` exists, has length 10 and begins with either `0020`, `0030` or `0040`
    - `lenderType` has length between 0 and 3 if it is present
    - `effectiveDate` exists, is a real date, and is in `yyyy-mm-dd` format
    - `expiryDate` is a real date and is in `yyyy-mm-dd` format if it is present
    - ``dealStatus` has length between 0 and 1 if it is present
    - `currency` exists and has length between 0 and 3
1. We get an id token for ACBS from the IdP
1. We transform the request body, adding some defaults
    - the most interesting part is that we replace `effectiveDate` with today's date if it was in the future
1. We POST the transformed request to ACBS
    - If the response from ACBS is a 201, we return a 201 with the `dealIdentifier`
    - If the response from ACBS is a 400 and is a string that contains "The deal not found", we return a 404
    - If the response from ACBS is a 400 but isn't a string / doesn't contain "The deal not found", we return a 400 and also return the error message from ACBS
    - If the response from ACBS is anything else, we return a 500