### PR TITLE
feat(APIM-170): add acbs deal borrowing restriction service

### DIFF
--- a/src/modules/acbs/acbs-deal-borrowing-restriction.service.test.ts
+++ b/src/modules/acbs/acbs-deal-borrowing-restriction.service.test.ts
@@ -1,0 +1,182 @@
+import { HttpService } from '@nestjs/axios';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsDealBorrowingRestrictionService } from './acbs-deal-borrowing-restriction.service';
+import { AcbsUpdateDealBorrowingRestrictionRequest } from './dto/acbs-update-deal-borrowing-restriction-request.dto';
+import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
+
+describe('AcbsDealBorrowingRestrictionService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const dealIdentifier = valueGenerator.stringOfNumericCharacters();
+  const portfolioIdentifier = valueGenerator.portfolioId();
+
+  const newBorrowingRestriction: AcbsUpdateDealBorrowingRestrictionRequest = {
+    SequenceNumber: valueGenerator.nonnegativeInteger(),
+    RestrictGroupCategory: {
+      RestrictGroupCategoryCode: valueGenerator.string(),
+    },
+    IncludingIndicator: valueGenerator.boolean(),
+    IncludeExcludeAllItemsIndicator: valueGenerator.boolean(),
+  };
+
+  const expectedHttpServicePutArgs = [
+    `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/BorrowingRestriction`,
+    newBorrowingRestriction,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    },
+  ];
+
+  let httpService: HttpService;
+  let service: AcbsDealBorrowingRestrictionService;
+
+  let httpServicePut: jest.Mock;
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServicePut = jest.fn();
+    httpService.put = httpServicePut;
+
+    service = new AcbsDealBorrowingRestrictionService({ baseUrl }, httpService);
+  });
+
+  describe('updateBorrowingRestrictionForDeal', () => {
+    it('sends a PUT to ACBS with the specified parameters', async () => {
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(
+          of({
+            data: '',
+            status: 200,
+            statusText: 'OK',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      await service.updateBorrowingRestrictionForDeal(portfolioIdentifier, dealIdentifier, newBorrowingRestriction, idToken);
+
+      expect(httpServicePut).toHaveBeenCalledTimes(1);
+      expect(httpServicePut).toHaveBeenCalledWith(...expectedHttpServicePutArgs);
+    });
+
+    it('throws an AcbsResourceNotFoundException if ACBS responds with a 400 that is a string containing "The deal not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = 'The deal not found or the user does not have access to it.';
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const updateBorrowingRestrictionForDealPromise = service.updateBorrowingRestrictionForDeal(
+        portfolioIdentifier,
+        dealIdentifier,
+        newBorrowingRestriction,
+        idToken,
+      );
+
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toThrow(`Deal with identifier ${dealIdentifier} was not found by ACBS.`);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is a string that does not contain "The deal not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = valueGenerator.string();
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const updateBorrowingRestrictionForDealPromise = service.updateBorrowingRestrictionForDeal(
+        portfolioIdentifier,
+        dealIdentifier,
+        newBorrowingRestriction,
+        idToken,
+      );
+
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toThrow(`Failed to update a borrowing restriction for deal ${dealIdentifier} in ACBS.`);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('errorBody', errorString);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is not a string', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const updateBorrowingRestrictionForDealPromise = service.updateBorrowingRestrictionForDeal(
+        portfolioIdentifier,
+        dealIdentifier,
+        newBorrowingRestriction,
+        idToken,
+      );
+
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toThrow(`Failed to update a borrowing restriction for deal ${dealIdentifier} in ACBS.`);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('errorBody', JSON.stringify(errorBody));
+    });
+
+    it('throws an AcbsUnexpectedException if ACBS responds with an error code that is not 400', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const updateBorrowingRestrictionForDealPromise = service.updateBorrowingRestrictionForDeal(
+        portfolioIdentifier,
+        dealIdentifier,
+        newBorrowingRestriction,
+        idToken,
+      );
+
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toBeInstanceOf(AcbsUnexpectedException);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toThrow(`Failed to update a borrowing restriction for deal ${dealIdentifier} in ACBS.`);
+      await expect(updateBorrowingRestrictionForDealPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-deal-borrowing-restriction.service.ts
+++ b/src/modules/acbs/acbs-deal-borrowing-restriction.service.ts
@@ -1,0 +1,35 @@
+import { HttpService } from '@nestjs/axios';
+import { Inject, Injectable } from '@nestjs/common';
+import AcbsConfig from '@ukef/config/acbs.config';
+
+import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
+import { AcbsHttpService } from './acbs-http.service';
+import { AcbsUpdateDealBorrowingRestrictionRequest } from './dto/acbs-update-deal-borrowing-restriction-request.dto';
+import { getDealNotFoundKnownAcbsError } from './known-errors';
+import { createWrapAcbsHttpPostOrPutErrorCallback } from './wrap-acbs-http-error-callback';
+
+@Injectable()
+export class AcbsDealBorrowingRestrictionService {
+  private readonly acbsHttpService: AcbsHttpService;
+
+  constructor(@Inject(AcbsConfig.KEY) config: AcbsConfigBaseUrl, httpService: HttpService) {
+    this.acbsHttpService = new AcbsHttpService(config, httpService);
+  }
+
+  async updateBorrowingRestrictionForDeal(
+    portfolioIdentifier: string,
+    dealIdentifier: string,
+    replacementDealBorrowingRestriction: AcbsUpdateDealBorrowingRestrictionRequest,
+    idToken: string,
+  ): Promise<void> {
+    await this.acbsHttpService.put({
+      path: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/BorrowingRestriction`,
+      requestBody: replacementDealBorrowingRestriction,
+      idToken,
+      onError: createWrapAcbsHttpPostOrPutErrorCallback({
+        messageForUnknownError: `Failed to update a borrowing restriction for deal ${dealIdentifier} in ACBS.`,
+        knownErrors: [getDealNotFoundKnownAcbsError(dealIdentifier)],
+      }),
+    });
+  }
+}

--- a/src/modules/acbs/acbs-deal-party.service.test.ts
+++ b/src/modules/acbs/acbs-deal-party.service.test.ts
@@ -1,6 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { PROPERTIES } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { CreateDealInvestorGenerator } from '@ukef-test/support/generator/create-deal-investor-generator';
 import { GetDealInvestorGenerator } from '@ukef-test/support/generator/get-deal-investor-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
@@ -8,8 +10,6 @@ import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
-import { CurrentDateProvider } from '../date/current-date.provider';
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsDealPartyService } from './acbs-deal-party.service';
 import { AcbsException } from './exception/acbs.exception';
 import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
@@ -40,7 +40,7 @@ describe('AcbsDealPartyService', () => {
 
   describe('getDealPartyForDeal', () => {
     const dealIdentifier = valueGenerator.ukefId();
-    const portfolioIdentifier = valueGenerator.string();
+    const portfolioIdentifier = valueGenerator.portfolioId();
     const acbsDealPartyURL = `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealParty`;
 
     it('throws an AcbsException if the request to ACBS fails', async () => {

--- a/src/modules/acbs/acbs-deal.service.get-deal-by-identifier.test.ts
+++ b/src/modules/acbs/acbs-deal.service.get-deal-by-identifier.test.ts
@@ -14,7 +14,7 @@ describe('AcbsDealService', () => {
   const valueGenerator = new RandomValueGenerator();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const dealIdentifier = valueGenerator.stringOfNumericCharacters({ length: 10 });
 
   let httpService: HttpService;

--- a/src/modules/acbs/acbs-facility-covenant.service.get-covenants.test.ts
+++ b/src/modules/acbs/acbs-facility-covenant.service.get-covenants.test.ts
@@ -1,11 +1,11 @@
 import { HttpService } from '@nestjs/axios';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetFacilityCovenantGenerator } from '@ukef-test/support/generator/get-facility-covenant-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsFacilityCovenantService } from './acbs-facility-covenant.service';
 import { AcbsException } from './exception/acbs.exception';
 
@@ -14,7 +14,7 @@ describe('AcbsFacilityCovenantService', () => {
   const dateStringTransformations = new DateStringTransformations();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   let httpService: HttpService;

--- a/src/modules/acbs/acbs-facility-fixed-fee.service.test.ts
+++ b/src/modules/acbs/acbs-facility-fixed-fee.service.test.ts
@@ -1,11 +1,11 @@
 import { HttpService } from '@nestjs/axios';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsFacilityFixedFeeService } from './acbs-facility-fixed-fee.service';
 import { AcbsException } from './exception/acbs.exception';
 
@@ -13,7 +13,7 @@ describe('AcbsFacilityFixedFeeService', () => {
   const valueGenerator = new RandomValueGenerator();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   let httpService: HttpService;

--- a/src/modules/acbs/acbs-facility-loan.service.test.ts
+++ b/src/modules/acbs/acbs-facility-loan.service.test.ts
@@ -1,11 +1,11 @@
 import { HttpService } from '@nestjs/axios';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetFacilityLoanGenerator } from '@ukef-test/support/generator/get-facility-loan-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { of, throwError } from 'rxjs';
 
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { AcbsFacilityLoanService } from './acbs-facility-loan.service';
 import { AcbsException } from './exception/acbs.exception';
 import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
@@ -15,7 +15,7 @@ describe('AcbsFacilityLoanService', () => {
   const dateStringTransformations = new DateStringTransformations();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   let httpService: HttpService;

--- a/src/modules/acbs/acbs-facility-party.service.get-by-facility-identifier.test.ts
+++ b/src/modules/acbs/acbs-facility-party.service.get-by-facility-identifier.test.ts
@@ -13,7 +13,7 @@ describe('AcbsFacilityPartyService', () => {
   const valueGenerator = new RandomValueGenerator();
   const idToken = valueGenerator.string();
   const baseUrl = valueGenerator.httpsUrl();
-  const portfolioIdentifier = valueGenerator.string({ length: 2 });
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.ukefId();
 
   const { facilityInvestorsInAcbs } = new GetFacilityInvestorGenerator(valueGenerator).generate({

--- a/src/modules/acbs/acbs.module.ts
+++ b/src/modules/acbs/acbs.module.ts
@@ -5,6 +5,7 @@ import { HttpModule } from '@ukef/modules/http/http.module';
 
 import { AcbsBundleInformationService } from './acbs-bundle-information.service';
 import { AcbsDealService } from './acbs-deal.service';
+import { AcbsDealBorrowingRestrictionService } from './acbs-deal-borrowing-restriction.service';
 import { AcbsDealGuaranteeService } from './acbs-deal-guarantee.service';
 import { AcbsDealPartyService } from './acbs-deal-party.service';
 import { AcbsFacilityService } from './acbs-facility.service';
@@ -33,6 +34,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsPartyService,
     AcbsPartyExternalRatingService,
     AcbsDealService,
+    AcbsDealBorrowingRestrictionService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
     AcbsFacilityService,
@@ -48,6 +50,7 @@ import { AcbsPartyExternalRatingService } from './acbs-party-external-rating.ser
     AcbsPartyService,
     AcbsPartyExternalRatingService,
     AcbsDealService,
+    AcbsDealBorrowingRestrictionService,
     AcbsDealGuaranteeService,
     AcbsDealPartyService,
     AcbsFacilityService,

--- a/src/modules/acbs/dto/acbs-update-deal-borrowing-restriction-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-update-deal-borrowing-restriction-request.dto.ts
@@ -1,0 +1,8 @@
+export interface AcbsUpdateDealBorrowingRestrictionRequest {
+  SequenceNumber: number;
+  RestrictGroupCategory: {
+    RestrictGroupCategoryCode: string;
+  };
+  IncludingIndicator: boolean;
+  IncludeExcludeAllItemsIndicator: boolean;
+}

--- a/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
@@ -69,7 +69,7 @@ describe('DealGuaranteeController', () => {
 
   describe('getGuaranteesForDeal', () => {
     const dealIdentifier = valueGenerator.ukefId();
-    const portfolioIdentifier = valueGenerator.string();
+    const portfolioIdentifier = valueGenerator.portfolioId();
 
     const { dealGuaranteesFromService } = new GetDealGuaranteeGenerator(valueGenerator).generate({
       numberToGenerate: 2,

--- a/src/modules/deal-investor/deal-investor.controller.test.ts
+++ b/src/modules/deal-investor/deal-investor.controller.test.ts
@@ -1,11 +1,11 @@
 import { UkefId } from '@ukef/helpers';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { CreateDealInvestorGenerator } from '@ukef-test/support/generator/create-deal-investor-generator';
 import { GetDealInvestorGenerator } from '@ukef-test/support/generator/get-deal-investor-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { CurrentDateProvider } from '../date/current-date.provider';
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { DealInvestorController } from './deal-investor.controller';
 import { DealInvestorService } from './deal-investor.service';
 import { CreateDealInvestorResponse } from './dto/create-deal-investor-response.dto';
@@ -37,7 +37,7 @@ describe('DealInvestorController', () => {
 
   describe('getDealInvestors', () => {
     const dealIdentifier = valueGenerator.ukefId();
-    const portfolioIdentifier = valueGenerator.string();
+    const portfolioIdentifier = valueGenerator.portfolioId();
 
     const { dealInvestorsFromService } = new GetDealInvestorGenerator(valueGenerator).generate({
       numberToGenerate: 2,

--- a/src/modules/facility-covenant/facility-covenant.controller.test.ts
+++ b/src/modules/facility-covenant/facility-covenant.controller.test.ts
@@ -76,7 +76,7 @@ describe('FacilityCovenantController', () => {
   });
 
   describe('getCovenantsForFacility', () => {
-    const portfolioIdentifier = valueGenerator.string();
+    const portfolioIdentifier = valueGenerator.portfolioId();
 
     const { facilityCovenantsFromApi: covenantsFromService } = new GetFacilityCovenantGenerator(valueGenerator, dateStringTransformations).generate({
       numberToGenerate: 2,

--- a/src/modules/facility-fixed-fee/facility-fixed-fee.controller.test.ts
+++ b/src/modules/facility-fixed-fee/facility-fixed-fee.controller.test.ts
@@ -1,14 +1,14 @@
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetFacilityFixedFeeGenerator } from '@ukef-test/support/generator/get-facility-fixed-fee-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { DateStringTransformations } from '../date/date-string.transformations';
-import { FacilityFixedFeeController } from '../facility-fixed-fee/facility-fixed-fee.controller';
-import { FacilityFixedFeeService } from '../facility-fixed-fee/facility-fixed-fee.service';
+import { FacilityFixedFeeController } from './facility-fixed-fee.controller';
+import { FacilityFixedFeeService } from './facility-fixed-fee.service';
 
 describe('FacilityFixedFeeController', () => {
   const valueGenerator = new RandomValueGenerator();
-  const portfolioIdentifier = valueGenerator.string();
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   const { apiFacilityFixedFees: serviceFixedFees } = new GetFacilityFixedFeeGenerator(valueGenerator, new DateStringTransformations()).generate({

--- a/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.test.ts
@@ -1,8 +1,8 @@
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { DateStringTransformations } from '../date/date-string.transformations';
 import { CreateFacilityGuaranteeRequestItem } from './dto/create-facility-guarantee-request.dto';
 import { CreateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
 import { FacilityGuaranteeController } from './facility-guarantee.controller';
@@ -10,7 +10,7 @@ import { FacilityGuaranteeService } from './facility-guarantee.service';
 
 describe('FacilityGuaranteeController', () => {
   const valueGenerator = new RandomValueGenerator();
-  const portfolioIdentifier = valueGenerator.string();
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   const { facilityGuarantees: guaranteesFromService } = new GetFacilityGuaranteeGenerator(valueGenerator, new DateStringTransformations()).generate({

--- a/src/modules/facility-loan/facility-loan.controller.test.ts
+++ b/src/modules/facility-loan/facility-loan.controller.test.ts
@@ -9,7 +9,7 @@ import { FacilityLoanService } from './facility-loan.service';
 
 describe('FacilityLoanController', () => {
   const valueGenerator = new RandomValueGenerator();
-  const portfolioIdentifier = valueGenerator.string();
+  const portfolioIdentifier = valueGenerator.portfolioId();
   const facilityIdentifier = valueGenerator.facilityId();
 
   let getFacilityLoansService: jest.Mock;

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -103,6 +103,10 @@ export class RandomValueGenerator {
     return ACBSID.BUNDLE_ID.PREFIX.concat(this.stringOfNumericCharacters({ length: lengthExcludingPrefix ?? 6 })) as AcbsBundleId;
   }
 
+  portfolioId(): string {
+    return this.string({ length: 2 });
+  }
+
   loanId(): string {
     return this.stringOfNumericCharacters({ length: 10 });
   }


### PR DESCRIPTION
## Introduction

For APIM-170, we want to create a borrowing restriction for every deal we create through `POST /deals`. We need to do this through the `PUT /Portfolio/{portfolioId}/Deal/{dealId}/BorrowingRestriction`.

In this PR, we create the ACBS service for sending this request (note that this does not complete APIM-170, but is the first part of it).

## Resolution

I've created `AcbsDealBorrowingRestrictionService` with a method for sending a PUT to `/Portfolio/{portfolioId}/Deal/{dealId}/BorrowingRestriction` that has our usual error handling for ACBS requests.

## Misc

I added a `portfolioId` method to `RandomValueGenerator` to make it easier to generate a random portfolio id for tests.
