### PR TITLE
feat(APIM-244): validate facility id in post facility investor

### DIFF
--- a/src/modules/facility-investor/dto/create-facility-investor-params.dto.ts
+++ b/src/modules/facility-investor/dto/create-facility-investor-params.dto.ts
@@ -1,0 +1,9 @@
+import { ValidatedFacilityIdentifierApiProperty } from '@ukef/decorators/validated-facility-identifier-api-property';
+import { UkefId } from '@ukef/helpers';
+
+export class CreateFacilityInvestorParams {
+  @ValidatedFacilityIdentifierApiProperty({
+    description: 'The identifier of the facility in ACBS.',
+  })
+  facilityIdentifier: UkefId;
+}

--- a/src/modules/facility-investor/dto/create-facility-investor-request.dto.ts
+++ b/src/modules/facility-investor/dto/create-facility-investor-request.dto.ts
@@ -8,13 +8,6 @@ import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
 export type CreateFacilityInvestorRequest = CreateFacilityInvestorRequestItem[];
 
 export class CreateFacilityInvestorRequestItem {
-  @ValidatedStringApiProperty({
-    description: 'The identifier of the facility to create the investor for.',
-    example: '0000000001',
-    length: 10,
-  })
-  readonly facilityIdentifier: string;
-
   @ValidatedDateOnlyApiProperty({
     description: `The date from which this limit is effective.`,
   })
@@ -45,15 +38,7 @@ export class CreateFacilityInvestorRequestItem {
   })
   readonly lenderType?: string;
 
-  constructor(
-    facilityIdentifier: string,
-    effectiveDate: DateOnlyString,
-    guaranteeExpiryDate: DateOnlyString,
-    currency: string,
-    maximumLiability: number,
-    lenderType?: string,
-  ) {
-    this.facilityIdentifier = facilityIdentifier;
+  constructor(effectiveDate: DateOnlyString, guaranteeExpiryDate: DateOnlyString, currency: string, maximumLiability: number, lenderType?: string) {
     this.effectiveDate = effectiveDate;
     this.guaranteeExpiryDate = guaranteeExpiryDate;
     this.currency = currency;

--- a/src/modules/facility-investor/facility-investor-to-create.interface.ts
+++ b/src/modules/facility-investor/facility-investor-to-create.interface.ts
@@ -1,7 +1,6 @@
 import { DateOnlyString } from '@ukef/helpers/date-only-string.type';
 
 export interface FacilityInvestorToCreate {
-  facilityIdentifier: string;
   effectiveDate: DateOnlyString;
   guaranteeExpiryDate: DateOnlyString;
   lenderType?: string;

--- a/src/modules/facility-investor/facility-investor.controller.test.ts
+++ b/src/modules/facility-investor/facility-investor.controller.test.ts
@@ -32,14 +32,7 @@ describe('FacilityInvestorController', () => {
     const currency = TEST_CURRENCIES.A_TEST_CURRENCY;
     const maximumLiability = 12345.6;
 
-    const newFacilityInvestor = new CreateFacilityInvestorRequestItem(
-      facilityIdentifier,
-      effectiveDate,
-      guaranteeExpiryDate,
-      currency,
-      maximumLiability,
-      lenderType,
-    );
+    const newFacilityInvestor = new CreateFacilityInvestorRequestItem(effectiveDate, guaranteeExpiryDate, currency, maximumLiability, lenderType);
 
     it('creates an investor for the facility with the service from the request body', async () => {
       await controller.createInvestorForFacility(facilityIdentifier, [newFacilityInvestor]);

--- a/src/modules/facility-investor/facility-investor.controller.test.ts
+++ b/src/modules/facility-investor/facility-investor.controller.test.ts
@@ -35,13 +35,13 @@ describe('FacilityInvestorController', () => {
     const newFacilityInvestor = new CreateFacilityInvestorRequestItem(effectiveDate, guaranteeExpiryDate, currency, maximumLiability, lenderType);
 
     it('creates an investor for the facility with the service from the request body', async () => {
-      await controller.createInvestorForFacility(facilityIdentifier, [newFacilityInvestor]);
+      await controller.createInvestorForFacility({ facilityIdentifier }, [newFacilityInvestor]);
 
       expect(facilityInvestorServiceCreateInvestorForFacility).toHaveBeenCalledWith(facilityIdentifier, newFacilityInvestor);
     });
 
     it('returns the facility identifier if creating the investor succeeds', async () => {
-      const response = await controller.createInvestorForFacility(facilityIdentifier, [newFacilityInvestor]);
+      const response = await controller.createInvestorForFacility({ facilityIdentifier }, [newFacilityInvestor]);
 
       expect(response).toStrictEqual(new CreateFacilityInvestorResponse(facilityIdentifier));
     });
@@ -49,7 +49,7 @@ describe('FacilityInvestorController', () => {
     it('does NOT include unexpected keys from the request body', async () => {
       const newFacilityInvestorPlusUnexpectedKeys = { ...newFacilityInvestor, unexpectedKey: 'unexpected value' };
 
-      await controller.createInvestorForFacility(facilityIdentifier, [newFacilityInvestorPlusUnexpectedKeys]);
+      await controller.createInvestorForFacility({ facilityIdentifier }, [newFacilityInvestorPlusUnexpectedKeys]);
 
       expect(facilityInvestorServiceCreateInvestorForFacility).toHaveBeenCalledWith(facilityIdentifier, newFacilityInvestor);
     });

--- a/src/modules/facility-investor/facility-investor.controller.ts
+++ b/src/modules/facility-investor/facility-investor.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/swagger';
 import { EXAMPLES } from '@ukef/constants';
 
+import { CreateFacilityInvestorParams } from './dto/create-facility-investor-params.dto';
 import { CreateFacilityInvestorRequest, CreateFacilityInvestorRequestItem } from './dto/create-facility-investor-request.dto';
 import { CreateFacilityInvestorResponse } from './dto/create-facility-investor-response.dto';
 import { GetFacilityInvestorsParamsDto } from './dto/get-facility-investors-params.dto';
@@ -51,7 +52,7 @@ export class FacilityInvestorController {
     description: 'An internal server error has occurred.',
   })
   async createInvestorForFacility(
-    @Param('facilityIdentifier') facilityIdentifier: string,
+    @Param() params: CreateFacilityInvestorParams,
     @Body(new ParseArrayPipe({ items: CreateFacilityInvestorRequestItem })) newFacilityInvestorRequest: CreateFacilityInvestorRequest,
   ): Promise<CreateFacilityInvestorResponse> {
     const newFacilityInvestor = newFacilityInvestorRequest[0];
@@ -62,6 +63,7 @@ export class FacilityInvestorController {
       maximumLiability: newFacilityInvestor.maximumLiability,
       lenderType: newFacilityInvestor.lenderType,
     };
+    const { facilityIdentifier } = params;
     await this.facilityInvestorService.createInvestorForFacility(facilityIdentifier, facilityInvestorToCreate);
     return Promise.resolve(new CreateFacilityInvestorResponse(facilityIdentifier));
   }

--- a/src/modules/facility-investor/facility-investor.controller.ts
+++ b/src/modules/facility-investor/facility-investor.controller.ts
@@ -56,7 +56,6 @@ export class FacilityInvestorController {
   ): Promise<CreateFacilityInvestorResponse> {
     const newFacilityInvestor = newFacilityInvestorRequest[0];
     const facilityInvestorToCreate: FacilityInvestorToCreate = {
-      facilityIdentifier,
       effectiveDate: newFacilityInvestor.effectiveDate,
       guaranteeExpiryDate: newFacilityInvestor.guaranteeExpiryDate,
       currency: newFacilityInvestor.currency,

--- a/src/modules/facility-investor/facility-investor.service.test.ts
+++ b/src/modules/facility-investor/facility-investor.service.test.ts
@@ -9,6 +9,7 @@ import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-
 import { when } from 'jest-when';
 
 import { FacilityInvestorService } from './facility-investor.service';
+import { FacilityInvestorToCreate } from './facility-investor-to-create.interface';
 
 describe('FacilityInvestorService', () => {
   const valueGenerator = new RandomValueGenerator();
@@ -43,8 +44,7 @@ describe('FacilityInvestorService', () => {
     const currency = TEST_CURRENCIES.A_TEST_CURRENCY;
     const maximumLiability = 12345.6;
 
-    const newFacilityInvestorWithAllFields = {
-      facilityIdentifier,
+    const newFacilityInvestorWithAllFields: FacilityInvestorToCreate = {
       effectiveDate: effectiveDate,
       guaranteeExpiryDate: guaranteeExpiryDate,
       lenderType,

--- a/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests.ts
+++ b/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 
 const expectedFacilityIdentifierMustMatchPatternErrorMessage = `facilityIdentifier must match /^00\\d{8}$/ regular expression`;
 
-export const withFacilityIdentifierUrlParamValidationApiTests = ({
+export const withFacilityIdentifierUrlValidationApiTests = ({
   makeRequestWithFacilityId,
   givenRequestWouldOtherwiseSucceedForFacilityId,
   successStatusCode,

--- a/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests.ts
+++ b/test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests.ts
@@ -12,85 +12,87 @@ export const withFacilityIdentifierUrlValidationApiTests = ({
   givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId: string) => void;
   successStatusCode?: number;
 }): void => {
-  const valueGenerator = new RandomValueGenerator();
-  const expectedSuccessStatusCode = successStatusCode ?? 200;
+  describe('facilityIdentifier URL validation', () => {
+    const valueGenerator = new RandomValueGenerator();
+    const expectedSuccessStatusCode = successStatusCode ?? 200;
 
-  it(`returns a ${expectedSuccessStatusCode} response if the facilityId in the URL is valid`, async () => {
-    const validFacilityId = valueGenerator.facilityId();
-    givenRequestWouldOtherwiseSucceedForFacilityId(validFacilityId);
+    it(`returns a ${expectedSuccessStatusCode} response if the facilityId in the URL is valid`, async () => {
+      const validFacilityId = valueGenerator.facilityId();
+      givenRequestWouldOtherwiseSucceedForFacilityId(validFacilityId);
 
-    const { status } = await makeRequestWithFacilityId(validFacilityId);
+      const { status } = await makeRequestWithFacilityId(validFacilityId);
 
-    expect(status).toBe(expectedSuccessStatusCode);
-  });
-
-  it('returns a 400 response if the facilityId in the URL has fewer than 10 digits', async () => {
-    const fewerThan10Digits = '001234567';
-    givenRequestWouldOtherwiseSucceedForFacilityId(fewerThan10Digits);
-
-    const { status, body } = await makeRequestWithFacilityId(fewerThan10Digits);
-
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([`facilityIdentifier must be longer than or equal to 10 characters`]),
-      statusCode: 400,
+      expect(status).toBe(expectedSuccessStatusCode);
     });
-  });
 
-  it('returns a 400 response if the facilityId in the URL has more than 10 digits', async () => {
-    const moreThan10Digits = '00123456789';
-    givenRequestWouldOtherwiseSucceedForFacilityId(moreThan10Digits);
+    it('returns a 400 response if the facilityId in the URL has fewer than 10 digits', async () => {
+      const fewerThan10Digits = '001234567';
+      givenRequestWouldOtherwiseSucceedForFacilityId(fewerThan10Digits);
 
-    const { status, body } = await makeRequestWithFacilityId(moreThan10Digits);
+      const { status, body } = await makeRequestWithFacilityId(fewerThan10Digits);
 
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([`facilityIdentifier must be shorter than or equal to 10 characters`]),
-      statusCode: 400,
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([`facilityIdentifier must be longer than or equal to 10 characters`]),
+        statusCode: 400,
+      });
     });
-  });
 
-  it('returns a 400 response if the facilityId in the URL has an alphabetic character', async () => {
-    const withAnAlphaCharacter = '00123a4567';
-    givenRequestWouldOtherwiseSucceedForFacilityId(withAnAlphaCharacter);
+    it('returns a 400 response if the facilityId in the URL has more than 10 digits', async () => {
+      const moreThan10Digits = '00123456789';
+      givenRequestWouldOtherwiseSucceedForFacilityId(moreThan10Digits);
 
-    const { status, body } = await makeRequestWithFacilityId(withAnAlphaCharacter);
+      const { status, body } = await makeRequestWithFacilityId(moreThan10Digits);
 
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
-      statusCode: 400,
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([`facilityIdentifier must be shorter than or equal to 10 characters`]),
+        statusCode: 400,
+      });
     });
-  });
 
-  it('returns a 400 response if the facilityId in the URL has a non-alphanumeric character', async () => {
-    const withAnNonAlphaNumericCharacter = '0012345!78';
-    givenRequestWouldOtherwiseSucceedForFacilityId(withAnNonAlphaNumericCharacter);
+    it('returns a 400 response if the facilityId in the URL has an alphabetic character', async () => {
+      const withAnAlphaCharacter = '00123a4567';
+      givenRequestWouldOtherwiseSucceedForFacilityId(withAnAlphaCharacter);
 
-    const { status, body } = await makeRequestWithFacilityId(withAnNonAlphaNumericCharacter);
+      const { status, body } = await makeRequestWithFacilityId(withAnAlphaCharacter);
 
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
-      statusCode: 400,
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+        statusCode: 400,
+      });
     });
-  });
 
-  it('returns a 400 response if the facilityId in the URL does not start with 00', async () => {
-    const doesNotStartWith00 = '0112345678';
-    givenRequestWouldOtherwiseSucceedForFacilityId(doesNotStartWith00);
+    it('returns a 400 response if the facilityId in the URL has a non-alphanumeric character', async () => {
+      const withAnNonAlphaNumericCharacter = '0012345!78';
+      givenRequestWouldOtherwiseSucceedForFacilityId(withAnNonAlphaNumericCharacter);
 
-    const { status, body } = await makeRequestWithFacilityId(doesNotStartWith00);
+      const { status, body } = await makeRequestWithFacilityId(withAnNonAlphaNumericCharacter);
 
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
-      statusCode: 400,
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+        statusCode: 400,
+      });
+    });
+
+    it('returns a 400 response if the facilityId in the URL does not start with 00', async () => {
+      const doesNotStartWith00 = '0112345678';
+      givenRequestWouldOtherwiseSucceedForFacilityId(doesNotStartWith00);
+
+      const { status, body } = await makeRequestWithFacilityId(doesNotStartWith00);
+
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([expectedFacilityIdentifierMustMatchPatternErrorMessage]),
+        statusCode: 400,
+      });
     });
   });
 };

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -425,6 +425,9 @@ paths:
           description: The identifier of the facility in ACBS.
           example: '0030000322'
           schema:
+            minLength: 10
+            maxLength: 10
+            pattern: ^00\\d{8}$
             type: string
       requestBody:
         required: true

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1693,12 +1693,6 @@ components:
     CreateFacilityInvestorRequestItem:
       type: object
       properties:
-        facilityIdentifier:
-          type: string
-          description: The identifier of the facility to create the investor for.
-          minLength: 10
-          maxLength: 10
-          example: '0000000001'
         effectiveDate:
           format: date
           type: string
@@ -1728,7 +1722,6 @@ components:
           maxLength: 3
           default: '500'
       required:
-        - facilityIdentifier
         - effectiveDate
         - guaranteeExpiryDate
         - currency

--- a/test/facility-fixed-fee/get-facility-fixed-fees.api-test.ts
+++ b/test/facility-fixed-fee/get-facility-fixed-fees.api-test.ts
@@ -2,7 +2,7 @@ import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withFacilityIdentifierUrlParamValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests';
+import { withFacilityIdentifierUrlValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
 import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
@@ -52,7 +52,7 @@ describe('GET /facilities/{facilityIdentifier}/fixed-fees', () => {
       api.getWithoutAuth(getFacilityFixedFeesUrl, incorrectAuth?.headerName, incorrectAuth?.headerValue),
   });
 
-  withFacilityIdentifierUrlParamValidationApiTests({
+  withFacilityIdentifierUrlValidationApiTests({
     givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
       givenAuthenticationWithTheIdpSucceeds();
       requestToGetFixedFeesForFacilityWithId(facilityId).reply(200, acbsFacilityFixedFees);

--- a/test/facility-guarantee/get-facility-guarantees.api-test.ts
+++ b/test/facility-guarantee/get-facility-guarantees.api-test.ts
@@ -2,7 +2,7 @@ import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withFacilityIdentifierUrlParamValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests';
+import { withFacilityIdentifierUrlValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
 import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
@@ -52,7 +52,7 @@ describe('GET /facilities/{facilityIdentifier}/guarantees', () => {
       api.getWithoutAuth(getFacilityGuaranteesUrl, incorrectAuth?.headerName, incorrectAuth?.headerValue),
   });
 
-  withFacilityIdentifierUrlParamValidationApiTests({
+  withFacilityIdentifierUrlValidationApiTests({
     givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
       givenAuthenticationWithTheIdpSucceeds();
       requestToGetGuaranteesForFacilityWithId(facilityId).reply(200, facilityGuaranteesInAcbs);

--- a/test/facility-investor/get-facility-investors-by-facility-identifier.api-test.ts
+++ b/test/facility-investor/get-facility-investors-by-facility-identifier.api-test.ts
@@ -1,7 +1,7 @@
 import { PROPERTIES } from '@ukef/constants';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withFacilityIdentifierUrlParamValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-param-validation-api-tests';
+import { withFacilityIdentifierUrlValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
 import { GetFacilityInvestorGenerator } from '@ukef-test/support/generator/get-facility-investor-generator';
@@ -52,7 +52,7 @@ describe('GET /facilities/{facilityIdentifier}/investors', () => {
       api.getWithoutAuth(getFacilityInvestorsUrl, incorrectAuth?.headerName, incorrectAuth?.headerValue),
   });
 
-  withFacilityIdentifierUrlParamValidationApiTests({
+  withFacilityIdentifierUrlValidationApiTests({
     givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
       givenAuthenticationWithTheIdpSucceeds();
       requestToGetFacilityInvestorsWithId(facilityId).reply(200, facilityInvestorsInAcbs);

--- a/test/facility-investor/post-facility-investor.api-test.ts
+++ b/test/facility-investor/post-facility-investor.api-test.ts
@@ -7,12 +7,14 @@ import { withCurrencyFieldValidationApiTests } from '@ukef-test/common-tests/req
 import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
+import { withFacilityIdentifierUrlValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
 import { TEST_CURRENCIES } from '@ukef-test/support/constants/test-currency.constant';
 import { TEST_DATES } from '@ukef-test/support/constants/test-date.constant';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import nock from 'nock';
+import supertest from 'supertest';
 
 describe('POST /facilities/{facilityIdentifier}/investors', () => {
   const valueGenerator = new RandomValueGenerator();
@@ -80,7 +82,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
 
   const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
     givenRequestWouldOtherwiseSucceed: () => givenRequestToCreateFacilityPartyInAcbsSucceeds(),
-    makeRequest: () => api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor),
+    makeRequest: () => postForFacilityIdentifier(requestBodyToCreateFacilityInvestor),
     successStatusCode: 201,
   });
 
@@ -97,7 +99,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     givenAuthenticationWithTheIdpSucceeds();
     const acbsRequest = givenRequestToCreateFacilityPartyInAcbsSucceeds();
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor);
+    const { status, body } = await postForFacilityIdentifier(requestBodyToCreateFacilityInvestor);
 
     expect(status).toBe(201);
     expect(body).toStrictEqual({
@@ -114,11 +116,11 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
       LenderType: { LenderTypeCode: PROPERTIES.FACILITY_INVESTOR.DEFAULT.lenderType.lenderTypeCode },
     };
     givenAuthenticationWithTheIdpSucceeds();
-    const acbsRequest = requestToCreateFacilityPartyInAcbsWithRequestBody(acbsRequestBodyWithDefaultLenderTypeCode).reply(201, undefined, {
-      location: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderType}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}`,
-    });
+    const acbsRequest = requestToCreateFacilityPartyInAcbs({ facilityId: facilityIdentifier, requestBody: acbsRequestBodyWithDefaultLenderTypeCode }).reply(
+      ...acbsSuccessResponseForFacilityId(facilityIdentifier),
+    );
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyWithoutLenderType);
+    const { status, body } = await postForFacilityIdentifier(requestBodyWithoutLenderType);
 
     expect(status).toBe(201);
     expect(body).toStrictEqual({
@@ -131,7 +133,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     givenAuthenticationWithTheIdpSucceeds();
     requestToCreateFacilityPartyInAcbs().reply(400, 'The facility not found or user does not have access');
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor);
+    const { status, body } = await postForFacilityIdentifier(requestBodyToCreateFacilityInvestor);
 
     expect(status).toBe(404);
     expect(body).toStrictEqual({ message: 'Not found', statusCode: 404 });
@@ -142,7 +144,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     const acbsErrorMessage = { Message: 'error message' };
     requestToCreateFacilityPartyInAcbs().reply(400, acbsErrorMessage);
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor);
+    const { status, body } = await postForFacilityIdentifier(requestBodyToCreateFacilityInvestor);
 
     expect(status).toBe(400);
     expect(body).toStrictEqual({ message: 'Bad request', error: JSON.stringify(acbsErrorMessage), statusCode: 400 });
@@ -153,7 +155,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     const acbsErrorMessage = 'ACBS error message';
     requestToCreateFacilityPartyInAcbs().reply(400, acbsErrorMessage);
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor);
+    const { status, body } = await postForFacilityIdentifier(requestBodyToCreateFacilityInvestor);
 
     expect(status).toBe(400);
     expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
@@ -163,16 +165,27 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     givenAuthenticationWithTheIdpSucceeds();
     requestToCreateFacilityPartyInAcbs().reply(401, 'Unauthorized');
 
-    const { status, body } = await api.post(createFacilityInvestorUrl, requestBodyToCreateFacilityInvestor);
+    const { status, body } = await postForFacilityIdentifier(requestBodyToCreateFacilityInvestor);
 
     expect(status).toBe(500);
     expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
   });
 
+  withFacilityIdentifierUrlValidationApiTests({
+    makeRequestWithFacilityId: (facilityId: string) => post({ facilityId, body: requestBodyToCreateFacilityInvestor }),
+    givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId: string) => {
+      givenAuthenticationWithTheIdpSucceeds();
+      requestToCreateFacilityPartyInAcbs({ facilityId, requestBody: acbsRequestBodyToCreateFacilityParty }).reply(
+        ...acbsSuccessResponseForFacilityId(facilityId),
+      );
+    },
+    successStatusCode: 201,
+  });
+
   withDateOnlyFieldValidationApiTests({
     fieldName: 'effectiveDate',
     validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
+    makeRequest: (body) => postForFacilityIdentifier(body),
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
@@ -182,7 +195,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
   withDateOnlyFieldValidationApiTests({
     fieldName: 'guaranteeExpiryDate',
     validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
+    makeRequest: (body) => postForFacilityIdentifier(body),
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
@@ -192,7 +205,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
   withNonNegativeNumberFieldValidationApiTests({
     fieldName: 'maximumLiability',
     validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
+    makeRequest: (body) => postForFacilityIdentifier(body),
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
@@ -202,7 +215,7 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
   withCurrencyFieldValidationApiTests({
     valueGenerator,
     validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
+    makeRequest: (body) => postForFacilityIdentifier(body),
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
@@ -215,24 +228,33 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
     required: false,
     generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
     validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
+    makeRequest: (body) => postForFacilityIdentifier(body),
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
     },
   });
 
+  const postForFacilityIdentifier = (body: object): supertest.Test => post({ facilityId: facilityIdentifier, body });
+
+  const post = ({ facilityId, body }: { facilityId: string; body: object }): supertest.Test => {
+    const url = `/api/v1/facilities/${facilityId}/investors`;
+    return api.post(url, body);
+  };
+
   const givenRequestToCreateFacilityPartyInAcbsSucceeds = (): nock.Scope =>
-    requestToCreateFacilityPartyInAcbs().reply(201, undefined, {
-      location: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderType}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}`,
-    });
+    requestToCreateFacilityPartyInAcbs().reply(...acbsSuccessResponseForFacilityId(facilityIdentifier));
 
-  const requestToCreateFacilityPartyInAcbs = (): nock.Interceptor => requestToCreateFacilityPartyInAcbsWithRequestBody(acbsRequestBodyToCreateFacilityParty);
-
-  const requestToCreateFacilityPartyInAcbsWithRequestBody = (requestBody: nock.RequestBodyMatcher): nock.Interceptor =>
-    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
-      .post(`/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty`, requestBody)
+  const requestToCreateFacilityPartyInAcbs = (
+    { facilityId, requestBody }: { facilityId: string; requestBody: nock.RequestBodyMatcher } = {
+      facilityId: facilityIdentifier,
+      requestBody: acbsRequestBodyToCreateFacilityParty,
+    },
+  ): nock.Interceptor => {
+    return nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .post(`/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/FacilityParty`, requestBody)
       .matchHeader('authorization', `Bearer ${idToken}`);
+  };
 
   const givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds = (): void => {
     const requestBodyPlaceholder = '*';
@@ -240,8 +262,14 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
       .filteringRequestBody(() => requestBodyPlaceholder)
       .post(`/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty`, requestBodyPlaceholder)
       .matchHeader('authorization', `Bearer ${idToken}`)
-      .reply(201, undefined, {
-        location: `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityParty?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderType}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}`,
-      });
+      .reply(...acbsSuccessResponseForFacilityId(facilityIdentifier));
   };
+
+  const acbsSuccessResponseForFacilityId = (facilityId: string): [number, undefined, { location: string }] => [
+    201,
+    undefined,
+    {
+      location: `/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/FacilityParty?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderType}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}`,
+    },
+  ];
 });

--- a/test/facility-investor/post-facility-investor.api-test.ts
+++ b/test/facility-investor/post-facility-investor.api-test.ts
@@ -34,7 +34,6 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
 
   const requestBodyToCreateFacilityInvestor: CreateFacilityInvestorRequest = [
     {
-      facilityIdentifier,
       effectiveDate: effectiveDateInFuture,
       guaranteeExpiryDate: guaranteeExpiryDateInFuture,
       lenderType,
@@ -202,19 +201,6 @@ describe('POST /facilities/{facilityIdentifier}/investors', () => {
 
   withCurrencyFieldValidationApiTests({
     valueGenerator,
-    validRequestBody: requestBodyToCreateFacilityInvestor,
-    makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
-    givenAnyRequestBodyWouldSucceed: () => {
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateFacilityInvestorInAcbsSucceeds();
-    },
-  });
-
-  withStringFieldValidationApiTests({
-    fieldName: 'facilityIdentifier',
-    length: 10,
-    required: true,
-    generateFieldValueOfLength: (length: number) => valueGenerator.ukefId(length - 4),
     validRequestBody: requestBodyToCreateFacilityInvestor,
     makeRequest: (body) => api.post(createFacilityInvestorUrl, body),
     givenAnyRequestBodyWouldSucceed: () => {


### PR DESCRIPTION
## Introduction

During testing, the client used the `POST /facilities/{facilityId}/investors` endpoint and received a 400 response with an empty response message.

After investigation, it turned out that this was actually user error - the client had used `:facilityIdentifier` as the facility id in the URL which caused an ACBS 400 error with an empty response message. However it did highlight 2 changes we wanted to make to improve usability and prevent this user error happening again:

1. remove `facilityIdentifier` from the request body since it is already in the URL
2. add the validation rules to `facilityIdentifier` in the URL that we're using on the newer endpoints.

I'll also raise a ticket to make sure the above 2 changes are implemented across _all_ our endpoints.

## Resolution

For `POST /facilities/{facilityId}/investors`:
1. I have removed `facilityIdentifier` from the request body (and updated our documented list of changes to note this)
1. I have added the validation rules for `facilityId` in the URL that we are using on newer endpoints

