### PR TITLE
feat(APIM-249): CICD E2E execution

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,7 +40,7 @@ The workflow consists of four jobs:
 * 🔬 The `api-tests` job runs API tests using npm.
 * 👨‍💻 The `e2e-tests` job runs E2E tests using npm and Docker.
 
-The workflow is triggered whenever a pull request is made to the `main` branch, and the changes made in the pull request are tested using the three types of tests mentioned above. The tests are run on an Ubuntu machine with Node.js version 18 installed.
+The workflow is triggered whenever a pull request is made to the `main` branch, and the changes made (defined in the `paths`) in the pull request are tested using the three types of tests mentioned above. The tests are run on an Ubuntu machine with Node.js version 18 installed.
 
 Overall, this workflow provides a comprehensive test suite to ensure the quality of code changes made in the main branch of the repository.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,7 +27,7 @@ The "codacy" job uses the Codacy analysis CLI action to perform SCA for code qua
 Secrets, such as the Fossa API key, are assumed to be set up beforehand in the repository's secrets.
 
 ## TEST
-This is a GitHub Actions workflow performs QA and then runs three different types of tests on a pull request on the main branch:
+This is a GitHub Actions workflow that performs QA and then runs three different types of tests on a pull request on the `main` branch:
 
 * Unit tests
 * API tests

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,9 +27,22 @@ The "codacy" job uses the Codacy analysis CLI action to perform SCA for code qua
 Secrets, such as the Fossa API key, are assumed to be set up beforehand in the repository's secrets.
 
 ## TEST
-This is a GitHub Actions YAML file that is responsible for initiating unit tests (Jest) and API tests (Jest) upon a pull request (PR) creation on the main branch. 
-The first job, "setup," sets environment variables for the dev environment, a London timezone, and Node.js version 18. It also outputs these variables for later jobs to use.
-The second job, "unit-tests," runs on the ubuntu-latest operating system and executes the unit tests. It uses the output from the "setup" job to set the environment name and timezone, checks out the repository, sets up Node.js, installs dependencies using npm ci, and executes the unit tests using npm run unit-test.
+This is a GitHub Actions workflow performs QA and then runs three different types of tests on a pull request on the main branch:
+
+* Unit tests
+* API tests
+* End to end (E2E) tests.
+
+The workflow consists of four jobs:
+
+* ⚙️ The `setup` job sets up the environment for the subsequent tests by outputting the `environment` and `timezone` variables.
+* 🧪 The `unit-tests` job runs unit tests using npm, which is a package manager for Node.js.
+* 🔬 The `api-tests` job runs API tests using npm.
+* 👨‍💻 The `e2e-tests` job runs E2E tests using npm and Docker.
+
+The workflow is triggered whenever a pull request is made to the `main` branch, and the changes made in the pull request are tested using the three types of tests mentioned above. The tests are run on an Ubuntu machine with Node.js version 18 installed.
+
+Overall, this workflow provides a comprehensive test suite to ensure the quality of code changes made in the main branch of the repository.
 
 ## Lint
 This code is a GitHub Actions YAML file that is responsible for initiating linting checks upon a pull request (PR) creation on the main branch for a Node.js project. The on event is set to pull_request with specified branches and paths. The file has two jobs; "setup" and "lint". The "setup" job sets environment variables for the dev environment, a London timezone, and Node.js version 18, then output these variables for later jobs to use. The "lint" job runs on the ubuntu-latest operating system, sets up the environment name and timezone using the output from the "setup" job, checks out the repository, sets up Node.js, installs dependencies, and executes the linting using npm run lint.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@
 # upon a PR creation. Following test suites are executed:
 # 1. Unit tests (Jest)
 # 2. API tests (Jest)
+# 3. E2E tests (Jest)
 
 name: Quality Assurance - Tests
 run-name: Executing test QA on ${{ github.repository }} 🚀
@@ -92,3 +93,59 @@ jobs:
       - name: Execute
         working-directory: ./
         run: npm run api-test
+
+# 4. E2E tests
+  e2e-tests:
+    name: E2E 🧑‍💻
+    needs: setup
+    environment:
+      name: ${{ needs.setup.outputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Timezone
+        uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: ${{ needs.setup.outputs.timezone }}
+      
+      - name: Repository
+        uses: actions/checkout@v3
+
+      - name: Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node }}
+
+      - name: Dependencies
+        working-directory: ./
+        run: npm ci
+
+      - name: Docker
+        working-directory: ./
+        env:
+          PORT: ${{ secrets.PORT }}
+          NODE_ENV: ${{ secrets.NODE_ENV }}
+          TZ: ${{ secrets.TZ }}
+          LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+          SWAGGER_USER: ${{ secrets.SWAGGER_USER }}
+          SWAGGER_PASSWORD: ${{ secrets.SWAGGER_PASSWORD }}
+          ACBS_BASE_URL: ${{ secrets.ACBS_BASE_URL }}
+          ACBS_MAX_REDIRECTS: ${{ secrets.ACBS_MAX_REDIRECTS }}
+          ACBS_TIMEOUT: ${{ secrets.ACBS_TIMEOUT }}
+          ACBS_AUTHENTICATION_API_KEY: ${{ secrets.ACBS_AUTHENTICATION_API_KEY }}
+          ACBS_AUTHENTICATION_API_KEY_HEADER_NAME: ${{ secrets.ACBS_AUTHENTICATION_API_KEY_HEADER_NAME }}
+          ACBS_AUTHENTICATION_BASE_URL: ${{ secrets.ACBS_AUTHENTICATION_BASE_URL }}
+          ACBS_AUTHENTICATION_CLIENT_ID: ${{ secrets.ACBS_AUTHENTICATION_CLIENT_ID }}
+          ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL_IN_MILLISECONDS: ${{ secrets.ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL_IN_MILLISECONDS }}
+          ACBS_AUTHENTICATION_LOGIN_NAME: ${{ secrets.ACBS_AUTHENTICATION_LOGIN_NAME }}
+          ACBS_AUTHENTICATION_MAX_REDIRECTS: ${{ secrets.ACBS_AUTHENTICATION_MAX_REDIRECTS }}
+          ACBS_AUTHENTICATION_PASSWORD: ${{ secrets.ACBS_AUTHENTICATION_PASSWORD }}
+          ACBS_AUTHENTICATION_RETRY_DELAY_IN_MILLISECONDS: ${{ secrets.ACBS_AUTHENTICATION_RETRY_DELAY_IN_MILLISECONDS }}
+          ACBS_AUTHENTICATION_TIMEOUT: ${{ secrets.ACBS_AUTHENTICATION_TIMEOUT }}
+          ACBS_AUTHENTICATION_MAX_NUMBER_OF_RETRIES: ${{ secrets.ACBS_AUTHENTICATION_MAX_NUMBER_OF_RETRIES }}
+          API_KEY: ${{ secrets.API_KEY }}
+          API_KEY_STRATEGY: ${{ secrets.API_KEY_STRATEGY }}
+        run: docker-compose up --build -d
+
+      - name: Execute
+        working-directory: ./
+        run: npm run e2e-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,15 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-    - '**'
+      - '.github/workflows/test.yml'
+      - 'src/**'
+      - 'test/**'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'package*'
+      - 'tsconfig*'
+      - 'jest.config.ts'
+      - 'nest.cli.json'
 
 env:
   environment: dev

--- a/README.md
+++ b/README.md
@@ -7,6 +7,33 @@ TFS micro-service provides endpoints for internal trade finance manager systems 
 npm install
 ```
 
+## Compilation / Build
+
+### tsconfig.build.json
+# TypeScript Configuration ⚙️
+This file configures how TypeScript compiles your code.
+
+## Extends 🔱
+The `extends` property specifies the path to the base configuration file which is set to `./tsconfig.json`.
+
+## Compiler Options 🔧
+The `compilerOptions` property specifies the compiler options.
+
+* `types` specifies the types that should be included in the compilation, `node` in this case.
+
+## Include 📂
+The `include` property specifies the files that should be included in the compilation.
+
+## Exclude 🚫
+The `exclude` property specifies the files that should be excluded from the compilation.
+
+* `node_modules` excludes the `node_modules` directory.
+* `test` excludes the `test` directory and all files that end with `.test.ts`.
+* `dist` excludes the `dist` directory.
+* `docker-compose*.yml` excludes all files that start with `docker-compose` and end with `.yml`.
+* `Dockerfile` excludes the `Dockerfile` file.
+* `logs` excludes the `logs` directory.
+
 ## Run 💡
 
 How to run `tfs` on local environment as `dev` runtime mode.
@@ -27,7 +54,7 @@ We are running several test suites as part of our CI/CD pipeline.
 
 * Unit test :   These tests are written using Jest and ends with `*.test.ts` extension.
 * API test  :   These tests are written using Jest and ends with `*.api-test.ts` extension.
-* E2E test  :   These tests are written using Cypress and ends with `*.spec.ts` extension. Currently there are *no* E2E tests and none are executed during CI/CD.
+* E2E test  :   These tests are written using Cypress and ends with `*.e2e-test.ts` extension. Currently there are **no** E2E tests and none are executed during CI/CD.
 
 ```bash
 # unit tests

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We are running several test suites as part of our CI/CD pipeline.
 
 * Unit test :   These tests are written using Jest and ends with `*.test.ts` extension.
 * API test  :   These tests are written using Jest and ends with `*.api-test.ts` extension.
-* E2E test  :   These tests are written using Cypress and ends with `*.e2e-test.ts` extension.
+* E2E test  :   These tests are written using Jest and ends with `*.e2e-test.ts` extension.
 
 ### NOTE ⚠️
 Currently there are **no** E2E tests and none are executed during CI/CD. Once tests have been added please remove `--passWithNoTests` flag from `e2e-tests` scripts, current flags allows Jest to exit with status instead of an error.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ We are running several test suites as part of our CI/CD pipeline.
 
 * Unit test :   These tests are written using Jest and ends with `*.test.ts` extension.
 * API test  :   These tests are written using Jest and ends with `*.api-test.ts` extension.
-* E2E test  :   These tests are written using Cypress and ends with `*.e2e-test.ts` extension. Currently there are **no** E2E tests and none are executed during CI/CD.
+* E2E test  :   These tests are written using Cypress and ends with `*.e2e-test.ts` extension.
+
+### NOTE ⚠️
+Currently there are **no** E2E tests and none are executed during CI/CD. Once tests have been added please remove `--passWithNoTests` flag from `e2e-tests` scripts, current flags allows Jest to exit with status instead of an error.
 
 ```bash
 # unit tests

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,6 +34,13 @@ const config: JestConfigWithTsJest = {
       transform: { '^.+\\.(ts|tsx)?$': ['ts-jest', { useESM: true }] },
       ...defaultSettings,
     },
+    {
+      displayName: 'E2E',
+      setupFilesAfterEnv: ['./setup/override-environment-variables.ts'],
+      testMatch: ['**/*.e2e-test.ts'],
+      transform: { '^.+\\.(ts|tsx)?$': ['ts-jest', { useESM: true }] },
+      ...defaultSettings,
+    },
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "UKEF",
   "scripts": {
     "api-test": "jest --coverage --selectProjects=API",
-    "e2e-test": "jest --coverage --selectProjects=E2E",
     "build": "nest build -p tsconfig.build.json",
+    "e2e-test": "jest --coverage --selectProjects=E2E",
     "postinstall": "husky install",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "UKEF",
   "scripts": {
     "api-test": "jest --coverage --selectProjects=API",
+    "e2e-test": "jest --coverage --selectProjects=E2E",
     "build": "nest build -p tsconfig.build.json",
     "postinstall": "husky install",
     "lint": "eslint . --ext .ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "api-test": "jest --coverage --selectProjects=API",
     "build": "nest build -p tsconfig.build.json",
-    "e2e-test": "jest --coverage --selectProjects=E2E",
+    "e2e-test": "jest --passWithNoTests --coverage --selectProjects=E2E",
     "postinstall": "husky install",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,23 +1,22 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": ["node"]
-  },
-  "include": ["src", "jest.config.ts"],
-  "exclude": [
-    // NPM
-    "node_modules",
-    // Unit, API and E2E tests
-    "test",
-    "**/*.test.ts",
-    "**/*.test-parts",
-    "**/*.spec.ts",
-    // Build
-    "dist",
-    // Docker
-    "docker-compose*.yml",
-    "Dockerfile",
-    // Logs
-    "logs"
-  ]
-}
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "types": ["node"]
+    },
+    "include": ["src", "jest.config.ts"],
+    "exclude": [
+      // NPM
+      "node_modules",
+      // Unit, API and E2E tests
+      "test",
+      "**/*.test.ts",
+      "**/*.test-parts",
+      // Build
+      "dist",
+      // Docker
+      "docker-compose*.yml",
+      "Dockerfile",
+      // Logs
+      "logs"
+    ]
+  }


### PR DESCRIPTION
## Introduction 🗒️ 
Docker build and run processes are not being triggered as part of the CI/CD pipeline.

## Resolution 🚀 
* Added `e2e-tests` job to the QA workflow, which will trigger docker build and run processes.
* Introduced `.e2e-test.ts` extensions for end-to-end tests with actual requests to ACBS.
* Updated and enhanced documentation pertaining to test QA and TS  compilation.

## Note ⚠️ 
* Currently `e2e-tests` script is executed with `--passWithNoTests` flag since no `*.e2e-test.ts` exist, once introduced flag should be removed and relevant documentation should be updated.