### PR TITLE
docs(APIM-97): document caching of ACBS id token

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ this.logger.log({ id: 'your message here' }, 'context-name');
 The Trade Finance Services API requires an API Key in order to access its resources.
 This can be achieved by providing a randomised API Key as an environment variable (`API_KEY`) and a strategy (`API_KEY_STRATEGY`) which defines the name of the header passed to the API.
 
+### Caching
+Currently, only the ID token that is used for authenticating our requests to ACBS is cached.
+The lifetime of this cache is controlled by the `ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL_IN_MILLISECONDS` environment variable.
+This token has a lifetime of 30 minutes, so it is safe to set this variable to any value between 1 and 180000000.
+
+Do NOT set the variable to 0, as this will cache the ID token permanently.
+
+We do not have a setting to disable this cache, but setting the TTL to 1ms will _essentially_ disable it.
+
 ### Writing Conventional Commits
 
 The most important prefixes you should have in mind are:

--- a/src/main.module.ts
+++ b/src/main.module.ts
@@ -12,7 +12,6 @@ import { LoggerModule } from 'nestjs-pino';
     }),
     LoggerModule.forRoot({
       pinoHttp: {
-        // TODO APIM-97: it would be good to have a way to configure the log-level
         customProps: () => ({
           context: 'HTTP',
         }),

--- a/src/modules/acbs-authentication/caching-acbs-authentication.service.ts
+++ b/src/modules/acbs-authentication/caching-acbs-authentication.service.ts
@@ -62,8 +62,6 @@ export class CachingAcbsAuthenticationService extends AcbsAuthenticationService 
   }
 
   private async tryStoreIdTokenInCache(idToken: string): Promise<void> {
-    // TODO APIM-97: a ttl of 0 caches the value permanently - should we disable this?
-    // TODO APIM-97: should we allow caching to be turned off?
     try {
       await this.cacheManager.set(ACBS_ID_TOKEN_CACHE_KEY, idToken, this.config.idTokenCacheTtlInMilliseconds);
     } catch (error) {

--- a/test/support/wait-for.ts
+++ b/test/support/wait-for.ts
@@ -2,6 +2,4 @@ import { waitFor } from '@ukef/helpers/wait-for.helper';
 
 import { TIME_EXCEEDING_ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL } from './environment-variables';
 
-// TODO APIM-97: should we use fake timers instead?
-// TODO APIM-97: should all tests wait for cache to expire?
 export const waitForAcbsAuthenticationIdTokenCacheToExpire = (): Promise<void> => waitFor(TIME_EXCEEDING_ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL);


### PR DESCRIPTION
## Introduction
In https://github.com/UK-Export-Finance/tfs-api/pull/53, we added caching of the ACBS id token, but didn't document how long the token could be safely cached for. This PR documents this.

## Resolution
I've added this information to the README