### PR TITLE
feat(APIM-184): control log level with environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,8 @@ PORT=
 
 # App
 NODE_ENV=development
-TZ=Europe/London 
+TZ=Europe/London
+LOG_LEVEL=info
 
 # Swagger
 SWAGGER_USER=

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -114,7 +114,7 @@ jobs:
               "PORT=${{ secrets.PORT }}" \
               "NODE_ENV=${{ secrets.NODE_ENV }}" \
               "TZ=${{ secrets.TZ }}" \
-              "LOG_LEVEL=${{ secrets.LOG_LEVEL }}" \
+              "LOG_LEVEL=${{ vars.LOG_LEVEL }}" \
               "SWAGGER_USER=${{ secrets.SWAGGER_USER }}" \
               "SWAGGER_PASSWORD=${{ secrets.SWAGGER_PASSWORD }}" \
               "API_KEY=${{ secrets.API_KEY }}" \

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -114,6 +114,7 @@ jobs:
               "PORT=${{ secrets.PORT }}" \
               "NODE_ENV=${{ secrets.NODE_ENV }}" \
               "TZ=${{ secrets.TZ }}" \
+              "LOG_LEVEL=${{ secrets.LOG_LEVEL }}" \
               "SWAGGER_USER=${{ secrets.SWAGGER_USER }}" \
               "SWAGGER_PASSWORD=${{ secrets.SWAGGER_PASSWORD }}" \
               "API_KEY=${{ secrets.API_KEY }}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       PORT:
       NODE_ENV:
       TZ:
+      LOG_LEVEL:
       SWAGGER_USER:
       SWAGGER_PASSWORD:
       API_KEY:

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -1,0 +1,75 @@
+import appConfig from './app.config';
+import { InvalidConfigException } from './invalid-config.exception';
+
+describe('appConfig', () => {
+  let originalProcessEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalProcessEnv = process.env;
+  });
+
+  afterEach(() => {
+    process.env = originalProcessEnv;
+  });
+
+  it('throws an InvalidConfigException if LOG_LEVEL is specified but is not a valid log level', () => {
+    process.env = {
+      LOG_LEVEL: 'not-a-real-log-level',
+    };
+
+    const gettingTheAppConfig = () => appConfig();
+
+    expect(gettingTheAppConfig).toThrow(InvalidConfigException);
+    expect(gettingTheAppConfig).toThrow(`LOG_LEVEL must be one of fatal,error,warn,info,debug,trace,silent or not specified.`);
+  });
+
+  it('uses info as the logLevel if LOG_LEVEL is not specified', () => {
+    process.env = {};
+
+    const config = appConfig();
+
+    expect(config.logLevel).toBe('info');
+  });
+
+  it('uses info as the logLevel if LOG_LEVEL is empty', () => {
+    process.env = {
+      LOG_LEVEL: '',
+    };
+
+    const config = appConfig();
+
+    expect(config.logLevel).toBe('info');
+  });
+
+  it.each([
+    {
+      LOG_LEVEL: 'fatal',
+    },
+    {
+      LOG_LEVEL: 'error',
+    },
+    {
+      LOG_LEVEL: 'warn',
+    },
+    {
+      LOG_LEVEL: 'info',
+    },
+    {
+      LOG_LEVEL: 'debug',
+    },
+    {
+      LOG_LEVEL: 'trace',
+    },
+    {
+      LOG_LEVEL: 'silent',
+    },
+  ])('uses LOG_LEVEL as the logLevel if LOG_LEVEL is valid ($LOG_LEVEL)', ({ LOG_LEVEL }) => {
+    process.env = {
+      LOG_LEVEL,
+    };
+
+    const config = appConfig();
+
+    expect(config.logLevel).toBe(LOG_LEVEL);
+  });
+});

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -2,9 +2,17 @@ import './load-dotenv';
 
 import { registerAs } from '@nestjs/config';
 
-export default registerAs(
-  'app',
-  (): Record<string, any> => ({
+import { InvalidConfigException } from './invalid-config.exception';
+
+const validLogLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'];
+
+export default registerAs('app', (): Record<string, any> => {
+  const logLevel = process.env.LOG_LEVEL || 'info';
+  if (!validLogLevels.includes(logLevel)) {
+    throw new InvalidConfigException(`LOG_LEVEL must be one of ${validLogLevels} or not specified.`);
+  }
+
+  return {
     name: process.env.APP_NAME || 'tfs',
     env: process.env.NODE_ENV || 'development',
 
@@ -18,5 +26,5 @@ export default registerAs(
     port: process.env.HTTP_PORT ? Number.parseInt(process.env.HTTP_PORT, 10) : 3001,
     apiKey: process.env.API_KEY,
     logLevel: process.env.LOG_LEVEL || 'info',
-  }),
-);
+  };
+});

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -17,5 +17,6 @@ export default registerAs(
     globalPrefix: '/api',
     port: process.env.HTTP_PORT ? Number.parseInt(process.env.HTTP_PORT, 10) : 3001,
     apiKey: process.env.API_KEY,
+    logLevel: process.env.LOG_LEVEL || 'info',
   }),
 );

--- a/src/config/invalid-config.exception.ts
+++ b/src/config/invalid-config.exception.ts
@@ -1,0 +1,5 @@
+export class InvalidConfigException extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/main.module.ts
+++ b/src/main.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import config from '@ukef/config';
 import { TfsModule } from '@ukef/modules/tfs.module';
 import { LoggerModule } from 'nestjs-pino';
@@ -10,18 +10,23 @@ import { LoggerModule } from 'nestjs-pino';
       isGlobal: true,
       load: [...config],
     }),
-    LoggerModule.forRoot({
-      pinoHttp: {
-        customProps: () => ({
-          context: 'HTTP',
-        }),
-        transport: {
-          target: 'pino-pretty',
-          options: {
-            singleLine: true,
+    LoggerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        pinoHttp: {
+          customProps: () => ({
+            context: 'HTTP',
+          }),
+          level: config.get<string>('app.logLevel'),
+          transport: {
+            target: 'pino-pretty',
+            options: {
+              singleLine: true,
+            },
           },
         },
-      },
+      }),
     }),
     TfsModule,
   ],

--- a/test/support/environment-variables.ts
+++ b/test/support/environment-variables.ts
@@ -4,6 +4,7 @@ const valueGenerator = new RandomValueGenerator();
 
 export const ENVIRONMENT_VARIABLES = Object.freeze({
   NODE_ENV: 'test',
+  LOG_LEVEL: 'debug',
 
   SWAGGER_USER: valueGenerator.string(),
   SWAGGER_PASSWORD: valueGenerator.string(),


### PR DESCRIPTION
## Introduction

Currently the application logs at info level and above, but there is no way to configure this during development / for each deployment.

## Resolution

I've added an environment variable, LOG_LEVEL, for configuring the log level. `app.config.ts` validates that it is a valid log level to be used.