### PR TITLE
feat(APIM-122): add acbs service for getting facility guarantees for a facility

### DIFF
--- a/src/modules/acbs/acbs-config-base-url.type.ts
+++ b/src/modules/acbs/acbs-config-base-url.type.ts
@@ -1,0 +1,4 @@
+import { ConfigType } from '@nestjs/config';
+import AcbsConfig from '@ukef/config/acbs.config';
+
+export type AcbsConfigBaseUrl = Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>;

--- a/src/modules/acbs/acbs-deal-guarantee.service.ts
+++ b/src/modules/acbs/acbs-deal-guarantee.service.ts
@@ -1,9 +1,9 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateDealGuaranteeDto } from './dto/acbs-create-deal-guarantee.dto';
 import { getDealNotFoundKnownAcbsError } from './known-errors';
@@ -15,7 +15,7 @@ export class AcbsDealGuaranteeService {
 
   constructor(
     @Inject(AcbsConfig.KEY)
-    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    config: AcbsConfigBaseUrl,
     httpService: HttpService,
   ) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);

--- a/src/modules/acbs/acbs-deal-party.service.ts
+++ b/src/modules/acbs/acbs-deal-party.service.ts
@@ -1,9 +1,9 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateDealInvestorRequest } from './dto/acbs-create-deal-investor-request.dto';
 import { AcbsGetDealPartyResponseDto } from './dto/acbs-get-deal-party-response.dto';
@@ -16,7 +16,7 @@ export class AcbsDealPartyService {
 
   constructor(
     @Inject(AcbsConfig.KEY)
-    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    config: AcbsConfigBaseUrl,
     httpService: HttpService,
   ) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);

--- a/src/modules/acbs/acbs-deal.service.ts
+++ b/src/modules/acbs/acbs-deal.service.ts
@@ -1,8 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateDealDto } from './dto/acbs-create-deal.dto';
 import { AcbsGetDealResponseDto } from './dto/acbs-get-deal-response.dto';
@@ -15,7 +15,7 @@ export class AcbsDealService {
 
   constructor(
     @Inject(AcbsConfig.KEY)
-    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    config: AcbsConfigBaseUrl,
     httpService: HttpService,
   ) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);

--- a/src/modules/acbs/acbs-facility-guarantee.service.test.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.test.ts
@@ -1,0 +1,125 @@
+import { HttpService } from '@nestjs/axios';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsFacilityGuaranteeService } from './acbs-facility-guarantee.service';
+import { AcbsGetFacilityGuaranteeDto, AcbsGetFacilityGuaranteesResponseDto } from './dto/acbs-get-facility-guarantees-response.dto';
+import { AcbsException } from './exception/acbs.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+
+describe('AcbsFacilityGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const facilityIdentifier = valueGenerator.stringOfNumericCharacters({ length: 10 });
+
+  let httpService: HttpService;
+  let service: AcbsFacilityGuaranteeService;
+
+  let httpServiceGet: jest.Mock;
+
+  const expectedHttpServiceGetArgs = [
+    `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityGuarantee`,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}` },
+    },
+  ];
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
+    service = new AcbsFacilityGuaranteeService({ baseUrl }, httpService);
+  });
+
+  const generateFacilityGuarantee = (): AcbsGetFacilityGuaranteeDto => ({
+    EffectiveDate: valueGenerator.dateTimeString(),
+    GuarantorParty: {
+      PartyIdentifier: valueGenerator.stringOfNumericCharacters({ length: 8 }),
+    },
+    LimitKey: valueGenerator.string(),
+    ExpirationDate: valueGenerator.dateTimeString(),
+    GuaranteedLimit: valueGenerator.nonnegativeFloat(),
+    GuaranteeType: {
+      GuaranteeTypeCode: valueGenerator.string(),
+    },
+  });
+
+  const facilityGuaranteesInAcbs: AcbsGetFacilityGuaranteesResponseDto = [generateFacilityGuarantee(), generateFacilityGuarantee()];
+
+  describe('getGuaranteesForFacility', () => {
+    it('returns the guarantees for the facility from ACBS if ACBS responds with the guarantees', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: facilityGuaranteesInAcbs,
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const guarantees = await service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(guarantees).toBe(facilityGuaranteesInAcbs);
+    });
+
+    it('returns an empty array if ACBS responds with an empty array', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: [],
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const guarantees = await service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(guarantees).toStrictEqual([]);
+    });
+
+    it('throws an AcbsException if the request to ACBS fails', async () => {
+      const getGuaranteesForFacilityError = new AxiosError();
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(throwError(() => getGuaranteesForFacilityError));
+
+      const getGuaranteesForFacilityPromise = service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      await expect(getGuaranteesForFacilityPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getGuaranteesForFacilityPromise).rejects.toThrow(`Failed to get the guarantees for the facility with identifier ${facilityIdentifier}.`);
+      await expect(getGuaranteesForFacilityPromise).rejects.toHaveProperty('innerError', getGuaranteesForFacilityError);
+    });
+
+    it(`throws an AcbsResourceNotFoundException if ACBS responds with a 200 response where the response body is 'null'`, async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: null,
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const getGuaranteesForFacilityPromise = service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      await expect(getGuaranteesForFacilityPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(getGuaranteesForFacilityPromise).rejects.toThrow(`Guarantees for facility with identifier ${facilityIdentifier} were not found by ACBS.`);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-facility-guarantee.service.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.ts
@@ -24,6 +24,9 @@ export class AcbsFacilityGuaranteeService {
     });
 
     if (guarantees === null) {
+      // The ACBS endpoint has surprising behaviour where a `200 OK` response with response body `null` is returned if the
+      // facility does not exist, but it can also be returned in cases where the facility does exist. That means we do not
+      // know if the facility exists or not at this point.
       throw new AcbsResourceNotFoundException(`Guarantees for facility with identifier ${facilityIdentifier} were not found by ACBS.`);
     }
 

--- a/src/modules/acbs/acbs-facility-guarantee.service.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.ts
@@ -1,0 +1,32 @@
+import { HttpService } from '@nestjs/axios';
+
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
+import { AcbsHttpService } from './acbs-http.service';
+import { AcbsGetFacilityGuaranteesResponseDto } from './dto/acbs-get-facility-guarantees-response.dto';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { createWrapAcbsHttpGetErrorCallback } from './wrap-acbs-http-error-callback';
+
+export class AcbsFacilityGuaranteeService {
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(config: AcbsConfigBaseUrl, httpService: HttpService) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
+
+  async getGuaranteesForFacility(portfolioIdentifier: string, facilityIdentifier: string, idToken: string): Promise<AcbsGetFacilityGuaranteesResponseDto> {
+    const { data: guarantees } = await this.acbsHttpService.get<AcbsGetFacilityGuaranteesResponseDto>({
+      path: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityGuarantee`,
+      idToken,
+      onError: createWrapAcbsHttpGetErrorCallback({
+        messageForUnknownError: `Failed to get the guarantees for the facility with identifier ${facilityIdentifier}.`,
+        knownErrors: [],
+      }),
+    });
+
+    if (guarantees === null) {
+      throw new AcbsResourceNotFoundException(`Guarantees for facility with identifier ${facilityIdentifier} were not found by ACBS.`);
+    }
+
+    return guarantees;
+  }
+}

--- a/src/modules/acbs/acbs-facility-party.service.ts
+++ b/src/modules/acbs/acbs-facility-party.service.ts
@@ -1,9 +1,9 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsCreateFacilityPartyDto } from './dto/acbs-create-facility-party.dto';
 import { getFacilityNotFoundKnownAcbsError } from './known-errors';
@@ -13,7 +13,7 @@ import { createWrapAcbsHttpPostErrorCallback } from './wrap-acbs-http-error-call
 export class AcbsFacilityPartyService {
   private readonly acbsHttpService: AcbsHttpService;
 
-  constructor(@Inject(AcbsConfig.KEY) config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, httpService: HttpService) {
+  constructor(@Inject(AcbsConfig.KEY) config: AcbsConfigBaseUrl, httpService: HttpService) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);
   }
 

--- a/src/modules/acbs/acbs-party-external-rating.service.ts
+++ b/src/modules/acbs/acbs-party-external-rating.service.ts
@@ -1,8 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsPartyExternalRatingsResponseDto } from './dto/acbs-party-external-ratings-response.dto';
 import { getPartyNotFoundKnownAcbsError } from './known-errors';
@@ -14,7 +14,7 @@ export class AcbsPartyExternalRatingService {
 
   constructor(
     @Inject(AcbsConfig.KEY)
-    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    config: AcbsConfigBaseUrl,
     httpService: HttpService,
   ) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);

--- a/src/modules/acbs/acbs-party.service.ts
+++ b/src/modules/acbs/acbs-party.service.ts
@@ -1,8 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
 import { AcbsGetPartyResponseDto } from './dto/acbs-get-party-response.dto';
 import { getPartyNotFoundKnownAcbsError } from './known-errors';
@@ -14,7 +14,7 @@ export class AcbsPartyService {
 
   constructor(
     @Inject(AcbsConfig.KEY)
-    config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>,
+    config: AcbsConfigBaseUrl,
     httpService: HttpService,
   ) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);

--- a/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
@@ -1,0 +1,16 @@
+import { DateString } from '@ukef/helpers';
+
+export type AcbsGetFacilityGuaranteesResponseDto = AcbsGetFacilityGuaranteeDto[];
+
+export interface AcbsGetFacilityGuaranteeDto {
+  EffectiveDate: DateString;
+  GuarantorParty: {
+    PartyIdentifier: string;
+  };
+  LimitKey: string;
+  ExpirationDate: DateString;
+  GuaranteedLimit: number;
+  GuaranteeType: {
+    GuaranteeTypeCode: string;
+  };
+}


### PR DESCRIPTION
## Introduction
As part of migrating the `GET /facilities/{facilityId}/guarantees` endpoint, we need to be able to get facility guarantees for a facility from ACBS.

Note this does not _complete_ APIM-122, that will be done by adding an endpoint that uses this service afterwards.

## Resolution
I've created `AcbsFacilityGuaranteeService` in the `acbs` module for doing this.

Unfortunately the GET endpoint we use from ACBS has surprising behaviour:
- (A) if you try to get the guarantees for a facility that doesn't exist, then you get a `200 OK` response where the response body is `null`
- (B) if you try to get the guarantees for a facility that does exist, then you get one of:
   1. a `200 OK` response where the response body is an array of guarantees
   2. a `200 OK` response where the response body is an empty array 
   3. a `200 OK` response where the response body is `null`

(B.3) is problematic because this is also the response for (A), so if we get `200 OK` with a `null` response body then we do not know if the facility exists or not.

My plan is to handle this as follows:

- (A): return a 404
- (B)
   1. return a 200 with the guarantees array
   2. return a 200 with an empty array
   3. return a 404


For reference, Mulesoft currently handles this as follows:

- (A) return a 200 status code _with a response body that says it is actually a 404_
- (B)
   1. return a 200 with the guarantees array
   2. return a 200 status code _with a response body that says it is actually a 404_
   3. return a 200 status code _with a response body that says it is actually a 404_

so this is an improvement over the current behaviour


## Misc
All of our ACBS services use a common type to get the base URL from the config: I've commonised this into a type alias.