### PR TITLE
feat: added GET `/facility/{facilityId}/fixedFee` endpoint

### DIFF
--- a/src/constants/enum.constant.ts
+++ b/src/constants/enum.constant.ts
@@ -1,5 +1,6 @@
 import * as COVENANT_TYPE_CODES from './enums/covenant-type-code';
 import * as GUARANTEE_TYPE_CODES from './enums/guarantee-type-code';
+import * as INCOME_CLASS_CODES from './enums/income-class-code';
 import * as LENDER_TYPE_CODES from './enums/lender-type-code';
 import * as PORTFOLIO from './enums/portfolio';
 import * as PRODUCT_TYPE_GROUPS from './enums/product-type-group';
@@ -9,7 +10,8 @@ export const ENUMS = {
   LENDER_TYPE_CODES: LENDER_TYPE_CODES.LenderTypeCodeEnum,
   PORTFOLIO: PORTFOLIO.PortfolioEnum,
   COVENANT_TYPE_CODES: COVENANT_TYPE_CODES.CovenantTypeCodeEnum,
-  GUARANTEE_TYPE_CODES: GUARANTEE_TYPE_CODES.guaranteeTypeCodeEnum,
   PRODUCT_TYPE_IDS: PRODUCT_TYPE_IDS.ProductTypeIdEnum,
   PRODUCT_TYPE_GROUPS: PRODUCT_TYPE_GROUPS.ProductTypeGroupEnum,
+  GUARANTEE_TYPE_CODES: GUARANTEE_TYPE_CODES.GuaranteeTypeCodeEnum,
+  INCOME_CLASS_CODES: INCOME_CLASS_CODES.IncomeClassCodeEnum,
 };

--- a/src/constants/enums/guarantee-type-code.ts
+++ b/src/constants/enums/guarantee-type-code.ts
@@ -1,7 +1,7 @@
 /**
  * ACBS table T1080 has more values, but just these are used by DTFS.
  */
-export enum guaranteeTypeCodeEnum {
+export enum GuaranteeTypeCodeEnum {
   BOND_GIVER = '315',
   BOND_BENEFICIARY = '310',
   FACILITY_PROVIDER = '500',

--- a/src/constants/enums/income-class-code.ts
+++ b/src/constants/enums/income-class-code.ts
@@ -1,0 +1,6 @@
+// These enums are as specified in the documentation, however note that these appear incomplete
+export enum IncomeClassCodeEnum {
+  BPM = 'BPM',
+  EPM = 'EMP',
+  FGT = 'FGT',
+}

--- a/src/modules/acbs/acbs-deal-party.service.ts
+++ b/src/modules/acbs/acbs-deal-party.service.ts
@@ -49,7 +49,7 @@ export class AcbsDealPartyService {
         messageForUnknownError: `Failed to create an investor for deal ${dealIdentifier} in ACBS.`,
         knownErrors: [
           {
-            substringToFind: 'The deal not found',
+            caseInsensitiveSubstringToFind: 'The deal not found',
             throwError: (error) => {
               throw new AcbsResourceNotFoundException(`Deal with identifier ${dealIdentifier} was not found by ACBS.`, error);
             },

--- a/src/modules/acbs/acbs-facility-fixed-fee.service.test.ts
+++ b/src/modules/acbs/acbs-facility-fixed-fee.service.test.ts
@@ -1,0 +1,97 @@
+import { HttpService } from '@nestjs/axios';
+import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { AcbsFacilityFixedFeeService } from './acbs-facility-fixed-fee.service';
+import { AcbsException } from './exception/acbs.exception';
+
+describe('AcbsFacilityFixedFeeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  let httpService: HttpService;
+  let service: AcbsFacilityFixedFeeService;
+
+  let httpServiceGet: jest.Mock;
+
+  const expectedHttpServiceGetArgs = [
+    `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/Fee`,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}` },
+    },
+  ];
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
+    service = new AcbsFacilityFixedFeeService({ baseUrl }, httpService);
+  });
+
+  const { acbsFacilityFixedFees: facilityFixedFeesInAcbs } = new GetFacilityFixedFeeGenerator(valueGenerator, new DateStringTransformations()).generate({
+    numberToGenerate: 2,
+    facilityIdentifier,
+    portfolioIdentifier,
+  });
+
+  describe('getFixedFeesForFacility', () => {
+    it('returns the fixed fees for the facility from ACBS if ACBS responds with the fixed fees', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: facilityFixedFeesInAcbs,
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const fixedFees = await service.getFixedFeesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(fixedFees).toBe(facilityFixedFeesInAcbs);
+    });
+
+    it('returns an empty array if ACBS responds with an empty array', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: [],
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const fixedFees = await service.getFixedFeesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(fixedFees).toStrictEqual([]);
+    });
+
+    it('throws an AcbsException if the request to ACBS fails', async () => {
+      const getFixedFeesForFacilityError = new AxiosError();
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(throwError(() => getFixedFeesForFacilityError));
+
+      const getFixedFeesForFacilityPromise = service.getFixedFeesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      await expect(getFixedFeesForFacilityPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getFixedFeesForFacilityPromise).rejects.toThrow(`Failed to get the fixed fees for the facility with identifier ${facilityIdentifier}.`);
+      await expect(getFixedFeesForFacilityPromise).rejects.toHaveProperty('innerError', getFixedFeesForFacilityError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-facility-fixed-fee.service.ts
+++ b/src/modules/acbs/acbs-facility-fixed-fee.service.ts
@@ -1,0 +1,29 @@
+import { HttpService } from '@nestjs/axios';
+import { Inject } from '@nestjs/common';
+import AcbsConfig from '@ukef/config/acbs.config';
+
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
+import { AcbsHttpService } from './acbs-http.service';
+import { AcbsGetFacilityFixedFeeResponseDto } from './dto/acbs-get-facility-fixed-fee-response.dto';
+import { createWrapAcbsHttpGetErrorCallback } from './wrap-acbs-http-error-callback';
+
+export class AcbsFacilityFixedFeeService {
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(@Inject(AcbsConfig.KEY) config: AcbsConfigBaseUrl, httpService: HttpService) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
+
+  async getFixedFeesForFacility(portfolioIdentifier: string, facilityIdentifier: string, idToken: string): Promise<AcbsGetFacilityFixedFeeResponseDto> {
+    const { data: fixedFees } = await this.acbsHttpService.get<AcbsGetFacilityFixedFeeResponseDto>({
+      path: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/Fee`,
+      idToken,
+      onError: createWrapAcbsHttpGetErrorCallback({
+        messageForUnknownError: `Failed to get the fixed fees for the facility with identifier ${facilityIdentifier}.`,
+        knownErrors: [],
+      }),
+    });
+
+    return fixedFees;
+  }
+}

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -8,6 +8,7 @@ import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
 import { AcbsDealPartyService } from './acbs-deal-party.service';
 import { AcbsFacilityService } from './acbs-facility.service';
 import { AcbsFacilityCovenantService } from './acbs-facility-covenant.service';
+import { AcbsFacilityFixedFeeService } from './acbs-facility-fixed-fee.service';
 import { AcbsFacilityGuaranteeService } from './acbs-facility-guarantee.service';
 import { AcbsFacilityLoanService } from './acbs-facility-loan.service';
 import { AcbsFacilityPartyService } from './acbs-facility-party.service';
@@ -34,6 +35,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsDealPartyService,
     AcbsFacilityService,
     AcbsFacilityCovenantService,
+    AcbsFacilityFixedFeeService,
     AcbsFacilityGuaranteeService,
     AcbsFacilityLoanService,
     AcbsFacilityPartyService,
@@ -47,6 +49,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsDealPartyService,
     AcbsFacilityService,
     AcbsFacilityCovenantService,
+    AcbsFacilityFixedFeeService,
     AcbsFacilityGuaranteeService,
     AcbsFacilityLoanService,
     AcbsFacilityPartyService,

--- a/src/modules/acbs/dto/acbs-get-facility-fixed-fee-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-facility-fixed-fee-response.dto.ts
@@ -1,0 +1,23 @@
+import { DateString } from '@ukef/helpers';
+
+export type AcbsGetFacilityFixedFeeResponseDto = AcbsGetFacilityFixedFeeResponseItem[];
+
+export interface AcbsGetFacilityFixedFeeResponseItem {
+  FixedFeeAmount: number;
+  EffectiveDate: DateString;
+  ExpirationDate: DateString;
+  NextDueDate: DateString;
+  NextAccrueToDate: DateString;
+  SegmentIdentifier: string;
+  Description: string;
+  Currency: {
+    CurrencyCode: string;
+  };
+  LenderType: {
+    LenderTypeCode: string;
+  };
+  IncomeClass: {
+    IncomeClassCode: string;
+  };
+  SpreadToInvestorsIndicator: boolean;
+}

--- a/src/modules/acbs/known-errors.ts
+++ b/src/modules/acbs/known-errors.ts
@@ -21,7 +21,7 @@ export const getDealNotFoundKnownAcbsError = (dealIdentifier: string): KnownErro
 });
 
 export const getFacilityNotFoundKnownAcbsError = (facilityIdentifier: string): KnownError => ({
-  substringToFind: 'facility not found', // This is used because ACBS uses the wording 'Facility not found...' for some endpoints and 'The facility not found...' for others.
+  substringToFind: 'acility not found', // This is used because ACBS uses the wording 'Facility not found...' for some endpoints and 'The facility not found...' for others.
   throwError: (error) => {
     throw new AcbsResourceNotFoundException(`Facility with identifier ${facilityIdentifier} was not found by ACBS.`, error);
   },

--- a/src/modules/acbs/known-errors.ts
+++ b/src/modules/acbs/known-errors.ts
@@ -4,24 +4,24 @@ import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-fou
 
 export type KnownErrors = KnownError[];
 
-type KnownError = { substringToFind: string; throwError: (error: AxiosError) => never };
+type KnownError = { caseInsensitiveSubstringToFind: string; throwError: (error: AxiosError) => never };
 
 export const getPartyNotFoundKnownAcbsError = (partyIdentifier: string): KnownError => ({
-  substringToFind: 'Party not found',
+  caseInsensitiveSubstringToFind: 'Party not found',
   throwError: (error) => {
     throw new AcbsResourceNotFoundException(`Party with identifier ${partyIdentifier} was not found by ACBS.`, error);
   },
 });
 
 export const getDealNotFoundKnownAcbsError = (dealIdentifier: string): KnownError => ({
-  substringToFind: 'The deal not found',
+  caseInsensitiveSubstringToFind: 'The deal not found',
   throwError: (error) => {
     throw new AcbsResourceNotFoundException(`Deal with identifier ${dealIdentifier} was not found by ACBS.`, error);
   },
 });
 
 export const getFacilityNotFoundKnownAcbsError = (facilityIdentifier: string): KnownError => ({
-  substringToFind: 'acility not found', // This is used because ACBS uses the wording 'Facility not found...' for some endpoints and 'The facility not found...' for others.
+  caseInsensitiveSubstringToFind: 'Facility not found',
   throwError: (error) => {
     throw new AcbsResourceNotFoundException(`Facility with identifier ${facilityIdentifier} was not found by ACBS.`, error);
   },

--- a/src/modules/acbs/wrap-acbs-http-error-callback.ts
+++ b/src/modules/acbs/wrap-acbs-http-error-callback.ts
@@ -13,8 +13,8 @@ export const createWrapAcbsHttpGetErrorCallback =
   (error: Error) => {
     if (error instanceof AxiosError && error.response && typeof error.response.data === 'string') {
       const errorMessageInLowerCase = error.response.data.toLowerCase();
-      knownErrors.forEach(({ substringToFind, throwError }) => {
-        if (errorMessageInLowerCase.includes(substringToFind.toLowerCase())) {
+      knownErrors.forEach(({ caseInsensitiveSubstringToFind, throwError }) => {
+        if (errorMessageInLowerCase.includes(caseInsensitiveSubstringToFind.toLowerCase())) {
           return throwError(error);
         }
       });
@@ -32,8 +32,8 @@ export const createWrapAcbsHttpPostErrorCallback =
 
     if (typeof error.response.data === 'string') {
       const errorMessageInLowerCase = error.response.data.toLowerCase();
-      knownErrors.forEach(({ substringToFind, throwError }) => {
-        if (errorMessageInLowerCase.includes(substringToFind.toLowerCase())) {
+      knownErrors.forEach(({ caseInsensitiveSubstringToFind, throwError }) => {
+        if (errorMessageInLowerCase.includes(caseInsensitiveSubstringToFind.toLowerCase())) {
           return throwError(error);
         }
       });

--- a/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-params.dto.ts
+++ b/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-params.dto.ts
@@ -1,0 +1,9 @@
+import { ValidatedFacilityIdentifierApiProperty } from '@ukef/decorators/validated-facility-identifier-api-property';
+import { UkefId } from '@ukef/helpers';
+
+export class GetFacilityFixedFeeParamsDto {
+  @ValidatedFacilityIdentifierApiProperty({
+    description: 'The identifier of the facility in ACBS.',
+  })
+  facilityIdentifier: UkefId;
+}

--- a/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
+++ b/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
@@ -1,21 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ENUMS, EXAMPLES } from '@ukef/constants';
 import { LenderTypeCodeEnum } from '@ukef/constants/enums/lender-type-code';
+import { PortfolioEnum } from '@ukef/constants/enums/portfolio';
+import { ValidatedFacilityIdentifierApiProperty } from '@ukef/decorators/validated-facility-identifier-api-property';
+import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
 import { DateOnlyString } from '@ukef/helpers';
 
 export type GetFacilityFixedFeeResponse = GetFacilityFixedFeeResponseItem[];
 export class GetFacilityFixedFeeResponseItem {
-  @ApiProperty({
+  @ValidatedFacilityIdentifierApiProperty({
     description: 'The identifier of the facility.',
-    example: EXAMPLES.FACILITY_ID,
-    minLength: 10,
-    maxLength: 10,
   })
   readonly facilityIdentifier: string;
 
   @ApiProperty({
     description: 'The identifier of the portfolio.',
     example: ENUMS.PORTFOLIO.E1,
+    enum: PortfolioEnum,
   })
   readonly portfolioIdentifier: string;
 
@@ -59,10 +60,9 @@ export class GetFacilityFixedFeeResponseItem {
   })
   readonly nextAccrueToDate: DateOnlyString;
 
-  @ApiProperty({
+  @ValidatedStringApiProperty({
     description: 'Segment identifier from income exposure table. 2 alphanumeric characters.',
-    maxLength: 2,
-    minLength: 2,
+    length: 2,
   })
   readonly period: string;
 

--- a/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
+++ b/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
@@ -1,0 +1,105 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ENUMS, EXAMPLES } from '@ukef/constants';
+import { DateOnlyString } from '@ukef/helpers';
+
+export type GetFacilityFixedFeeResponse = GetFacilityFixedFeeResponseItem[];
+export class GetFacilityFixedFeeResponseItem {
+  @ApiProperty({
+    description: 'The identifier of the facility.',
+    example: EXAMPLES.FACILITY_ID,
+    minLength: 10,
+    maxLength: 10,
+  })
+  readonly facilityIdentifier: string;
+
+  @ApiProperty({
+    description: 'The identifier of the portfolio.',
+    example: ENUMS.PORTFOLIO.E1,
+  })
+  readonly portfolioIdentifier: string;
+
+  @ApiProperty({
+    description: 'The fixed amount to be billed to the client. If a flat amount is charged, this field is required.',
+    example: EXAMPLES.DEAL_OR_FACILITY_VALUE,
+    minimum: 0,
+    maximum: 1e17,
+  })
+  readonly amount: number;
+
+  @ApiProperty({
+    description: 'The effective date of this accruing/Fixed fee schedule.',
+    type: Date,
+    format: 'date',
+    example: '2023-03-24',
+  })
+  readonly effectiveDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'The expiration date of this accruing/Fixed fee schedule.',
+    type: Date,
+    format: 'date',
+    example: '2023-03-24',
+  })
+  readonly expirationDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'Date the next fee bill is due for this fee schedule.',
+    type: Date,
+    format: 'date',
+    example: '2023-03-24',
+  })
+  readonly nextDueDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'End date for the current accrual period. This date can be different than the Next Due Date.',
+    type: Date,
+    format: 'date',
+    example: '2023-03-24',
+  })
+  readonly nextAccrueToDate: DateOnlyString;
+
+  @ApiProperty({
+    description: 'Segment identifier from income exposure table. 2 alphanumeric characters.',
+    maxLength: 2,
+    minLength: 2,
+  })
+  readonly period: string;
+
+  @ApiProperty({
+    description: 'Description of accruing/Fixed fee which is be entered by user.',
+    minLength: 0,
+    maxLength: 35,
+  })
+  readonly description: string;
+
+  @ApiProperty({
+    description:
+      'The currency of Facility Fee, defined in the Currency Definition Table under Systems Administration of Servicing. For example, USD for United States Dollar.',
+    example: EXAMPLES.CURRENCY,
+    minLength: 0,
+    maxLength: 3,
+  })
+  readonly currency: string;
+
+  @ApiProperty({
+    description: 'Defines the code for the role of the party in the Facility for which the fee is created.',
+    example: ENUMS.LENDER_TYPE_CODES.ECGD,
+    minLength: 0,
+    maxLength: 3,
+  })
+  readonly lenderTypeCode: string;
+
+  @ApiProperty({
+    description: 'Defines the code for the fee type of this schedule for reporting and GL purposes.',
+    example: ENUMS.INCOME_CLASS_CODES.BPM,
+    minLength: 0,
+    maxLength: 3,
+  })
+  readonly incomeClassCode: string;
+
+  @ApiProperty({
+    description:
+      'Action indicator to be supplied together with the Fee to control propagation of the fee effects to other investors. Not applicable to output data.',
+  })
+  readonly spreadToInvestorsIndicator: boolean;
+}

--- a/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
+++ b/src/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ENUMS, EXAMPLES } from '@ukef/constants';
+import { LenderTypeCodeEnum } from '@ukef/constants/enums/lender-type-code';
 import { DateOnlyString } from '@ukef/helpers';
 
 export type GetFacilityFixedFeeResponse = GetFacilityFixedFeeResponseItem[];
@@ -83,6 +84,7 @@ export class GetFacilityFixedFeeResponseItem {
 
   @ApiProperty({
     description: 'Defines the code for the role of the party in the Facility for which the fee is created.',
+    enum: LenderTypeCodeEnum,
     example: ENUMS.LENDER_TYPE_CODES.ECGD,
     minLength: 0,
     maxLength: 3,

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.controller.test.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.controller.test.ts
@@ -1,0 +1,40 @@
+import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { FacilityFixedFeeController } from '../facility-fixed-fee/facility-fixed-fee.controller';
+import { FacilityFixedFeeService } from '../facility-fixed-fee/facility-fixed-fee.service';
+
+describe('FacilityFixedFeeController', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const portfolioIdentifier = valueGenerator.string();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  const { apiFacilityFixedFees: serviceFixedFees } = new GetFacilityFixedFeeGenerator(valueGenerator, new DateStringTransformations()).generate({
+    numberToGenerate: 2,
+    facilityIdentifier,
+    portfolioIdentifier,
+  });
+
+  let getFacilityFixedFeesService: jest.Mock;
+  let controller: FacilityFixedFeeController;
+
+  beforeEach(() => {
+    const facilityFixedFeeService = new FacilityFixedFeeService(null, null, null);
+    getFacilityFixedFeesService = jest.fn();
+    facilityFixedFeeService.getFixedFeesForFacility = getFacilityFixedFeesService;
+
+    controller = new FacilityFixedFeeController(facilityFixedFeeService);
+  });
+
+  describe('getFixedFeesForFacility', () => {
+    it('returns the fixed fees from the service', async () => {
+      when(getFacilityFixedFeesService).calledWith(facilityIdentifier).mockResolvedValueOnce(serviceFixedFees);
+
+      const fixedFees = await controller.getFixedFeesForFacility({ facilityIdentifier });
+
+      expect(fixedFees).toStrictEqual(serviceFixedFees);
+    });
+  });
+});

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.controller.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiInternalServerErrorResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+
+import { GetFacilityFixedFeeParamsDto } from './dto/get-facility-fixed-fee-params.dto';
+import { GetFacilityFixedFeeResponse, GetFacilityFixedFeeResponseItem } from './dto/get-facility-fixed-fee-response.dto';
+import { FacilityFixedFeeService } from './facility-fixed-fee.service';
+
+@Controller()
+export class FacilityFixedFeeController {
+  constructor(private readonly facilityFixedFeeService: FacilityFixedFeeService) {}
+  @Get('/facilities/:facilityIdentifier/fixed-fees')
+  @ApiOperation({
+    summary: 'Get all fixed fees for a facility.',
+  })
+  @ApiOkResponse({
+    description: 'The fixed fees for the facility have been successfully retrieved.',
+    type: GetFacilityFixedFeeResponseItem,
+    isArray: true,
+  })
+  @ApiBadRequestResponse({
+    description: 'The specified facilityIdentifier is not valid.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An internal server error has occurred.',
+  })
+  async getFixedFeesForFacility(@Param() params: GetFacilityFixedFeeParamsDto): Promise<GetFacilityFixedFeeResponse> {
+    return await this.facilityFixedFeeService.getFixedFeesForFacility(params.facilityIdentifier);
+  }
+}

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.module.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
+
+import { DateModule } from '../date/date.module';
+import { FacilityFixedFeeController } from './facility-fixed-fee.controller';
+import { FacilityFixedFeeService } from './facility-fixed-fee.service';
+
+@Module({
+  imports: [AcbsModule, DateModule],
+  controllers: [FacilityFixedFeeController],
+  providers: [FacilityFixedFeeService],
+})
+export class FacilityFixedFeeModule {}

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.service.test.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.service.test.ts
@@ -1,0 +1,58 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { AcbsFacilityFixedFeeService } from '../acbs/acbs-facility-fixed-fee.service';
+import { FacilityFixedFeeService } from './facility-fixed-fee.service';
+
+describe('FacilityFixedFeeService', () => {
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  const { apiFacilityFixedFees: expectedFacilityFixedFees, acbsFacilityFixedFees } = new GetFacilityFixedFeeGenerator(
+    valueGenerator,
+    new DateStringTransformations(),
+  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
+
+  let acbsAuthenticationService: AcbsAuthenticationService;
+  let service: FacilityFixedFeeService;
+
+  let getFacilityFixedFeesAcbsService: jest.Mock;
+
+  beforeEach(() => {
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    const acbsService = new AcbsFacilityFixedFeeService(null, null);
+    getFacilityFixedFeesAcbsService = jest.fn();
+    acbsService.getFixedFeesForFacility = getFacilityFixedFeesAcbsService;
+
+    service = new FacilityFixedFeeService(acbsAuthenticationService, acbsService, new DateStringTransformations());
+  });
+
+  describe('getFixedFeesForFacility', () => {
+    it('returns a transformation of the guarantees from ACBS', async () => {
+      when(getFacilityFixedFeesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(acbsFacilityFixedFees);
+
+      const guarantees = await service.getFixedFeesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual(expectedFacilityFixedFees);
+    });
+
+    it('returns an empty array if ACBS returns an empty array', async () => {
+      when(getFacilityFixedFeesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
+
+      const guarantees = await service.getFixedFeesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual([]);
+    });
+  });
+});

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.service.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
+
+import { AcbsFacilityFixedFeeService } from '../acbs/acbs-facility-fixed-fee.service';
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { GetFacilityFixedFeeResponse } from './dto/get-facility-fixed-fee-response.dto';
+
+@Injectable()
+export class FacilityFixedFeeService {
+  constructor(
+    private readonly acbsAuthenticationService: AcbsAuthenticationService,
+    private readonly acbsFacilityFixedFeeService: AcbsFacilityFixedFeeService,
+    private readonly dateStringTransformations: DateStringTransformations,
+  ) {}
+
+  async getFixedFeesForFacility(facilityIdentifier: string): Promise<GetFacilityFixedFeeResponse> {
+    const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+    const idToken = await this.acbsAuthenticationService.getIdToken();
+    const fixedFeesInAcbs = await this.acbsFacilityFixedFeeService.getFixedFeesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+    return fixedFeesInAcbs.map((fixedFee) => {
+      const effectiveDate = this.dateStringTransformations.removeTimeIfExists(fixedFee.EffectiveDate);
+      const expirationDate = this.dateStringTransformations.removeTimeIfExists(fixedFee.ExpirationDate);
+      const nextDueDate = this.dateStringTransformations.removeTimeIfExists(fixedFee.NextDueDate);
+      const nextAccrueToDate = this.dateStringTransformations.removeTimeIfExists(fixedFee.NextAccrueToDate);
+
+      return {
+        facilityIdentifier,
+        portfolioIdentifier,
+        amount: fixedFee.FixedFeeAmount,
+        effectiveDate,
+        expirationDate,
+        nextDueDate,
+        nextAccrueToDate,
+        period: fixedFee.SegmentIdentifier,
+        description: fixedFee.Description,
+        currency: fixedFee.Currency.CurrencyCode,
+        lenderTypeCode: fixedFee.LenderType.LenderTypeCode,
+        incomeClassCode: fixedFee.IncomeClass.IncomeClassCode,
+        spreadToInvestorsIndicator: fixedFee.SpreadToInvestorsIndicator,
+      };
+    });
+  }
+}

--- a/src/modules/tfs.module.ts
+++ b/src/modules/tfs.module.ts
@@ -1,19 +1,19 @@
 import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
+import { AcbsExceptionTransformInterceptor } from '@ukef/modules/acbs-adapter/acbs-exception-transform.interceptor';
 import { AuthModule } from '@ukef/modules/auth/auth.module';
 import { DealModule } from '@ukef/modules/deal/deal.module';
 import { DealGuaranteeModule } from '@ukef/modules/deal-guarantee/deal-guarantee.module';
 import { DealInvestorModule } from '@ukef/modules/deal-investor/deal-investor.module';
 import { FacilityModule } from '@ukef/modules/facility/facility.module';
+import { FacilityCovenantModule } from '@ukef/modules/facility-covenant/facility-covenant.module';
+import { FacilityFixedFeeModule } from '@ukef/modules/facility-fixed-fee/facility-fixed-fee.module';
 import { FacilityGuaranteeModule } from '@ukef/modules/facility-guarantee/facility-guarantee.module';
 import { FacilityInvestorModule } from '@ukef/modules/facility-investor/facility-investor.module';
+import { FacilityLoanModule } from '@ukef/modules/facility-loan/facility-loan.module';
 import { PartyModule } from '@ukef/modules/party/party.module';
 import { PartyExternalRatingModule } from '@ukef/modules/party-external-rating/party-external-rating.module';
-
-import { AcbsExceptionTransformInterceptor } from './acbs-adapter/acbs-exception-transform.interceptor';
-import { FacilityCovenantModule } from './facility-covenant/facility-covenant.module';
-import { FacilityLoanModule } from './facility-loan/facility-loan.module';
 
 @Module({
   imports: [
@@ -24,6 +24,7 @@ import { FacilityLoanModule } from './facility-loan/facility-loan.module';
     DealInvestorModule,
     FacilityModule,
     FacilityCovenantModule,
+    FacilityFixedFeeModule,
     FacilityGuaranteeModule,
     FacilityInvestorModule,
     FacilityLoanModule,

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -279,6 +279,34 @@ paths:
           description: The specified facilityIdentifier is not valid.
         '500':
           description: An internal server error has occurred.
+  /api/v1/facilities/{facilityIdentifier}/fixed-fees:
+    get:
+      operationId: FacilityFixedFeeController_getFixedFeesForFacility
+      summary: Get all fixed fees for a facility.
+      parameters:
+        - name: facilityIdentifier
+          required: true
+          in: path
+          description: The identifier of the facility in ACBS.
+          example: '0030000322'
+          schema:
+            minLength: 10
+            maxLength: 10
+            pattern: ^00\\d{8}$
+            type: string
+      responses:
+        '200':
+          description: The fixed fees for the facility have been successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFacilityFixedFeeResponseItem'
+        '400':
+          description: The specified facilityIdentifier is not valid.
+        '500':
+          description: An internal server error has occurred.
   /api/v1/facilities/{facilityIdentifier}/guarantees:
     get:
       operationId: FacilityGuaranteeController_getGuaranteesForFacility
@@ -1345,6 +1373,106 @@ components:
         - guaranteeCommencementDate
         - effectiveDate
         - guaranteeExpiryDate
+    GetFacilityFixedFeeResponseItem:
+      type: object
+      properties:
+        facilityIdentifier:
+          type: string
+          description: The identifier of the facility.
+          example: '0030000322'
+          minLength: 10
+          maxLength: 10
+        portfolioIdentifier:
+          type: string
+          description: The identifier of the portfolio.
+          example: E1
+        amount:
+          type: number
+          description: >-
+            The fixed amount to be billed to the client. If a flat amount is
+            charged, this field is required.
+          example: 501927.25
+          minimum: 0
+          maximum: 100000000000000000
+        effectiveDate:
+          format: date
+          type: string
+          description: The effective date of this accruing/Fixed fee schedule.
+          example: '2023-03-24'
+        expirationDate:
+          format: date
+          type: string
+          description: The expiration date of this accruing/Fixed fee schedule.
+          example: '2023-03-24'
+        nextDueDate:
+          format: date
+          type: string
+          description: Date the next fee bill is due for this fee schedule.
+          example: '2023-03-24'
+        nextAccrueToDate:
+          format: date
+          type: string
+          description: >-
+            End date for the current accrual period. This date can be different
+            than the Next Due Date.
+          example: '2023-03-24'
+        period:
+          type: string
+          description: >-
+            Segment identifier from income exposure table. 2 alphanumeric
+            characters.
+          maxLength: 2
+          minLength: 2
+        description:
+          type: string
+          description: Description of accruing/Fixed fee which is be entered by user.
+          minLength: 0
+          maxLength: 35
+        currency:
+          type: string
+          description: >-
+            The currency of Facility Fee, defined in the Currency Definition
+            Table under Systems Administration of Servicing. For example, USD
+            for United States Dollar.
+          example: USD
+          minLength: 0
+          maxLength: 3
+        lenderTypeCode:
+          type: string
+          description: >-
+            Defines the code for the role of the party in the Facility for which
+            the fee is created.
+          example: '500'
+          minLength: 0
+          maxLength: 3
+        incomeClassCode:
+          type: string
+          description: >-
+            Defines the code for the fee type of this schedule for reporting and
+            GL purposes.
+          example: BPM
+          minLength: 0
+          maxLength: 3
+        spreadToInvestorsIndicator:
+          type: boolean
+          description: >-
+            Action indicator to be supplied together with the Fee to control
+            propagation of the fee effects to other investors. Not applicable to
+            output data.
+      required:
+        - facilityIdentifier
+        - portfolioIdentifier
+        - amount
+        - effectiveDate
+        - expirationDate
+        - nextDueDate
+        - nextAccrueToDate
+        - period
+        - description
+        - currency
+        - lenderTypeCode
+        - incomeClassCode
+        - spreadToInvestorsIndicator
     GetFacilityGuaranteesResponseItem:
       type: object
       properties:

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1379,13 +1379,16 @@ components:
         facilityIdentifier:
           type: string
           description: The identifier of the facility.
-          example: '0030000322'
           minLength: 10
           maxLength: 10
+          pattern: ^00\\d{8}$
+          example: '0030000322'
         portfolioIdentifier:
           type: string
           description: The identifier of the portfolio.
           example: E1
+          enum:
+            - E1
         amount:
           type: number
           description: >-
@@ -1421,8 +1424,8 @@ components:
           description: >-
             Segment identifier from income exposure table. 2 alphanumeric
             characters.
-          maxLength: 2
           minLength: 2
+          maxLength: 2
         description:
           type: string
           description: Description of accruing/Fixed fee which is be entered by user.

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1442,6 +1442,9 @@ components:
           description: >-
             Defines the code for the role of the party in the Facility for which
             the fee is created.
+          enum:
+            - '100'
+            - '500'
           example: '500'
           minLength: 0
           maxLength: 3

--- a/test/facility-fixed-fee/get-facility-fixed-fees.api-test.ts
+++ b/test/facility-fixed-fee/get-facility-fixed-fees.api-test.ts
@@ -1,0 +1,115 @@
+import { PROPERTIES } from '@ukef/constants';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withFacilityIdentifierUrlParamValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
+import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+describe('GET /facilities/{facilityIdentifier}/fixed-fees', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const facilityIdentifier = valueGenerator.facilityId();
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+
+  const getGetFacilityFixedFeesUrlForFacilityId = (facilityId: string) => `/api/v1/facilities/${facilityId}/fixed-fees`;
+
+  const getFacilityFixedFeesUrl = getGetFacilityFixedFeesUrlForFacilityId(facilityIdentifier);
+
+  const { apiFacilityFixedFees: expectedFacilityFixedFees, acbsFacilityFixedFees } = new GetFacilityFixedFeeGenerator(
+    valueGenerator,
+    new DateStringTransformations(),
+  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => requestToGetFixedFeesForFacility().reply(200, acbsFacilityFixedFees),
+    makeRequest: () => api.get(getFacilityFixedFeesUrl),
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      requestToGetFixedFeesForFacility().reply(200, acbsFacilityFixedFees);
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.getWithoutAuth(getFacilityFixedFeesUrl, incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  withFacilityIdentifierUrlParamValidationApiTests({
+    givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
+      givenAuthenticationWithTheIdpSucceeds();
+      requestToGetFixedFeesForFacilityWithId(facilityId).reply(200, acbsFacilityFixedFees);
+    },
+    makeRequestWithFacilityId: (facilityId) => api.get(getGetFacilityFixedFeesUrlForFacilityId(facilityId)),
+  });
+
+  it('returns a 200 response with the facility fixed fees if they are returned by ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFixedFeesForFacility().reply(200, acbsFacilityFixedFees);
+
+    const { status, body } = await api.get(getFacilityFixedFeesUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(expectedFacilityFixedFees);
+  });
+
+  it('returns a 200 response with an empty array if ACBS returns a 200 response with an empty array', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFixedFeesForFacility().reply(200, []);
+
+    const { status, body } = await api.get(getFacilityFixedFeesUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual([]);
+  });
+
+  it('returns a 500 response if getting the facility fixed fees from ACBS returns a status code that is NOT 200', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFixedFeesForFacility().reply(401);
+
+    const { status, body } = await api.get(getFacilityFixedFeesUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns a 500 response if getting the facility fixed fees from ACBS times out', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFixedFeesForFacility().delay(TIME_EXCEEDING_ACBS_TIMEOUT).reply(200, acbsFacilityFixedFees);
+
+    const { status, body } = await api.get(getFacilityFixedFeesUrl);
+
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  const requestToGetFixedFeesForFacilityWithId = (facilityId: string): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .get(`/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/Fee`)
+      .matchHeader('authorization', `Bearer ${idToken}`);
+
+  const requestToGetFixedFeesForFacility = (): nock.Interceptor => requestToGetFixedFeesForFacilityWithId(facilityIdentifier);
+});

--- a/test/support/generator/get-facility-fixed-fee-generator.ts
+++ b/test/support/generator/get-facility-fixed-fee-generator.ts
@@ -1,0 +1,111 @@
+import { DateString } from '@ukef/helpers';
+import { AcbsGetFacilityFixedFeeResponseDto } from '@ukef/modules/acbs/dto/acbs-get-facility-fixed-fee-response.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { GetFacilityFixedFeeResponse } from '@ukef/modules/facility-fixed-fee/dto/get-facility-fixed-fee-response.dto';
+
+import { AbstractGenerator } from './abstract-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class GetFacilityFixedFeeGenerator extends AbstractGenerator<FacilityFixedFeeValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator, protected readonly dateStringTransformations: DateStringTransformations) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): FacilityFixedFeeValues {
+    return {
+      fixedFeeAmount: this.valueGenerator.nonnegativeFloat({ fixed: 2 }),
+      effectiveDateInAcbs: this.valueGenerator.dateTimeString(),
+      expirationDateInAcbs: this.valueGenerator.dateTimeString(),
+      nextDueDateInAcbs: this.valueGenerator.dateTimeString(),
+      nextAccrueToDateInAcbs: this.valueGenerator.dateTimeString(),
+      segmentIdentifier: this.valueGenerator.stringOfNumericCharacters({ length: 2 }),
+      description: this.valueGenerator.string(),
+      currency: {
+        currencyCode: this.valueGenerator.string(),
+      },
+      lenderType: {
+        lenderTypeCode: this.valueGenerator.string(),
+      },
+      incomeClass: {
+        incomeClassCode: this.valueGenerator.string({ length: 3 }),
+      },
+      spreadToInvestorsIndicator: this.valueGenerator.boolean(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(
+    values: FacilityFixedFeeValues[],
+    { facilityIdentifier, portfolioIdentifier }: GenerateOptions,
+  ): GenerateResult {
+    const acbsFacilityFixedFees: AcbsGetFacilityFixedFeeResponseDto = values.map((acbsFacilityFixedFee) => ({
+      FixedFeeAmount: acbsFacilityFixedFee.fixedFeeAmount,
+      EffectiveDate: acbsFacilityFixedFee.effectiveDateInAcbs,
+      ExpirationDate: acbsFacilityFixedFee.expirationDateInAcbs,
+      NextDueDate: acbsFacilityFixedFee.nextDueDateInAcbs,
+      NextAccrueToDate: acbsFacilityFixedFee.nextAccrueToDateInAcbs,
+      SegmentIdentifier: acbsFacilityFixedFee.segmentIdentifier,
+      Description: acbsFacilityFixedFee.description,
+      Currency: {
+        CurrencyCode: acbsFacilityFixedFee.currency.currencyCode,
+      },
+      LenderType: {
+        LenderTypeCode: acbsFacilityFixedFee.lenderType.lenderTypeCode,
+      },
+      IncomeClass: {
+        IncomeClassCode: acbsFacilityFixedFee.incomeClass.incomeClassCode,
+      },
+      SpreadToInvestorsIndicator: acbsFacilityFixedFee.spreadToInvestorsIndicator,
+    }));
+
+    const apiFacilityFixedFees: GetFacilityFixedFeeResponse = values.map((apiFacilityFixedFee) => ({
+      facilityIdentifier,
+      portfolioIdentifier,
+      amount: apiFacilityFixedFee.fixedFeeAmount,
+      effectiveDate: this.dateStringTransformations.removeTime(apiFacilityFixedFee.effectiveDateInAcbs),
+      expirationDate: this.dateStringTransformations.removeTime(apiFacilityFixedFee.expirationDateInAcbs),
+      nextDueDate: this.dateStringTransformations.removeTime(apiFacilityFixedFee.nextDueDateInAcbs),
+      nextAccrueToDate: this.dateStringTransformations.removeTime(apiFacilityFixedFee.nextAccrueToDateInAcbs),
+      period: apiFacilityFixedFee.segmentIdentifier,
+      description: apiFacilityFixedFee.description,
+      currency: apiFacilityFixedFee.currency.currencyCode,
+      lenderTypeCode: apiFacilityFixedFee.lenderType.lenderTypeCode,
+      incomeClassCode: apiFacilityFixedFee.incomeClass.incomeClassCode,
+      spreadToInvestorsIndicator: apiFacilityFixedFee.spreadToInvestorsIndicator,
+    }));
+
+    return {
+      acbsFacilityFixedFees,
+      apiFacilityFixedFees: apiFacilityFixedFees,
+    };
+  }
+}
+
+interface FacilityFixedFeeValues {
+  fixedFeeAmount: number;
+  effectiveDateInAcbs: DateString;
+  expirationDateInAcbs: DateString;
+  nextDueDateInAcbs: DateString;
+  nextAccrueToDateInAcbs: DateString;
+  segmentIdentifier: string;
+  description: string;
+  currency: {
+    currencyCode: string;
+  };
+  lenderType: {
+    lenderTypeCode: string;
+  };
+  incomeClass: {
+    incomeClassCode: string;
+  };
+  spreadToInvestorsIndicator: boolean;
+}
+
+interface GenerateOptions {
+  facilityIdentifier: string;
+  portfolioIdentifier: string;
+}
+
+interface GenerateResult {
+  acbsFacilityFixedFees: AcbsGetFacilityFixedFeeResponseDto;
+  apiFacilityFixedFees: GetFacilityFixedFeeResponse;
+}


### PR DESCRIPTION
## Introduction
The GET /facilities/{facilityId}/fixed-feesendpoint allows the client to retrieve all fixed fees for a specific facility. I have migrated the GET ‘/facility/{facilityId}/fixedFee’ endpoint to the TFS API.

## Resolution
This endpoint:

- Validates that the specified facilityIdentifier has 10 characters and matches the regex pattern using the `ValidatedFacilityIdentifierApiProperty` decorator.
- Uses the id token to GET /Portfolio/E1/Facility/{facilityIdentifier}/Fee from ACBS
- Transforms the response the same way that Mulesoft does: Returns a 200 with the data (this includes the case of an empty array if the facility has no fees
- Returns a 200 and an empty array if the facility does not exist (ACBS returns the same response for no fees as facility not existing -- so we can not identify whether the facility exists or not)