### PR TITLE
feat(APIM-122): add endpoint to get guarantees for a facility

### DIFF
--- a/src/modules/acbs/acbs-facility-guarantee.service.test.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.test.ts
@@ -14,7 +14,7 @@ describe('AcbsFacilityGuaranteeService', () => {
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
   const portfolioIdentifier = valueGenerator.string({ length: 2 });
-  const facilityIdentifier = valueGenerator.ukefId();
+  const facilityIdentifier = valueGenerator.facilityId();
 
   let httpService: HttpService;
   let service: AcbsFacilityGuaranteeService;

--- a/src/modules/acbs/acbs-facility-guarantee.service.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.ts
@@ -1,4 +1,6 @@
 import { HttpService } from '@nestjs/axios';
+import { Inject } from '@nestjs/common';
+import AcbsConfig from '@ukef/config/acbs.config';
 
 import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
 import { AcbsHttpService } from './acbs-http.service';
@@ -9,7 +11,7 @@ import { createWrapAcbsHttpGetErrorCallback } from './wrap-acbs-http-error-callb
 export class AcbsFacilityGuaranteeService {
   private readonly acbsHttpService: AcbsHttpService;
 
-  constructor(config: AcbsConfigBaseUrl, httpService: HttpService) {
+  constructor(@Inject(AcbsConfig.KEY) config: AcbsConfigBaseUrl, httpService: HttpService) {
     this.acbsHttpService = new AcbsHttpService(config, httpService);
   }
 

--- a/src/modules/acbs/acbs-facility-party.service.test.ts
+++ b/src/modules/acbs/acbs-facility-party.service.test.ts
@@ -15,7 +15,7 @@ describe('AcbsFacilityPartyService', () => {
   const valueGenerator = new RandomValueGenerator();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const facilityIdentifier = valueGenerator.stringOfNumericCharacters();
+  const facilityIdentifier = valueGenerator.facilityId();
   const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
 
   const newFacilityParty = generateAcbsCreateFacilityPartyDtoUsing(valueGenerator);

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -8,6 +8,7 @@ import { AcbsDealService } from './acbs-deal.service';
 import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
 import { AcbsDealPartyService } from './acbs-deal-party.service';
 import { AcbsFacilityService } from './acbs-facility.service';
+import { AcbsFacilityGuaranteeService } from './acbs-facility-guarantee.service';
 import { AcbsFacilityPartyService } from './acbs-facility-party.service';
 import { AcbsPartyService } from './acbs-party.service';
 import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.service';
@@ -31,8 +32,9 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsDealService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
-    AcbsFacilityPartyService,
     AcbsFacilityService,
+    AcbsFacilityGuaranteeService,
+    AcbsFacilityPartyService,
   ],
   exports: [
     AcbsAuthenticationModule,
@@ -41,8 +43,9 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsDealService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
-    AcbsFacilityPartyService,
     AcbsFacilityService,
+    AcbsFacilityGuaranteeService,
+    AcbsFacilityPartyService,
   ],
 })
 export class AcbsModule {}

--- a/src/modules/facility-guarantee/dto/get-facility-guarantees-params.dto.ts
+++ b/src/modules/facility-guarantee/dto/get-facility-guarantees-params.dto.ts
@@ -1,0 +1,13 @@
+import { EXAMPLES } from '@ukef/constants';
+import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
+import { UkefId } from '@ukef/helpers';
+
+export class GetFacilityGuaranteesParamsDto {
+  @ValidatedStringApiProperty({
+    description: 'The identifier of the facility in ACBS.',
+    example: EXAMPLES.FACILITY_ID,
+    length: 10,
+    pattern: /^00\d{8}$/,
+  })
+  facilityIdentifier: UkefId;
+}

--- a/src/modules/facility-guarantee/dto/get-facility-guarantees-response.dto.ts
+++ b/src/modules/facility-guarantee/dto/get-facility-guarantees-response.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EXAMPLES, PROPERTIES } from '@ukef/constants';
+import { DateOnlyString } from '@ukef/helpers';
+
+export type GetFacilityGuaranteesResponse = GetFacilityGuaranteesResponseItem[];
+
+export class GetFacilityGuaranteesResponseItem {
+  @ApiProperty({
+    description: 'The identifier of the facility.',
+    example: EXAMPLES.FACILITY_ID,
+  })
+  facilityIdentifier: string;
+
+  @ApiProperty({
+    description: 'The identifier of the portfolio.',
+    example: PROPERTIES.GLOBAL.portfolioIdentifier,
+  })
+  portfolioIdentifier: string;
+
+  @ApiProperty({
+    description: 'The date that this guarantee will take effect.',
+    type: Date,
+    format: 'date',
+  })
+  guaranteeCommencementDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'The date that this guarantee will take effect. This is always equal to the guaranteeCommencementDate.',
+    type: Date,
+    format: 'date',
+  })
+  effectiveDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'The ACBS party identifier of the guarantor, the customer who is making the guarantee/obligation.',
+    example: EXAMPLES.PARTY_ID,
+  })
+  guarantorParty: string;
+
+  @ApiProperty({
+    description: 'An ACBS party identifier.',
+    example: EXAMPLES.PARTY_ID,
+  })
+  limitKey: string;
+
+  @ApiProperty({
+    description: 'The date the guarantee for this customer will expire.',
+    type: Date,
+    format: 'date',
+  })
+  guaranteeExpiryDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'The maximum amount the guarantor will guarantee.',
+  })
+  maximumLiability: number;
+
+  @ApiProperty({
+    description: 'The identifier for the type of the guarantee.',
+    example: '315',
+  })
+  guaranteeTypeCode: string;
+}

--- a/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
@@ -32,7 +32,7 @@ describe('FacilityGuaranteeController', () => {
     it('returns the guarantees from the service', async () => {
       when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesFromService);
 
-      const guarantees = await controller.getGuaranteesForFacility(facilityIdentifier);
+      const guarantees = await controller.getGuaranteesForFacility({ facilityIdentifier });
 
       expect(guarantees).toStrictEqual(guaranteesFromService);
     });
@@ -44,7 +44,7 @@ describe('FacilityGuaranteeController', () => {
       }));
       when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesWithAnUnexpectedKey);
 
-      const guarantees = await controller.getGuaranteesForFacility(facilityIdentifier);
+      const guarantees = await controller.getGuaranteesForFacility({ facilityIdentifier });
 
       expect(guarantees).toStrictEqual(guaranteesFromService);
     });

--- a/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
@@ -17,20 +17,20 @@ describe('FacilityGuaranteeController', () => {
     portfolioIdentifier,
   });
 
-  let facilityGuaranteeServiceGetGuaranteesForFacility: jest.Mock;
+  let getFacilityGuaranteesService: jest.Mock;
   let controller: FacilityGuaranteeController;
 
   beforeEach(() => {
     const facilityGuaranteeService = new FacilityGuaranteeService(null, null, null);
-    facilityGuaranteeServiceGetGuaranteesForFacility = jest.fn();
-    facilityGuaranteeService.getGuaranteesForFacility = facilityGuaranteeServiceGetGuaranteesForFacility;
+    getFacilityGuaranteesService = jest.fn();
+    facilityGuaranteeService.getGuaranteesForFacility = getFacilityGuaranteesService;
 
     controller = new FacilityGuaranteeController(facilityGuaranteeService);
   });
 
   describe('getGuaranteesForFacility', () => {
     it('returns the guarantees from the service', async () => {
-      when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesFromService);
+      when(getFacilityGuaranteesService).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesFromService);
 
       const guarantees = await controller.getGuaranteesForFacility({ facilityIdentifier });
 
@@ -42,7 +42,7 @@ describe('FacilityGuaranteeController', () => {
         ...guarantee,
         unexpectedKey: valueGenerator.string(),
       }));
-      when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesWithAnUnexpectedKey);
+      when(getFacilityGuaranteesService).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesWithAnUnexpectedKey);
 
       const guarantees = await controller.getGuaranteesForFacility({ facilityIdentifier });
 

--- a/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
@@ -1,0 +1,52 @@
+import { GetFacilityGuaranteesGenerator } from '@ukef-test/support/generator/get-facility-guarantees.generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { FacilityGuaranteeController } from './facility-guarantee.controller';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeController', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const portfolioIdentifier = valueGenerator.string();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  const { facilityGuarantees: guaranteesFromService } = new GetFacilityGuaranteesGenerator(valueGenerator, new DateStringTransformations()).generate({
+    numberToGenerate: 2,
+    facilityIdentifier,
+    portfolioIdentifier,
+  });
+
+  let facilityGuaranteeServiceGetGuaranteesForFacility: jest.Mock;
+  let controller: FacilityGuaranteeController;
+
+  beforeEach(() => {
+    const facilityGuaranteeService = new FacilityGuaranteeService(null, null, null);
+    facilityGuaranteeServiceGetGuaranteesForFacility = jest.fn();
+    facilityGuaranteeService.getGuaranteesForFacility = facilityGuaranteeServiceGetGuaranteesForFacility;
+
+    controller = new FacilityGuaranteeController(facilityGuaranteeService);
+  });
+
+  describe('getGuaranteesForFacility', () => {
+    it('returns the guarantees from the service', async () => {
+      when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesFromService);
+
+      const guarantees = await controller.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual(guaranteesFromService);
+    });
+
+    it('does NOT return unexpected keys returned from the service', async () => {
+      const guaranteesWithAnUnexpectedKey = guaranteesFromService.map((guarantee) => ({
+        ...guarantee,
+        unexpectedKey: valueGenerator.string(),
+      }));
+      when(facilityGuaranteeServiceGetGuaranteesForFacility).calledWith(facilityIdentifier).mockResolvedValueOnce(guaranteesWithAnUnexpectedKey);
+
+      const guarantees = await controller.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual(guaranteesFromService);
+    });
+  });
+});

--- a/src/modules/facility-guarantee/facility-guarantee.controller.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+
+import { GetFacilityGuaranteesParamsDto } from './dto/get-facility-guarantees-params.dto';
+import { GetFacilityGuaranteesResponse, GetFacilityGuaranteesResponseItem } from './dto/get-facility-guarantees-response.dto';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+@Controller()
+export class FacilityGuaranteeController {
+  constructor(private readonly facilityGuaranteeService: FacilityGuaranteeService) {}
+  @Get('/facilities/:facilityIdentifier/guarantees')
+  @ApiOperation({
+    summary: 'Get all guarantees for a facility.',
+  })
+  @ApiOkResponse({
+    description: 'The guarantees for the facility have been successfully retrieved.',
+    type: GetFacilityGuaranteesResponseItem,
+    isArray: true,
+  })
+  @ApiBadRequestResponse({
+    description: 'The specified facilityIdentifier is not valid.',
+  })
+  @ApiNotFoundResponse({
+    description:
+      'The specified facility, or the guarantees for that facility, were not found. (Due to limitations of ACBS, a 404 response does not guarantee that the facility does not exist.)',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An internal server error has occurred.',
+  })
+  async getGuaranteesForFacility(@Param() params: GetFacilityGuaranteesParamsDto): Promise<GetFacilityGuaranteesResponse> {
+    const guaranteesForFacility = await this.facilityGuaranteeService.getGuaranteesForFacility(params.facilityIdentifier);
+    return guaranteesForFacility.map((guarantee) => ({
+      facilityIdentifier: guarantee.facilityIdentifier,
+      portfolioIdentifier: guarantee.portfolioIdentifier,
+      guaranteeCommencementDate: guarantee.guaranteeCommencementDate,
+      effectiveDate: guarantee.effectiveDate,
+      guarantorParty: guarantee.guarantorParty,
+      limitKey: guarantee.limitKey,
+      guaranteeExpiryDate: guarantee.guaranteeExpiryDate,
+      maximumLiability: guarantee.maximumLiability,
+      guaranteeTypeCode: guarantee.guaranteeTypeCode,
+    }));
+  }
+}

--- a/src/modules/facility-guarantee/facility-guarantee.interface.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.interface.ts
@@ -1,0 +1,13 @@
+import { DateOnlyString } from '@ukef/helpers';
+
+export interface FacilityGuarantee {
+  facilityIdentifier: string;
+  portfolioIdentifier: string;
+  guaranteeCommencementDate: DateOnlyString;
+  effectiveDate: DateOnlyString;
+  guarantorParty: string;
+  limitKey: string;
+  guaranteeExpiryDate: DateOnlyString;
+  maximumLiability: number;
+  guaranteeTypeCode: string;
+}

--- a/src/modules/facility-guarantee/facility-guarantee.module.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
+import { DateModule } from '@ukef/modules/date/date.module';
+
+import { FacilityGuaranteeController } from './facility-guarantee.controller';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+@Module({
+  imports: [AcbsModule, DateModule],
+  controllers: [FacilityGuaranteeController],
+  providers: [FacilityGuaranteeService],
+})
+export class FacilityGuaranteeModule {}

--- a/src/modules/facility-guarantee/facility-guarantee.service.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.test.ts
@@ -1,0 +1,60 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsFacilityGuaranteeService } from '@ukef/modules/acbs/acbs-facility-guarantee.service';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { GetFacilityGuaranteesGenerator } from '@ukef-test/support/generator/get-facility-guarantees.generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeService', () => {
+  const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  const { facilityGuarantees: expectedFacilityGuarantees, facilityGuaranteesInAcbs } = new GetFacilityGuaranteesGenerator(
+    valueGenerator,
+    new DateStringTransformations(),
+  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
+
+  let acbsAuthenticationService: AcbsAuthenticationService;
+  let service: FacilityGuaranteeService;
+
+  let acbsFacilityGuaranteeServiceGetGuaranteesForFacility: jest.Mock;
+
+  beforeEach(() => {
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    const acbsService = new AcbsFacilityGuaranteeService(null, null);
+    acbsFacilityGuaranteeServiceGetGuaranteesForFacility = jest.fn();
+    acbsService.getGuaranteesForFacility = acbsFacilityGuaranteeServiceGetGuaranteesForFacility;
+
+    service = new FacilityGuaranteeService(acbsAuthenticationService, acbsService, new DateStringTransformations());
+  });
+
+  describe('getGuaranteesForFacility', () => {
+    it('returns a transformation of the guarantees from ACBS', async () => {
+      when(acbsFacilityGuaranteeServiceGetGuaranteesForFacility)
+        .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
+        .mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual(expectedFacilityGuarantees);
+    });
+
+    it('returns an empty array if ACBS returns an empty array', async () => {
+      when(acbsFacilityGuaranteeServiceGetGuaranteesForFacility).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
+
+      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual([]);
+    });
+  });
+});

--- a/src/modules/facility-guarantee/facility-guarantee.service.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.test.ts
@@ -23,7 +23,7 @@ describe('FacilityGuaranteeService', () => {
   let acbsAuthenticationService: AcbsAuthenticationService;
   let service: FacilityGuaranteeService;
 
-  let acbsFacilityGuaranteeServiceGetGuaranteesForFacility: jest.Mock;
+  let getFacilityGuaranteesAcbsService: jest.Mock;
 
   beforeEach(() => {
     const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
@@ -32,17 +32,15 @@ describe('FacilityGuaranteeService', () => {
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
 
     const acbsService = new AcbsFacilityGuaranteeService(null, null);
-    acbsFacilityGuaranteeServiceGetGuaranteesForFacility = jest.fn();
-    acbsService.getGuaranteesForFacility = acbsFacilityGuaranteeServiceGetGuaranteesForFacility;
+    getFacilityGuaranteesAcbsService = jest.fn();
+    acbsService.getGuaranteesForFacility = getFacilityGuaranteesAcbsService;
 
     service = new FacilityGuaranteeService(acbsAuthenticationService, acbsService, new DateStringTransformations());
   });
 
   describe('getGuaranteesForFacility', () => {
     it('returns a transformation of the guarantees from ACBS', async () => {
-      when(acbsFacilityGuaranteeServiceGetGuaranteesForFacility)
-        .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
-        .mockResolvedValueOnce(facilityGuaranteesInAcbs);
+      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
 
       const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
 
@@ -50,7 +48,7 @@ describe('FacilityGuaranteeService', () => {
     });
 
     it('returns an empty array if ACBS returns an empty array', async () => {
-      when(acbsFacilityGuaranteeServiceGetGuaranteesForFacility).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
+      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
 
       const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
 

--- a/src/modules/facility-guarantee/facility-guarantee.service.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsFacilityGuaranteeService } from '@ukef/modules/acbs/acbs-facility-guarantee.service';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+
+import { FacilityGuarantee } from './facility-guarantee.interface';
+
+@Injectable()
+export class FacilityGuaranteeService {
+  constructor(
+    private readonly acbsAuthenticationService: AcbsAuthenticationService,
+    private readonly acbsFacilityGuaranteeService: AcbsFacilityGuaranteeService,
+    private readonly dateStringTransformations: DateStringTransformations,
+  ) {}
+
+  async getGuaranteesForFacility(facilityIdentifier: string): Promise<FacilityGuarantee[]> {
+    const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+    const idToken = await this.acbsAuthenticationService.getIdToken();
+    const guaranteesInAcbs = await this.acbsFacilityGuaranteeService.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+    return guaranteesInAcbs.map((guarantee) => {
+      const effectiveDateOnly = this.dateStringTransformations.removeTimeIfExists(guarantee.EffectiveDate);
+      const expirationDateOnly = this.dateStringTransformations.removeTimeIfExists(guarantee.ExpirationDate);
+      return {
+        facilityIdentifier,
+        portfolioIdentifier,
+        guaranteeCommencementDate: effectiveDateOnly,
+        effectiveDate: effectiveDateOnly,
+        guarantorParty: guarantee.GuarantorParty.PartyIdentifier,
+        limitKey: guarantee.LimitKey,
+        guaranteeExpiryDate: expirationDateOnly,
+        maximumLiability: guarantee.GuaranteedLimit,
+        guaranteeTypeCode: guarantee.GuaranteeType.GuaranteeTypeCode,
+      };
+    });
+  }
+}

--- a/src/modules/facility-investor/facility-investor.controller.test.ts
+++ b/src/modules/facility-investor/facility-investor.controller.test.ts
@@ -24,7 +24,7 @@ describe('FacilityInvestorController', () => {
   });
 
   describe('createInvestorForFacility', () => {
-    const facilityIdentifier = valueGenerator.stringOfNumericCharacters();
+    const facilityIdentifier = valueGenerator.facilityId();
 
     const effectiveDate = TEST_DATES.A_FUTURE_EFFECTIVE_DATE_ONLY;
     const guaranteeExpiryDate = TEST_DATES.A_FUTURE_EXPIRY_DATE_ONLY;

--- a/src/modules/facility-investor/facility-investor.service.test.ts
+++ b/src/modules/facility-investor/facility-investor.service.test.ts
@@ -1,13 +1,13 @@
 import { PROPERTIES } from '@ukef/constants';
 import { AcbsFacilityPartyService } from '@ukef/modules/acbs/acbs-facility-party.service';
+import { AcbsCreateFacilityPartyDto } from '@ukef/modules/acbs/dto/acbs-create-facility-party.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
 import { TEST_CURRENCIES } from '@ukef-test/support/constants/test-currency.constant';
 import { TEST_DATES } from '@ukef-test/support/constants/test-date.constant';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { AcbsCreateFacilityPartyDto } from '../acbs/dto/acbs-create-facility-party.dto';
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { FacilityInvestorService } from './facility-investor.service';
 
 describe('FacilityInvestorService', () => {
@@ -33,7 +33,7 @@ describe('FacilityInvestorService', () => {
   });
 
   describe('createInvestorForFacility', () => {
-    const facilityIdentifier = valueGenerator.stringOfNumericCharacters();
+    const facilityIdentifier = valueGenerator.facilityId();
     const sectionIdentifier = PROPERTIES.FACILITY_INVESTOR.DEFAULT.sectionIdentifier;
     const facilityStatusCode = PROPERTIES.FACILITY_INVESTOR.DEFAULT.facilityStatus.facilityStatusCode;
     const involvedPartyIdentifier = PROPERTIES.FACILITY_INVESTOR.DEFAULT.involvedParty.partyIdentifier;

--- a/src/modules/tfs.module.ts
+++ b/src/modules/tfs.module.ts
@@ -6,6 +6,7 @@ import { DealModule } from '@ukef/modules/deal/deal.module';
 import { DealGuaranteeModule } from '@ukef/modules/deal-guarantee/deal-guarantee.module';
 import { DealInvestorModule } from '@ukef/modules/deal-investor/deal-investor.module';
 import { FacilityModule } from '@ukef/modules/facility/facility.module';
+import { FacilityGuaranteeModule } from '@ukef/modules/facility-guarantee/facility-guarantee.module';
 import { FacilityInvestorModule } from '@ukef/modules/facility-investor/facility-investor.module';
 import { PartyModule } from '@ukef/modules/party/party.module';
 import { PartyExternalRatingModule } from '@ukef/modules/party-external-rating/party-external-rating.module';
@@ -20,6 +21,7 @@ import { AcbsExceptionTransformInterceptor } from './acbs-adapter/acbs-exception
     DealGuaranteeModule,
     DealInvestorModule,
     FacilityModule,
+    FacilityGuaranteeModule,
     FacilityInvestorModule,
     PartyExternalRatingModule,
     PartyModule,

--- a/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests.ts
+++ b/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests.ts
@@ -1,0 +1,81 @@
+import request from 'supertest';
+
+const expectedFacilityIdentifierMustMatchPatternErrorMessage = `facilityIdentifier must match /^00\\d{8}$/ regular expression`;
+
+export const withFacilityIdentifierUrlParamValidationApiTests = ({
+  makeRequestWithFacilityId,
+  givenRequestWouldOtherwiseSucceedForFacilityId,
+}: {
+  makeRequestWithFacilityId: (facilityId: string) => request.Test;
+  givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId: string) => void;
+}): void => {
+  it('returns a 400 response if the facilityId in the URL has fewer than 10 digits', async () => {
+    const fewerThan10Digits = '001234567';
+    givenRequestWouldOtherwiseSucceedForFacilityId(fewerThan10Digits);
+
+    const { status, body } = await makeRequestWithFacilityId(fewerThan10Digits);
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Bad Request',
+      message: expect.arrayContaining([`facilityIdentifier must be longer than or equal to 10 characters`]),
+      statusCode: 400,
+    });
+  });
+
+  it('returns a 400 response if the facilityId in the URL has more than 10 digits', async () => {
+    const moreThan10Digits = '00123456789';
+    givenRequestWouldOtherwiseSucceedForFacilityId(moreThan10Digits);
+
+    const { status, body } = await makeRequestWithFacilityId(moreThan10Digits);
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Bad Request',
+      message: expect.arrayContaining([`facilityIdentifier must be shorter than or equal to 10 characters`]),
+      statusCode: 400,
+    });
+  });
+
+  it('returns a 400 response if the facilityId in the URL has an alphabetic character', async () => {
+    const withAnAlphaCharacter = '00123a4567';
+    givenRequestWouldOtherwiseSucceedForFacilityId(withAnAlphaCharacter);
+
+    const { status, body } = await makeRequestWithFacilityId(withAnAlphaCharacter);
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Bad Request',
+      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+      statusCode: 400,
+    });
+  });
+
+  it('returns a 400 response if the facilityId in the URL has a non-alphanumeric character', async () => {
+    const withAnNonAlphaNumericCharacter = '0012345!78';
+    givenRequestWouldOtherwiseSucceedForFacilityId(withAnNonAlphaNumericCharacter);
+
+    const { status, body } = await makeRequestWithFacilityId(withAnNonAlphaNumericCharacter);
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Bad Request',
+      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+      statusCode: 400,
+    });
+  });
+
+  it('returns a 400 response if the facilityId in the URL does not start with 00', async () => {
+    const doesNotStartWith00 = '0112345678';
+    givenRequestWouldOtherwiseSucceedForFacilityId(doesNotStartWith00);
+
+    const { status, body } = await makeRequestWithFacilityId(doesNotStartWith00);
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Bad Request',
+      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+      statusCode: 400,
+    });
+  });
+};

--- a/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests.ts
+++ b/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests.ts
@@ -1,3 +1,4 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import request from 'supertest';
 
 const expectedFacilityIdentifierMustMatchPatternErrorMessage = `facilityIdentifier must match /^00\\d{8}$/ regular expression`;
@@ -5,10 +6,24 @@ const expectedFacilityIdentifierMustMatchPatternErrorMessage = `facilityIdentifi
 export const withFacilityIdentifierUrlParamValidationApiTests = ({
   makeRequestWithFacilityId,
   givenRequestWouldOtherwiseSucceedForFacilityId,
+  successStatusCode,
 }: {
   makeRequestWithFacilityId: (facilityId: string) => request.Test;
   givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId: string) => void;
+  successStatusCode?: number;
 }): void => {
+  const valueGenerator = new RandomValueGenerator();
+  const expectedSuccessStatusCode = successStatusCode ?? 200;
+
+  it(`returns a ${expectedSuccessStatusCode} response if the facilityId in the URL is valid`, async () => {
+    const validFacilityId = valueGenerator.facilityId();
+    givenRequestWouldOtherwiseSucceedForFacilityId(validFacilityId);
+
+    const { status } = await makeRequestWithFacilityId(validFacilityId);
+
+    expect(status).toBe(expectedSuccessStatusCode);
+  });
+
   it('returns a 400 response if the facilityId in the URL has fewer than 10 digits', async () => {
     const fewerThan10Digits = '001234567';
     givenRequestWouldOtherwiseSucceedForFacilityId(fewerThan10Digits);

--- a/test/deal/get-deal-by-deal-identifier.api-test.ts
+++ b/test/deal/get-deal-by-deal-identifier.api-test.ts
@@ -145,7 +145,7 @@ describe('GET /deals/{dealIdentifier}', () => {
     });
   });
 
-  it('returns a 500 response if getting the party from ACBS returns a status code that is NOT 200', async () => {
+  it('returns a 500 response if getting the deal from ACBS returns a status code that is NOT 200', async () => {
     givenAuthenticationWithTheIdpSucceeds();
     requestToGetDeal().reply(401);
 

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -169,6 +169,39 @@ paths:
           description: The specified facility was not found.
         '500':
           description: An internal server error has occurred.
+  /api/v1/facilities/{facilityIdentifier}/guarantees:
+    get:
+      operationId: FacilityGuaranteeController_getGuaranteesForFacility
+      summary: Get all guarantees for a facility.
+      parameters:
+        - name: facilityIdentifier
+          required: true
+          in: path
+          description: The identifier of the facility in ACBS.
+          example: '0000000001'
+          schema:
+            minLength: 10
+            maxLength: 10
+            pattern: ^00\\d{8}$
+            type: string
+      responses:
+        '200':
+          description: The guarantees for the facility have been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFacilityGuaranteesResponseItem'
+        '400':
+          description: The specified facilityIdentifier is not valid.
+        '404':
+          description: >-
+            The specified facility, or the guarantees for that facility, were
+            not found. (Due to limitations of ACBS, a 404 response does not
+            guarantee that the facility does not exist.)
+        '500':
+          description: An internal server error has occurred.
   /api/v1/facilities/{facilityIdentifier}/investors:
     post:
       operationId: FacilityInvestorController_createInvestorForFacility
@@ -723,6 +756,58 @@ components:
         - obligorName
         - obligorIndustryClassification
         - probabilityOfDefault
+    GetFacilityGuaranteesResponseItem:
+      type: object
+      properties:
+        facilityIdentifier:
+          type: string
+          description: The identifier of the facility.
+          example: '0000000001'
+        portfolioIdentifier:
+          type: string
+          description: The identifier of the portfolio.
+          example: E1
+        guaranteeCommencementDate:
+          format: date
+          type: string
+          description: The date that this guarantee will take effect.
+        effectiveDate:
+          format: date
+          type: string
+          description: >-
+            The date that this guarantee will take effect. This is always equal
+            to the guaranteeCommencementDate.
+        guarantorParty:
+          type: string
+          description: >-
+            The ACBS party identifier of the guarantor, the customer who is
+            making the guarantee/obligation.
+          example: '00000001'
+        limitKey:
+          type: string
+          description: An ACBS party identifier.
+          example: '00000001'
+        guaranteeExpiryDate:
+          format: date
+          type: string
+          description: The date the guarantee for this customer will expire.
+        maximumLiability:
+          type: number
+          description: The maximum amount the guarantor will guarantee.
+        guaranteeTypeCode:
+          type: string
+          description: The identifier for the type of the guarantee.
+          example: '315'
+      required:
+        - facilityIdentifier
+        - portfolioIdentifier
+        - guaranteeCommencementDate
+        - effectiveDate
+        - guarantorParty
+        - limitKey
+        - guaranteeExpiryDate
+        - maximumLiability
+        - guaranteeTypeCode
     CreateFacilityInvestorRequestItem:
       type: object
       properties:

--- a/test/facility-guarantee/get-facility-guarantees.api-test.ts
+++ b/test/facility-guarantee/get-facility-guarantees.api-test.ts
@@ -1,0 +1,128 @@
+import { PROPERTIES } from '@ukef/constants';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withFacilityIdentifierUrlParamValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
+import { GetFacilityGuaranteesGenerator } from '@ukef-test/support/generator/get-facility-guarantees.generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+describe('GET /facilities/{facilityIdentifier}/guarantees', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const facilityIdentifier = valueGenerator.facilityId();
+  const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
+
+  const getGetFacilityGuaranteesUrlForFacilityId = (facilityId: string) => `/api/v1/facilities/${facilityId}/guarantees`;
+
+  const getFacilityGuaranteesUrl = getGetFacilityGuaranteesUrlForFacilityId(facilityIdentifier);
+
+  const { facilityGuarantees: expectedFacilityGuarantees, facilityGuaranteesInAcbs } = new GetFacilityGuaranteesGenerator(
+    valueGenerator,
+    new DateStringTransformations(),
+  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => requestToGetGuaranteesForFacility().reply(200, facilityGuaranteesInAcbs),
+    makeRequest: () => api.get(getFacilityGuaranteesUrl),
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      requestToGetGuaranteesForFacility().reply(200, facilityGuaranteesInAcbs);
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.getWithoutAuth(getFacilityGuaranteesUrl, incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  withFacilityIdentifierUrlParamValidationApiTests({
+    givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
+      givenAuthenticationWithTheIdpSucceeds();
+      requestToGetGuaranteesForFacilityWithId(facilityId).reply(200, facilityGuaranteesInAcbs);
+    },
+    makeRequestWithFacilityId: (facilityId) => api.get(getGetFacilityGuaranteesUrlForFacilityId(facilityId)),
+  });
+
+  it('returns a 200 response with the facility guarantees if they are returned by ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacility().reply(200, facilityGuaranteesInAcbs);
+
+    const { status, body } = await api.get(getFacilityGuaranteesUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(expectedFacilityGuarantees);
+  });
+
+  it('returns a 200 response with an empty array if ACBS returns a 200 response with an empty array', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacility().reply(200, []);
+
+    const { status, body } = await api.get(getFacilityGuaranteesUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual([]);
+  });
+
+  it('returns a 404 response if ACBS returns a 200 response with null as the response body', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacility().reply(200, null);
+
+    const { status, body } = await api.get(getFacilityGuaranteesUrl);
+
+    expect(status).toBe(404);
+    expect(body).toStrictEqual({
+      statusCode: 404,
+      message: 'Not found',
+    });
+  });
+
+  it('returns a 500 response if getting the facility guarantees from ACBS returns a status code that is NOT 200', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacility().reply(401);
+
+    const { status, body } = await api.get(getFacilityGuaranteesUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns a 500 response if getting the facility guarantees from ACBS times out', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacility().delay(TIME_EXCEEDING_ACBS_TIMEOUT).reply(200, facilityGuaranteesInAcbs);
+
+    const { status, body } = await api.get(getFacilityGuaranteesUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  const requestToGetGuaranteesForFacilityWithId = (facilityId: string): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .get(`/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/FacilityGuarantee`)
+      .matchHeader('authorization', `Bearer ${idToken}`);
+
+  const requestToGetGuaranteesForFacility = (): nock.Interceptor => requestToGetGuaranteesForFacilityWithId(facilityIdentifier);
+});

--- a/test/facility-investor/post-facility-investor.api-test.ts
+++ b/test/facility-investor/post-facility-investor.api-test.ts
@@ -1,5 +1,6 @@
 import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { CreateFacilityInvestorRequest } from '@ukef/modules/facility-investor/dto/create-facility-investor-request.dto';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
 import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
@@ -16,7 +17,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
   const valueGenerator = new RandomValueGenerator();
   const dateStringTransformations = new DateStringTransformations();
   const portfolioIdentifier = PROPERTIES.GLOBAL.portfolioIdentifier;
-  const facilityIdentifier = valueGenerator.ukefId();
+  const facilityIdentifier = valueGenerator.facilityId();
   const createFacilityInvestorUrl = `/api/v1/facilities/${facilityIdentifier}/investors`;
 
   const sectionIdentifier = PROPERTIES.FACILITY_INVESTOR.DEFAULT.sectionIdentifier;
@@ -30,7 +31,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
   const limitTypeCode = valueGenerator.stringOfNumericCharacters({ minLength: 1, maxLength: 2 });
   const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 10 });
 
-  const requestBodyToCreateFacilityInvestor = [
+  const requestBodyToCreateFacilityInvestor: CreateFacilityInvestorRequest = [
     {
       facilityIdentifier,
       effectiveDate: effectiveDateInFuture,

--- a/test/support/generator/get-facility-guarantees.generator.ts
+++ b/test/support/generator/get-facility-guarantees.generator.ts
@@ -1,0 +1,83 @@
+import { DateString } from '@ukef/helpers';
+import { AcbsGetFacilityGuaranteesResponseDto } from '@ukef/modules/acbs/dto/acbs-get-facility-guarantees-response.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { GetFacilityGuaranteesResponse } from '@ukef/modules/facility-guarantee/dto/get-facility-guarantees-response.dto';
+import { FacilityGuarantee } from '@ukef/modules/facility-guarantee/facility-guarantee.interface';
+
+import { AbstractGenerator } from './abstract-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class GetFacilityGuaranteesGenerator extends AbstractGenerator<FacilityGuaranteeValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator, protected readonly dateStringTransformations: DateStringTransformations) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): FacilityGuaranteeValues {
+    return {
+      effectiveDateInAcbs: this.valueGenerator.dateTimeString(),
+      guarantorPartyIdentifier: this.valueGenerator.stringOfNumericCharacters({ length: 8 }),
+      limitKey: this.valueGenerator.string(),
+      expirationDateInAcbs: this.valueGenerator.dateTimeString(),
+      guaranteedLimit: this.valueGenerator.nonnegativeFloat(),
+      guaranteeTypeCode: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(
+    values: FacilityGuaranteeValues[],
+    { facilityIdentifier, portfolioIdentifier }: GenerateOptions,
+  ): GenerateResult {
+    const facilityGuaranteesInAcbs: AcbsGetFacilityGuaranteesResponseDto = values.map((v) => ({
+      EffectiveDate: v.effectiveDateInAcbs,
+      GuarantorParty: {
+        PartyIdentifier: v.guarantorPartyIdentifier,
+      },
+      LimitKey: v.limitKey,
+      ExpirationDate: v.expirationDateInAcbs,
+      GuaranteedLimit: v.guaranteedLimit,
+      GuaranteeType: {
+        GuaranteeTypeCode: v.guaranteeTypeCode,
+      },
+    }));
+
+    const facilityGuarantees: FacilityGuarantee[] = values.map((v) => ({
+      facilityIdentifier,
+      portfolioIdentifier,
+      guaranteeCommencementDate: this.dateStringTransformations.removeTime(v.effectiveDateInAcbs),
+      effectiveDate: this.dateStringTransformations.removeTime(v.effectiveDateInAcbs),
+      guarantorParty: v.guarantorPartyIdentifier,
+      limitKey: v.limitKey,
+      guaranteeExpiryDate: this.dateStringTransformations.removeTime(v.expirationDateInAcbs),
+      maximumLiability: v.guaranteedLimit,
+      guaranteeTypeCode: v.guaranteeTypeCode,
+    }));
+
+    const facilityGuaranteesFromApi: GetFacilityGuaranteesResponse = facilityGuarantees;
+
+    return {
+      facilityGuaranteesInAcbs,
+      facilityGuarantees,
+      facilityGuaranteesFromApi,
+    };
+  }
+}
+
+interface FacilityGuaranteeValues {
+  effectiveDateInAcbs: DateString;
+  guarantorPartyIdentifier: string;
+  limitKey: string;
+  expirationDateInAcbs: DateString;
+  guaranteedLimit: number;
+  guaranteeTypeCode: string;
+}
+
+interface GenerateOptions {
+  facilityIdentifier: string;
+  portfolioIdentifier: string;
+}
+
+interface GenerateResult {
+  facilityGuaranteesInAcbs: AcbsGetFacilityGuaranteesResponseDto;
+  facilityGuarantees: FacilityGuarantee[];
+  facilityGuaranteesFromApi: GetFacilityGuaranteesResponse;
+}

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -69,6 +69,10 @@ export class RandomValueGenerator {
     return this.integer({ min: 0, max });
   }
 
+  facilityId(): UkefId {
+    return this.ukefId();
+  }
+
   // UKEF id example 0030000321. It should be used for Deal and Facility IDs.
   ukefId(lengthExcludingPrefix?: number): UkefId {
     return (UKEFID.MAIN_ID_PREFIX.DEV + this.stringOfNumericCharacters({ length: lengthExcludingPrefix ?? 6 })) as UkefId;


### PR DESCRIPTION
## Introduction
The `GET /facility/{facilityIdentifier}/guarantee` endpoint in Mulesoft allows you to get all guarantees for a facility. I have migrated this to `GET /facilities/{facilityIdentifier}/guarantees` in the TFS API

## Resolution

This endpoint:
1. Validates that the specified `facilityIdentifier` has 10 characters and matches `/^00\d{8}$`
2. Gets an id token for ACBS.
3. Uses the id token to `GET /Portfolio/E1/Facility/{facilityIdentifier}/FacilityGuarantee` from ACBS
4. Transforms the response the same way that Mulesoft does:
5. Returns a 200 with the data.

Note that ACBS has strange behaviour for this endpoint, it will return a 200 response with a response body of `null` if the facility does not exist, but it will also do it for some facilities that _do_ exist. Our TFS endpoint will return a 404 in this case.