### PR TITLE
feat(APIM-217): log acbs http requests/responses

### DIFF
--- a/src/modules/acbs-authentication/acbs-authentication.module.ts
+++ b/src/modules/acbs-authentication/acbs-authentication.module.ts
@@ -1,7 +1,7 @@
-import { HttpModule } from '@nestjs/axios';
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { HttpModule } from '@ukef/modules/http/http.module';
 
 import { AcbsAuthenticationService } from './acbs-authentication.service';
 import { BaseAcbsAuthenticationService, BaseAcbsAuthenticationServiceInjectionKey } from './base-acbs-authentication.service';

--- a/src/modules/acbs/acbs-http.service.ts
+++ b/src/modules/acbs/acbs-http.service.ts
@@ -2,7 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { ConfigType } from '@nestjs/config';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { AxiosResponse } from 'axios';
-import { catchError, lastValueFrom } from 'rxjs';
+import { catchError, lastValueFrom, ObservableInput } from 'rxjs';
 
 export class AcbsHttpService {
   constructor(private readonly config: Pick<ConfigType<typeof AcbsConfig>, 'baseUrl'>, private readonly httpService: HttpService) {}
@@ -14,7 +14,7 @@ export class AcbsHttpService {
   }: {
     path: string;
     idToken: string;
-    onError: (error: Error) => never;
+    onError: (error: Error) => ObservableInput<never>;
   }): Promise<AxiosResponse<ResponseBody, unknown>> {
     return await lastValueFrom(
       this.httpService
@@ -37,7 +37,7 @@ export class AcbsHttpService {
     path: string;
     requestBody: RequestBody;
     idToken: string;
-    onError: (error: Error) => never;
+    onError: (error: Error) => ObservableInput<never>;
   }): Promise<void> {
     await lastValueFrom(
       this.httpService

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -1,7 +1,7 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AcbsAuthenticationModule } from '@ukef/modules/acbs-authentication/acbs-authentication.module';
+import { HttpModule } from '@ukef/modules/http/http.module';
 
 import { AcbsDealService } from './acbs-deal.service';
 import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';

--- a/src/modules/acbs/wrap-acbs-http-error-callback.ts
+++ b/src/modules/acbs/wrap-acbs-http-error-callback.ts
@@ -1,11 +1,12 @@
 import { AxiosError } from 'axios';
+import { ObservableInput, throwError } from 'rxjs';
 
 import { AcbsException } from './exception/acbs.exception';
 import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
 import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
 import { KnownErrors } from './known-errors';
 
-type AcbsHttpErrorCallback = (error: Error) => never;
+type AcbsHttpErrorCallback = (error: Error) => ObservableInput<never>;
 
 export const createWrapAcbsHttpGetErrorCallback =
   ({ messageForUnknownError, knownErrors }: { messageForUnknownError: string; knownErrors: KnownErrors }): AcbsHttpErrorCallback =>
@@ -13,32 +14,35 @@ export const createWrapAcbsHttpGetErrorCallback =
     if (error instanceof AxiosError && error.response && typeof error.response.data === 'string') {
       knownErrors.forEach(({ substringToFind, throwError }) => {
         if (error.response.data.includes(substringToFind)) {
-          throwError(error);
+          return throwError(error);
         }
       });
     }
 
-    throw new AcbsException(messageForUnknownError, error);
+    return throwError(() => new AcbsException(messageForUnknownError, error));
   };
 
 export const createWrapAcbsHttpPostErrorCallback =
   ({ messageForUnknownError, knownErrors }: { messageForUnknownError: string; knownErrors: KnownErrors }): AcbsHttpErrorCallback =>
   (error: Error) => {
     if (!(error instanceof AxiosError) || !error.response || error.response.status !== 400) {
-      throw new AcbsUnexpectedException(messageForUnknownError, error);
+      return throwError(() => new AcbsUnexpectedException(messageForUnknownError, error));
     }
 
     if (typeof error.response.data === 'string') {
       knownErrors.forEach(({ substringToFind, throwError }) => {
         if (error.response.data.includes(substringToFind)) {
-          throwError(error);
+          return throwError(error);
         }
       });
     }
 
-    throw new AcbsBadRequestException(
-      messageForUnknownError,
-      error,
-      typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data),
+    return throwError(
+      () =>
+        new AcbsBadRequestException(
+          messageForUnknownError,
+          error,
+          typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data),
+        ),
     );
   };

--- a/src/modules/http/filter-axios-request-for-logging.helper.test.ts
+++ b/src/modules/http/filter-axios-request-for-logging.helper.test.ts
@@ -1,0 +1,41 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosRequestConfig } from 'axios';
+
+import { filterAxiosRequestForLogging } from './filter-axios-request-for-logging.helper';
+
+describe('filterAxiosRequestForLogging', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const timeout = valueGenerator.nonnegativeInteger();
+  const headers = { Accept: 'application/json' };
+  const maxRedirects = valueGenerator.nonnegativeInteger();
+  const baseURL = valueGenerator.httpsUrl();
+  const url = '/some-url';
+  const method = 'post';
+  const data = {
+    someNumber: valueGenerator.nonnegativeFloat(),
+  };
+
+  const request: AxiosRequestConfig = {
+    timeout,
+    headers,
+    maxRedirects,
+    baseURL,
+    url,
+    method,
+    data,
+    transformRequest: jest.fn(),
+    transformResponse: jest.fn(),
+  };
+
+  it('returns only the timeout, headers, maxRedirects, baseURL, url, method, and data of the request', () => {
+    expect(filterAxiosRequestForLogging(request)).toStrictEqual({
+      timeout,
+      headers,
+      maxRedirects,
+      baseURL,
+      url,
+      method,
+      data,
+    });
+  });
+});

--- a/src/modules/http/filter-axios-request-for-logging.helper.ts
+++ b/src/modules/http/filter-axios-request-for-logging.helper.ts
@@ -1,0 +1,16 @@
+import { AxiosRequestConfig } from 'axios';
+
+export const filterAxiosRequestForLogging = (
+  config: AxiosRequestConfig,
+): Pick<AxiosRequestConfig, 'timeout' | 'headers' | 'maxRedirects' | 'baseURL' | 'url' | 'method' | 'data'> => {
+  const { timeout, headers, maxRedirects, baseURL, url, method, data } = config;
+  return {
+    timeout,
+    headers,
+    maxRedirects,
+    baseURL,
+    url,
+    method,
+    data,
+  };
+};

--- a/src/modules/http/filter-axios-response-for-logging.helper.test.ts
+++ b/src/modules/http/filter-axios-response-for-logging.helper.test.ts
@@ -1,0 +1,32 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import { filterAxiosResponseForLogging } from './filter-axios-response-for-logging.helper';
+
+describe('filterAxiosResponseForLogging', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const data = {
+    someNumber: valueGenerator.nonnegativeFloat(),
+  };
+  const headers = { Accept: 'application/json' };
+  const status = 200;
+  const statusText = 'ok';
+
+  const response: AxiosResponse = {
+    data,
+    headers,
+    status,
+    statusText,
+    config: {} as InternalAxiosRequestConfig,
+    request: {},
+  };
+
+  it('returns only the data, headers, status, statusText of the response', () => {
+    expect(filterAxiosResponseForLogging(response)).toStrictEqual({
+      data,
+      headers,
+      status,
+      statusText,
+    });
+  });
+});

--- a/src/modules/http/filter-axios-response-for-logging.helper.ts
+++ b/src/modules/http/filter-axios-response-for-logging.helper.ts
@@ -1,0 +1,11 @@
+import { AxiosResponse } from 'axios';
+
+export const filterAxiosResponseForLogging = (response: AxiosResponse): Pick<AxiosResponse, 'data' | 'headers' | 'status' | 'statusText'> => {
+  const { data, headers, status, statusText } = response;
+  return {
+    data,
+    headers,
+    status,
+    statusText,
+  };
+};

--- a/src/modules/http/http-module-options.interface.ts
+++ b/src/modules/http/http-module-options.interface.ts
@@ -1,0 +1,3 @@
+import { HttpModuleAsyncOptions as AxiosHttpModuleOptions } from '@nestjs/axios';
+
+export type HttpModuleOptions = Pick<AxiosHttpModuleOptions, 'imports' | 'inject' | 'useFactory'>;

--- a/src/modules/http/http.module.test.ts
+++ b/src/modules/http/http.module.test.ts
@@ -83,7 +83,9 @@ describe('HttpModule', () => {
     it('specifies only module, imports, and exports', () => {
       const module = registerAsync();
 
-      expect(Object.keys(module).sort()).toStrictEqual(['exports', 'imports', 'module']);
+      const sortedModuleKeys = Object.keys(module).sort((a, b) => a.localeCompare(b));
+
+      expect(sortedModuleKeys).toStrictEqual(['exports', 'imports', 'module']);
     });
 
     it('specifies the module field as the class', () => {

--- a/src/modules/http/http.module.test.ts
+++ b/src/modules/http/http.module.test.ts
@@ -1,0 +1,107 @@
+import { HttpModule as AxiosHttpModule, HttpService } from '@nestjs/axios';
+import { DynamicModule } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { when } from 'jest-when';
+import { PinoLogger } from 'nestjs-pino';
+
+import { HttpModule } from './http.module';
+import { logAxiosRequestWith } from './log-axios-request.axios-interceptor';
+import { logAxiosResponseErrorWith } from './log-axios-response-error.axios-interceptor';
+import { logAxiosResponseSuccessWith } from './log-axios-response-success.axios-interceptor';
+
+jest.mock('./log-axios-request.axios-interceptor');
+jest.mock('./log-axios-response-error.axios-interceptor');
+jest.mock('./log-axios-response-success.axios-interceptor');
+
+describe('HttpModule', () => {
+  describe('constructor', () => {
+    const axiosRequestInterceptor = jest.fn();
+    const axiosResponseSuccessInterceptor = jest.fn();
+    const axiosResponseErrorInterceptor = jest.fn();
+
+    let httpService: HttpService;
+    let logger: PinoLogger;
+
+    const createNewHttpModule = () => new HttpModule(httpService, logger);
+
+    beforeEach(() => {
+      httpService = httpService = {
+        axiosRef: {
+          interceptors: {
+            request: { use: jest.fn() },
+            response: { use: jest.fn() },
+          },
+        },
+      } as unknown as HttpService;
+      logger = new PinoLogger({});
+      when(logAxiosRequestWith).calledWith(logger).mockReturnValueOnce(axiosRequestInterceptor);
+      when(logAxiosResponseSuccessWith).calledWith(logger).mockReturnValueOnce(axiosResponseSuccessInterceptor);
+      when(logAxiosResponseErrorWith).calledWith(logger).mockReturnValueOnce(axiosResponseErrorInterceptor);
+    });
+
+    it('registers the request and response logging interceptors on the axiosRef of the httpService', () => {
+      createNewHttpModule();
+
+      const requestInterceptor = (httpService.axiosRef.interceptors.request.use as jest.Mock).mock.calls[0][0];
+      const responseInterceptors = (httpService.axiosRef.interceptors.response.use as jest.Mock).mock.calls[0];
+      const responseSuccessInterceptor = responseInterceptors[0];
+      const responseErrorInterceptor = responseInterceptors[1];
+
+      expect(requestInterceptor).toBe(axiosRequestInterceptor);
+      expect(responseSuccessInterceptor).toBe(axiosResponseSuccessInterceptor);
+      expect(responseErrorInterceptor).toBe(axiosResponseErrorInterceptor);
+    });
+  });
+
+  describe('registerAsync', () => {
+    const imports = [ConfigModule];
+    const inject = [ConfigService];
+    const useFactory = jest.fn();
+    const dynamicAxiosHttpModule: DynamicModule = {
+      module: AxiosHttpModule,
+    };
+
+    beforeEach(() => {
+      const axiosHttpModuleRegisterAsync = jest.fn();
+      AxiosHttpModule.registerAsync = axiosHttpModuleRegisterAsync;
+      when(axiosHttpModuleRegisterAsync)
+        .calledWith({
+          imports,
+          inject,
+          useFactory,
+        })
+        .mockReturnValueOnce(dynamicAxiosHttpModule);
+    });
+
+    const registerAsync = (): DynamicModule =>
+      HttpModule.registerAsync({
+        imports,
+        inject,
+        useFactory,
+      });
+
+    it('specifies only module, imports, and exports', () => {
+      const module = registerAsync();
+
+      expect(Object.keys(module).sort()).toStrictEqual(['exports', 'imports', 'module']);
+    });
+
+    it('specifies the module field as the class', () => {
+      const module = registerAsync();
+
+      expect(module.module).toBe(HttpModule);
+    });
+
+    it('imports only the dynamic Axios HttpModule', () => {
+      const module = registerAsync();
+
+      expect(module.imports).toStrictEqual([dynamicAxiosHttpModule]);
+    });
+
+    it('exports only the AxiosHttpModule', () => {
+      const module = registerAsync();
+
+      expect(module.exports).toStrictEqual([AxiosHttpModule]);
+    });
+  });
+});

--- a/src/modules/http/http.module.ts
+++ b/src/modules/http/http.module.ts
@@ -1,0 +1,31 @@
+import { HttpModule as AxiosHttpModule, HttpService } from '@nestjs/axios';
+import { DynamicModule, Module } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+
+import { HttpModuleOptions } from './http-module-options.interface';
+import { logAxiosRequestWith } from './log-axios-request.axios-interceptor';
+import { logAxiosResponseErrorWith } from './log-axios-response-error.axios-interceptor';
+import { logAxiosResponseSuccessWith } from './log-axios-response-success.axios-interceptor';
+export { HttpService } from '@nestjs/axios';
+
+@Module({})
+export class HttpModule {
+  static registerAsync(options: HttpModuleOptions): DynamicModule {
+    return {
+      module: HttpModule,
+      imports: [
+        AxiosHttpModule.registerAsync({
+          imports: options.imports,
+          inject: options.inject,
+          useFactory: options.useFactory,
+        }),
+      ],
+      exports: [AxiosHttpModule],
+    };
+  }
+
+  constructor(httpService: HttpService, logger: PinoLogger) {
+    httpService.axiosRef.interceptors.request.use(logAxiosRequestWith(logger));
+    httpService.axiosRef.interceptors.response.use(logAxiosResponseSuccessWith(logger), logAxiosResponseErrorWith(logger));
+  }
+}

--- a/src/modules/http/log-axios-request.axios-interceptor.test.ts
+++ b/src/modules/http/log-axios-request.axios-interceptor.test.ts
@@ -1,0 +1,53 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
+import { when } from 'jest-when';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosRequestForLogging } from './filter-axios-request-for-logging.helper';
+import { logAxiosRequestWith } from './log-axios-request.axios-interceptor';
+import { AxiosRequestInterceptor } from './type/axios-request-interceptor.type';
+
+jest.mock('./filter-axios-request-for-logging.helper');
+
+describe('logAxiosRequest', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const timeout = valueGenerator.nonnegativeInteger();
+  const baseURL = valueGenerator.httpsUrl();
+  const data = {
+    someNumber: valueGenerator.nonnegativeFloat(),
+  };
+
+  const request: InternalAxiosRequestConfig = {
+    timeout,
+    baseURL,
+    headers: new AxiosHeaders(),
+    data,
+  };
+
+  const filteredRequest = {
+    data,
+  };
+
+  let logger: PinoLogger;
+  let logAxiosRequest: AxiosRequestInterceptor;
+
+  beforeEach(() => {
+    logger = new PinoLogger({});
+    logger.debug = jest.fn();
+    logAxiosRequest = logAxiosRequestWith(logger);
+
+    (filterAxiosRequestForLogging as jest.Mock).mockReset();
+    when(filterAxiosRequestForLogging).calledWith(request).mockReturnValueOnce(filteredRequest);
+  });
+
+  it('logs the filtered request at debug level', () => {
+    logAxiosRequest(request);
+
+    expect(logger.debug).toHaveBeenCalledWith({ outgoingRequest: filteredRequest }, 'Sending the following HTTP request.');
+  });
+
+  it('returns the original request', () => {
+    expect(logAxiosRequest(request)).toBe(request);
+  });
+});

--- a/src/modules/http/log-axios-request.axios-interceptor.ts
+++ b/src/modules/http/log-axios-request.axios-interceptor.ts
@@ -1,0 +1,12 @@
+import { InternalAxiosRequestConfig } from 'axios';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosRequestForLogging } from './filter-axios-request-for-logging.helper';
+import { AxiosRequestInterceptor } from './type/axios-request-interceptor.type';
+
+export const logAxiosRequestWith =
+  (logger: PinoLogger): AxiosRequestInterceptor =>
+  (config: InternalAxiosRequestConfig) => {
+    logger.debug({ outgoingRequest: filterAxiosRequestForLogging(config) }, 'Sending the following HTTP request.');
+    return config;
+  };

--- a/src/modules/http/log-axios-response-error.axios-interceptor.test.ts
+++ b/src/modules/http/log-axios-response-error.axios-interceptor.test.ts
@@ -1,0 +1,77 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { when } from 'jest-when';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosResponseForLogging } from './filter-axios-response-for-logging.helper';
+import { logAxiosResponseErrorWith } from './log-axios-response-error.axios-interceptor';
+import { AxiosResponseErrorInterceptor } from './type/axios-response-error-interceptor.type';
+
+jest.mock('./filter-axios-response-for-logging.helper');
+
+describe('logAxiosResponseError', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const data = {
+    someNumber: valueGenerator.nonnegativeFloat(),
+  };
+  const headers = { Accept: 'application/json' };
+  const status = 200;
+  const statusText = 'ok';
+
+  const response: AxiosResponse = {
+    data,
+    headers,
+    status,
+    statusText,
+    config: {} as InternalAxiosRequestConfig,
+    request: {},
+  };
+
+  const filteredResponse = {
+    data,
+    headers,
+    status,
+    statusText,
+  };
+
+  const errorWithoutResponse = new AxiosError('error without response');
+
+  const errorWithResponse = new AxiosError('error with response', undefined, undefined, undefined, response);
+
+  let logger: PinoLogger;
+  let logAxiosResponseError: AxiosResponseErrorInterceptor;
+
+  beforeEach(() => {
+    logger = new PinoLogger({});
+    logger.warn = jest.fn();
+    logAxiosResponseError = logAxiosResponseErrorWith(logger);
+
+    (filterAxiosResponseForLogging as jest.Mock).mockReset();
+    when(filterAxiosResponseForLogging).calledWith(response).mockReturnValueOnce(filteredResponse);
+  });
+
+  it('logs the full error at warn level for an error without a response', async () => {
+    await logAxiosResponseError(errorWithoutResponse).catch(() => {});
+
+    expect(logger.warn).toHaveBeenCalledWith(errorWithoutResponse, 'A HTTP server failed to respond to our request.');
+  });
+
+  it('logs the filtered response at warn level for an error with a response', async () => {
+    await logAxiosResponseError(errorWithResponse).catch(() => {});
+
+    expect(logger.warn).toHaveBeenCalledWith({ response: filteredResponse }, 'A HTTP server responded to our request with an error response.');
+  });
+
+  it('rejects with the original error for an error without a response', async () => {
+    const logAxiosResponseErrorPromise = logAxiosResponseError(errorWithoutResponse);
+
+    await expect(logAxiosResponseErrorPromise).rejects.toBe(errorWithoutResponse);
+  });
+
+  it('rejects with the original error for an error with a response', async () => {
+    const logAxiosResponseErrorPromise = logAxiosResponseError(errorWithResponse);
+
+    await expect(logAxiosResponseErrorPromise).rejects.toBe(errorWithResponse);
+  });
+});

--- a/src/modules/http/log-axios-response-error.axios-interceptor.ts
+++ b/src/modules/http/log-axios-response-error.axios-interceptor.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosResponseForLogging } from './filter-axios-response-for-logging.helper';
+import { AxiosResponseErrorInterceptor } from './type/axios-response-error-interceptor.type';
+
+export const logAxiosResponseErrorWith =
+  (logger: PinoLogger): AxiosResponseErrorInterceptor =>
+  (error: AxiosError) => {
+    const logInput = buildAxiosResponseLogInput(error);
+    logger.warn(logInput.object, logInput.message);
+    return Promise.reject(error);
+  };
+
+const buildAxiosResponseLogInput = (error: AxiosError): { object: unknown; message: string } => {
+  const responseFromServer = error.response;
+  const receivedResponseFromServer = !!responseFromServer;
+  return receivedResponseFromServer
+    ? {
+        object: { response: filterAxiosResponseForLogging(responseFromServer) },
+        message: 'A HTTP server responded to our request with an error response.',
+      }
+    : { object: error, message: 'A HTTP server failed to respond to our request.' };
+};

--- a/src/modules/http/log-axios-response-success.axios-interceptor.test.ts
+++ b/src/modules/http/log-axios-response-success.axios-interceptor.test.ts
@@ -1,0 +1,59 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { when } from 'jest-when';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosResponseForLogging } from './filter-axios-response-for-logging.helper';
+import { logAxiosResponseSuccessWith } from './log-axios-response-success.axios-interceptor';
+import { AxiosResponseSuccessInterceptor } from './type/axios-response-success-interceptor.type';
+
+jest.mock('./filter-axios-response-for-logging.helper');
+
+describe('logAxiosResponseSuccess', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const data = {
+    someNumber: valueGenerator.nonnegativeFloat(),
+  };
+  const headers = { Accept: 'application/json' };
+  const status = 200;
+  const statusText = 'ok';
+
+  const response: AxiosResponse = {
+    data,
+    headers,
+    status,
+    statusText,
+    config: {} as InternalAxiosRequestConfig,
+    request: {},
+  };
+
+  const filteredResponse = {
+    data,
+    headers,
+    status,
+    statusText,
+  };
+
+  let logger: PinoLogger;
+  let logAxiosResponseSuccess: AxiosResponseSuccessInterceptor;
+
+  beforeEach(() => {
+    logger = new PinoLogger({});
+    logger.debug = jest.fn();
+    logAxiosResponseSuccess = logAxiosResponseSuccessWith(logger);
+
+    (filterAxiosResponseForLogging as jest.Mock).mockReset();
+    when(filterAxiosResponseForLogging).calledWith(response).mockReturnValueOnce(filteredResponse);
+  });
+
+  it('logs the filtered response at debug level', () => {
+    logAxiosResponseSuccess(response);
+
+    expect(logger.debug).toHaveBeenCalledWith({ response: filteredResponse }, 'Received successful HTTP response.');
+  });
+
+  it('returns the original response', () => {
+    expect(logAxiosResponseSuccess(response)).toBe(response);
+  });
+});

--- a/src/modules/http/log-axios-response-success.axios-interceptor.ts
+++ b/src/modules/http/log-axios-response-success.axios-interceptor.ts
@@ -1,0 +1,12 @@
+import { AxiosResponse } from 'axios';
+import { PinoLogger } from 'nestjs-pino';
+
+import { filterAxiosResponseForLogging } from './filter-axios-response-for-logging.helper';
+import { AxiosResponseSuccessInterceptor } from './type/axios-response-success-interceptor.type';
+
+export const logAxiosResponseSuccessWith =
+  (logger: PinoLogger): AxiosResponseSuccessInterceptor =>
+  (response: AxiosResponse) => {
+    logger.debug({ response: filterAxiosResponseForLogging(response) }, 'Received successful HTTP response.');
+    return response;
+  };

--- a/src/modules/http/type/axios-request-interceptor.type.ts
+++ b/src/modules/http/type/axios-request-interceptor.type.ts
@@ -1,0 +1,3 @@
+import { InternalAxiosRequestConfig } from 'axios';
+
+export type AxiosRequestInterceptor = (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig;

--- a/src/modules/http/type/axios-response-error-interceptor.type.ts
+++ b/src/modules/http/type/axios-response-error-interceptor.type.ts
@@ -1,0 +1,3 @@
+import { AxiosError } from 'axios';
+
+export type AxiosResponseErrorInterceptor = (error: AxiosError) => Promise<void>;

--- a/src/modules/http/type/axios-response-success-interceptor.type.ts
+++ b/src/modules/http/type/axios-response-success-interceptor.type.ts
@@ -1,0 +1,3 @@
+import { AxiosResponse } from 'axios';
+
+export type AxiosResponseSuccessInterceptor = (response: AxiosResponse) => AxiosResponse;

--- a/src/modules/party/party.module.ts
+++ b/src/modules/party/party.module.ts
@@ -1,11 +1,12 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AcbsModule } from '@ukef/modules/acbs/acbs.module';
+import { HttpModule } from '@ukef/modules/http/http.module';
 
 import { DateModule } from '../date/date.module';
 import { PartyController } from './party.controller';
 import { PartyService } from './party.service';
+
 @Module({
   imports: [
     HttpModule.registerAsync({


### PR DESCRIPTION
## Introduction
We currently don't log requests to ACBS and responses from ACBS from ACBS unless there is an unexpected exception. Even if there is an unexpected exception, we are currently only logging the request to ACBS, not the response body from it.

We'd like to log requests to/responses from ACBS to help with debugging any issues and with verifying that we are sending the correct PUT / POST requests to ACBS.

## Resolution

I've created a new module, `HttpModule`, that all modules should use _instead of_ the `HttpModule` from `@nestjs/axios`.
This new module can be configured in the same way as `@nestjs/axios`'s `HttpModule`. 
When the new module is registered, it registers and re-exports the `@nestjs/axios` `HttpModule` and `HttpService`.
It also attaches [axios interceptors](https://axios-http.com/docs/interceptors) to the `HttpService`'s axios instance.
These interceptors take care of logging all http requests that our server makes.

For outbound http requests, we log at _debug_ level in the following format:
```
{
  "message": "Sending the following HTTP request.",
  "outgoingRequest":  {
    "timeout": <..>,
    "headers": <(the request headers)>,
    "maxRedirects": <..>,
    "baseURL": <..>,
    "url": <..>,
    "method": <..>,
    "data": <(this is the request body, if there is one)>,
  }
}
```

For incoming http responses with a success status code, we log at _debug_ level in the following format:
```
{
  "message": "Received successful HTTP response.",
  "response":  {
    "data": <(the response body)>,
    "headers": <(the response headers)>,
    "status": <..>,
    "statusText": <..>,
  }
}
```

For incoming http responses with an error status code, we log at _warn_ level in the following format:
```
{
  "message": "A HTTP server responded to our request with an error response.",
  "response":  {
    "data": <(the response body)>,
    "headers": <(the response headers)>,
    "status": <..>,
    "statusText": <..>,
  }
}
```

For any http requests that didn't receive a response from the server (e.g. because of a timeout, or the server wasn't found, etc.), we log the full `AxiosError` object at _warn_ level alongside the message `A HTTP server failed to respond to our request.`

## Misc

I refactored `src/modules/acbs/wrap-acbs-http-error-callback.ts` to make the `throwError` usage more consistent.
