### PR TITLE
feat(APIM-170): update deal borrowing restriction after creating deal

### DIFF
--- a/src/constants/properties.constant.ts
+++ b/src/constants/properties.constant.ts
@@ -109,6 +109,16 @@ export const PROPERTIES = {
       riskMitigationCode: '',
     },
   },
+  DEAL_BORROWING_RESTRICTION: {
+    DEFAULT: {
+      sequenceNumber: 1,
+      restrictGroupCategory: {
+        restrictGroupCategoryCode: '36',
+      },
+      includingIndicator: true,
+      includeExcludeAllItemsIndicator: true,
+    },
+  },
   DEAL_GUARANTEE: {
     DEFAULT: {
       sectionIdentifier: '00',

--- a/src/logging/log-keys-to-redact.test.ts
+++ b/src/logging/log-keys-to-redact.test.ts
@@ -88,5 +88,19 @@ describe('logKeysToRedact', () => {
       expect(result).toContain(buildKeyToRedact([logKey, 'innerError', sensitiveChildKeys[0]]));
       expect(result).toContain(buildKeyToRedact([logKey, 'innerError', sensitiveChildKeys[1]]));
     });
+
+    it('includes all sensitive child keys of an error cause', () => {
+      const { logKey, sensitiveChildKeys } = options.error;
+
+      expect(result).toContain(buildKeyToRedact([logKey, 'options', 'cause', sensitiveChildKeys[0]]));
+      expect(result).toContain(buildKeyToRedact([logKey, 'options', 'cause', sensitiveChildKeys[1]]));
+    });
+
+    it(`includes all sensitive child keys of an error cause's inner error`, () => {
+      const { logKey, sensitiveChildKeys } = options.error;
+
+      expect(result).toContain(buildKeyToRedact([logKey, 'options', 'cause', 'innerError', sensitiveChildKeys[0]]));
+      expect(result).toContain(buildKeyToRedact([logKey, 'options', 'cause', 'innerError', sensitiveChildKeys[1]]));
+    });
   });
 });

--- a/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
+++ b/src/modules/acbs-adapter/acbs-exception-transform.interceptor.test.ts
@@ -31,6 +31,7 @@ describe('AcbsExceptionTransformInterceptor', () => {
     await expect(interceptPromise).rejects.toBeInstanceOf(BadRequestException);
     await expect(interceptPromise).rejects.toHaveProperty('message', 'Bad request');
     await expect(interceptPromise).rejects.toHaveProperty('cause', acbsBadRequestException);
+    await expect(interceptPromise).rejects.toHaveProperty('response.error', errorBody);
   });
 
   it('does NOT convert thrown exceptions that are NOT AcbsResourceNotFoundException or AcbsBadRequestException', async () => {

--- a/src/modules/deal/deal-borrowing-restriction.service.test.ts
+++ b/src/modules/deal/deal-borrowing-restriction.service.test.ts
@@ -1,0 +1,46 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsDealBorrowingRestrictionService } from '@ukef/modules/acbs/acbs-deal-borrowing-restriction.service';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { CreateDealGenerator } from '@ukef-test/support/generator/create-deal-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { DealBorrowingRestrictionService } from './deal-borrowing-restriction.service';
+
+describe('DealBorrowingRestrictionService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const dealIdentifier = valueGenerator.dealId();
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+
+  const { acbsUpdateDealBorrowingRestrictionRequest: expectedRequest } = new CreateDealGenerator(valueGenerator, new DateStringTransformations()).generate({
+    numberToGenerate: 1,
+  });
+
+  let service: DealBorrowingRestrictionService;
+  let updateBorrowingRestrictionForDealInAcbs: jest.Mock;
+
+  beforeEach(() => {
+    const acbsDealBorrowingRestrictionService = new AcbsDealBorrowingRestrictionService(null, null);
+    updateBorrowingRestrictionForDealInAcbs = jest.fn();
+    acbsDealBorrowingRestrictionService.updateBorrowingRestrictionForDeal = updateBorrowingRestrictionForDealInAcbs;
+
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    const acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    service = new DealBorrowingRestrictionService(acbsAuthenticationService, acbsDealBorrowingRestrictionService);
+  });
+
+  describe('updateBorrowingRestrictionForDeal', () => {
+    it('updates the borrowing restriction for the deal in ACBS', async () => {
+      when(updateBorrowingRestrictionForDealInAcbs).calledWith();
+
+      await service.updateBorrowingRestrictionForDeal(dealIdentifier);
+
+      expect(updateBorrowingRestrictionForDealInAcbs).toHaveBeenCalledWith(portfolioIdentifier, dealIdentifier, expectedRequest, idToken);
+    });
+  });
+});

--- a/src/modules/deal/deal-borrowing-restriction.service.ts
+++ b/src/modules/deal/deal-borrowing-restriction.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { PROPERTIES } from '@ukef/constants';
+
+import { AcbsDealBorrowingRestrictionService } from '../acbs/acbs-deal-borrowing-restriction.service';
+import { AcbsUpdateDealBorrowingRestrictionRequest } from '../acbs/dto/acbs-update-deal-borrowing-restriction-request.dto';
+import { AcbsAuthenticationService } from '../acbs-authentication/acbs-authentication.service';
+
+@Injectable()
+export class DealBorrowingRestrictionService {
+  constructor(
+    private readonly acbsAuthenticationService: AcbsAuthenticationService,
+    private readonly acbsDealBorrowingRestrictionService: AcbsDealBorrowingRestrictionService,
+  ) {}
+
+  async updateBorrowingRestrictionForDeal(dealIdentifier: string): Promise<void> {
+    const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+    const borrowingRestrictionToUpdateInAcbs = this.buildBorrowingRestrictionToUpdateInAcbs();
+    const idToken = await this.acbsAuthenticationService.getIdToken();
+
+    return this.acbsDealBorrowingRestrictionService.updateBorrowingRestrictionForDeal(
+      portfolioIdentifier,
+      dealIdentifier,
+      borrowingRestrictionToUpdateInAcbs,
+      idToken,
+    );
+  }
+
+  private buildBorrowingRestrictionToUpdateInAcbs(): AcbsUpdateDealBorrowingRestrictionRequest {
+    const defaultValues = PROPERTIES.DEAL_BORROWING_RESTRICTION.DEFAULT;
+    const borrowingRestrictionToUpdateInAcbs: AcbsUpdateDealBorrowingRestrictionRequest = {
+      SequenceNumber: defaultValues.sequenceNumber,
+      RestrictGroupCategory: {
+        RestrictGroupCategoryCode: defaultValues.restrictGroupCategory.restrictGroupCategoryCode,
+      },
+      IncludingIndicator: defaultValues.includingIndicator,
+      IncludeExcludeAllItemsIndicator: defaultValues.includeExcludeAllItemsIndicator,
+    };
+    return borrowingRestrictionToUpdateInAcbs;
+  }
+}

--- a/src/modules/deal/deal.controller.test.ts
+++ b/src/modules/deal/deal.controller.test.ts
@@ -28,7 +28,7 @@ describe('DealController', () => {
   let dealServiceGetDealByIdentifier: jest.Mock;
 
   beforeEach(() => {
-    dealService = new DealService(null, null, null, null);
+    dealService = new DealService(null, null, null, null, null);
 
     dealServiceCreateDeal = jest.fn();
     dealService.createDeal = dealServiceCreateDeal;

--- a/src/modules/deal/deal.module.ts
+++ b/src/modules/deal/deal.module.ts
@@ -4,10 +4,11 @@ import { DateModule } from '@ukef/modules/date/date.module';
 
 import { DealController } from './deal.controller';
 import { DealService } from './deal.service';
+import { DealBorrowingRestrictionService } from './deal-borrowing-restriction.service';
 
 @Module({
   imports: [AcbsModule, DateModule],
   controllers: [DealController],
-  providers: [DealService],
+  providers: [DealService, DealBorrowingRestrictionService],
 })
 export class DealModule {}

--- a/src/modules/deal/deal.service.create-deal.test.ts
+++ b/src/modules/deal/deal.service.create-deal.test.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common';
 import { PROPERTIES } from '@ukef/constants';
 import { AcbsDealService } from '@ukef/modules/acbs/acbs-deal.service';
 import { AcbsCreateDealDto } from '@ukef/modules/acbs/dto/acbs-create-deal.dto';
@@ -9,6 +10,7 @@ import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-
 import { when } from 'jest-when';
 
 import { DealService } from './deal.service';
+import { DealBorrowingRestrictionService } from './deal-borrowing-restriction.service';
 
 describe('DealService', () => {
   const valueGenerator = new RandomValueGenerator();
@@ -18,6 +20,7 @@ describe('DealService', () => {
   let service: DealService;
   let acbsDealServiceCreateDeal: jest.Mock;
   let currentDateProviderGetEarliestDateFromTodayAnd: jest.Mock;
+  let updateDealBorrowingRestriction: jest.Mock;
 
   beforeEach(() => {
     const acbsDealService = new AcbsDealService(null, null);
@@ -33,7 +36,11 @@ describe('DealService', () => {
     currentDateProviderGetEarliestDateFromTodayAnd = jest.fn();
     currentDateProvider.getEarliestDateFromTodayAnd = currentDateProviderGetEarliestDateFromTodayAnd;
 
-    service = new DealService(acbsAuthenticationService, acbsDealService, dateStringTransformations, currentDateProvider);
+    updateDealBorrowingRestriction = jest.fn();
+    const dealBorrowingRestrictionService = new DealBorrowingRestrictionService(null, null);
+    dealBorrowingRestrictionService.updateBorrowingRestrictionForDeal = updateDealBorrowingRestriction;
+
+    service = new DealService(acbsAuthenticationService, acbsDealService, dateStringTransformations, currentDateProvider, dealBorrowingRestrictionService);
   });
 
   describe('createDeal', () => {
@@ -54,108 +61,146 @@ describe('DealService', () => {
       when(currentDateProviderGetEarliestDateFromTodayAnd).calledWith(guaranteeCommencementDateAsDate).mockReturnValueOnce(guaranteeCommencementDateAsDate);
     });
 
-    it('creates a deal in ACBS with a transformation of the requested new deal', async () => {
-      await service.createDeal(dealToCreate);
-
-      expect(acbsDealServiceCreateDeal).toHaveBeenCalledWith(portfolioIdentifier, expectedDealToCreateInAcbs, idToken);
-    });
-
-    it('truncates the obligorName to 19 characters in the Description', async () => {
-      const tooLongObligorName = '123456789_123456789_123456789';
-      const obligorNameTruncatedTo19Characters = '123456789_123456789';
-      const dealWithTooLongObligorName = { ...dealToCreate, obligorName: tooLongObligorName };
-      const descriptionWithTruncatedObligorName = CreateDealGenerator.getExpectedDescription({
-        obligorName: obligorNameTruncatedTo19Characters,
-        currency: dealToCreate.currency,
-        formattedDate: guaranteeCommencementDateForDescription,
-      });
-
-      await service.createDeal(dealWithTooLongObligorName);
-
-      const dealCreatedInAcbs = getDealCreatedInAcbs();
-
-      expect(dealCreatedInAcbs.Description).toBe(descriptionWithTruncatedObligorName);
-    });
-
-    it('rounds the dealValue to 2dp for the LimitAmount', async () => {
-      const dealValueWithMoreThan2dp = 1.234;
-      const dealValueRoundedTo2dp = 1.23;
-      const dealWithDealValueWithMoreThan2dp = { ...dealToCreate, dealValue: dealValueWithMoreThan2dp };
-
-      await service.createDeal(dealWithDealValueWithMoreThan2dp);
-
-      const dealCreatedInAcbs = getDealCreatedInAcbs();
-
-      expect(dealCreatedInAcbs.LimitAmount).toBe(dealValueRoundedTo2dp);
-    });
-
-    describe('replaces the guaranteeCommencementDate with today if the guaranteeCommencementDate is after today', () => {
-      let dealCreatedInAcbs: AcbsCreateDealDto;
-
-      beforeEach(async () => {
-        currentDateProviderGetEarliestDateFromTodayAnd.mockReset();
-        when(currentDateProviderGetEarliestDateFromTodayAnd).calledWith(guaranteeCommencementDateAsDate).mockReturnValueOnce(now);
-
+    describe('creating the deal', () => {
+      it('creates a deal in ACBS with a transformation of the requested new deal', async () => {
         await service.createDeal(dealToCreate);
 
-        dealCreatedInAcbs = getDealCreatedInAcbs();
+        expect(acbsDealServiceCreateDeal).toHaveBeenCalledWith(portfolioIdentifier, expectedDealToCreateInAcbs, idToken);
       });
 
-      it('in the OriginalEffectiveDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.OriginalEffectiveDate).toBe(midnightToday);
-      });
-
-      it('in the OriginalApprovalDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.OriginalApprovalDate).toBe(midnightToday);
-      });
-
-      it('in the TargetClosingDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.TargetClosingDate).toBe(midnightToday);
-      });
-
-      it('in the Description field in ACBS', () => {
-        const expectedDescriptionWithToday = CreateDealGenerator.getExpectedDescription({
-          obligorName: dealToCreate.obligorName,
-          currency: dealToCreate.currency,
-          formattedDate: todayFormattedForDescription,
-        });
-
-        expect(dealCreatedInAcbs.Description).toBe(expectedDescriptionWithToday);
-      });
-    });
-
-    describe('does NOT replace the guaranteeCommencementDate with today if the guaranteeCommencementDate is before or equal to today', () => {
-      let dealCreatedInAcbs: AcbsCreateDealDto;
-
-      beforeEach(async () => {
-        currentDateProviderGetEarliestDateFromTodayAnd.mockReset();
-        when(currentDateProviderGetEarliestDateFromTodayAnd).calledWith(guaranteeCommencementDateAsDate).mockReturnValueOnce(guaranteeCommencementDateAsDate);
-
-        await service.createDeal(dealToCreate);
-
-        dealCreatedInAcbs = getDealCreatedInAcbs();
-      });
-
-      it('in the OriginalEffectiveDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.OriginalEffectiveDate).toBe(guaranteeCommencementDateString);
-      });
-
-      it('in the OriginalApprovalDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.OriginalApprovalDate).toBe(guaranteeCommencementDateString);
-      });
-
-      it('in the TargetClosingDate field in ACBS', () => {
-        expect(dealCreatedInAcbs.TargetClosingDate).toBe(guaranteeCommencementDateString);
-      });
-
-      it('in the Description field in ACBS', () => {
-        const expectedDescriptionWithGuaranteeCommencementDate = CreateDealGenerator.getExpectedDescription({
-          obligorName: dealToCreate.obligorName,
+      it('truncates the obligorName to 19 characters in the Description', async () => {
+        const tooLongObligorName = '123456789_123456789_123456789';
+        const obligorNameTruncatedTo19Characters = '123456789_123456789';
+        const dealWithTooLongObligorName = { ...dealToCreate, obligorName: tooLongObligorName };
+        const descriptionWithTruncatedObligorName = CreateDealGenerator.getExpectedDescription({
+          obligorName: obligorNameTruncatedTo19Characters,
           currency: dealToCreate.currency,
           formattedDate: guaranteeCommencementDateForDescription,
         });
 
-        expect(dealCreatedInAcbs.Description).toBe(expectedDescriptionWithGuaranteeCommencementDate);
+        await service.createDeal(dealWithTooLongObligorName);
+
+        const dealCreatedInAcbs = getDealCreatedInAcbs();
+
+        expect(dealCreatedInAcbs.Description).toBe(descriptionWithTruncatedObligorName);
+      });
+
+      it('rounds the dealValue to 2dp for the LimitAmount', async () => {
+        const dealValueWithMoreThan2dp = 1.234;
+        const dealValueRoundedTo2dp = 1.23;
+        const dealWithDealValueWithMoreThan2dp = { ...dealToCreate, dealValue: dealValueWithMoreThan2dp };
+
+        await service.createDeal(dealWithDealValueWithMoreThan2dp);
+
+        const dealCreatedInAcbs = getDealCreatedInAcbs();
+
+        expect(dealCreatedInAcbs.LimitAmount).toBe(dealValueRoundedTo2dp);
+      });
+
+      describe('replaces the guaranteeCommencementDate with today if the guaranteeCommencementDate is after today', () => {
+        let dealCreatedInAcbs: AcbsCreateDealDto;
+
+        beforeEach(async () => {
+          currentDateProviderGetEarliestDateFromTodayAnd.mockReset();
+          when(currentDateProviderGetEarliestDateFromTodayAnd).calledWith(guaranteeCommencementDateAsDate).mockReturnValueOnce(now);
+
+          await service.createDeal(dealToCreate);
+
+          dealCreatedInAcbs = getDealCreatedInAcbs();
+        });
+
+        it('in the OriginalEffectiveDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.OriginalEffectiveDate).toBe(midnightToday);
+        });
+
+        it('in the OriginalApprovalDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.OriginalApprovalDate).toBe(midnightToday);
+        });
+
+        it('in the TargetClosingDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.TargetClosingDate).toBe(midnightToday);
+        });
+
+        it('in the Description field in ACBS', () => {
+          const expectedDescriptionWithToday = CreateDealGenerator.getExpectedDescription({
+            obligorName: dealToCreate.obligorName,
+            currency: dealToCreate.currency,
+            formattedDate: todayFormattedForDescription,
+          });
+
+          expect(dealCreatedInAcbs.Description).toBe(expectedDescriptionWithToday);
+        });
+      });
+
+      describe('does NOT replace the guaranteeCommencementDate with today if the guaranteeCommencementDate is before or equal to today', () => {
+        let dealCreatedInAcbs: AcbsCreateDealDto;
+
+        beforeEach(async () => {
+          currentDateProviderGetEarliestDateFromTodayAnd.mockReset();
+          when(currentDateProviderGetEarliestDateFromTodayAnd).calledWith(guaranteeCommencementDateAsDate).mockReturnValueOnce(guaranteeCommencementDateAsDate);
+
+          await service.createDeal(dealToCreate);
+
+          dealCreatedInAcbs = getDealCreatedInAcbs();
+        });
+
+        it('in the OriginalEffectiveDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.OriginalEffectiveDate).toBe(guaranteeCommencementDateString);
+        });
+
+        it('in the OriginalApprovalDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.OriginalApprovalDate).toBe(guaranteeCommencementDateString);
+        });
+
+        it('in the TargetClosingDate field in ACBS', () => {
+          expect(dealCreatedInAcbs.TargetClosingDate).toBe(guaranteeCommencementDateString);
+        });
+
+        it('in the Description field in ACBS', () => {
+          const expectedDescriptionWithGuaranteeCommencementDate = CreateDealGenerator.getExpectedDescription({
+            obligorName: dealToCreate.obligorName,
+            currency: dealToCreate.currency,
+            formattedDate: guaranteeCommencementDateForDescription,
+          });
+
+          expect(dealCreatedInAcbs.Description).toBe(expectedDescriptionWithGuaranteeCommencementDate);
+        });
+      });
+    });
+
+    describe('update the deal borrowing restriction', () => {
+      it('updates the borrowing restriction for the deal if it has been created successfully', async () => {
+        await service.createDeal(dealToCreate);
+
+        expect(updateDealBorrowingRestriction).toHaveBeenCalledWith(dealToCreate.dealIdentifier);
+      });
+
+      it('does not update the borrowing restriction for the deal if creating the deal throws an error', async () => {
+        when(acbsDealServiceCreateDeal)
+          .calledWith(portfolioIdentifier, expectedDealToCreateInAcbs, idToken)
+          .mockRejectedValueOnce(new Error('Simulated error for test.'));
+
+        await service.createDeal(dealToCreate).catch(() => {
+          // ignored for test
+        });
+
+        expect(updateDealBorrowingRestriction).not.toHaveBeenCalled();
+      });
+
+      it('throws an InternalServerErrorException if the ACBS service throws an error', async () => {
+        const { dealIdentifier } = dealToCreate;
+        const acbsServiceError = new Error('Simulated error for test.');
+        when(updateDealBorrowingRestriction).calledWith(dealIdentifier).mockRejectedValueOnce(acbsServiceError);
+
+        const createDealPromise = service.createDeal(dealToCreate);
+
+        await expect(createDealPromise).rejects.toBeInstanceOf(InternalServerErrorException);
+        await expect(createDealPromise).rejects.toThrow('Internal server error');
+        await expect(createDealPromise).rejects.toHaveProperty('cause', acbsServiceError);
+        await expect(createDealPromise).rejects.toHaveProperty(
+          'response.error',
+          `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+        );
       });
     });
 

--- a/src/modules/deal/deal.service.get-deal-by-identifier.test.ts
+++ b/src/modules/deal/deal.service.get-deal-by-identifier.test.ts
@@ -66,7 +66,7 @@ describe('DealService', () => {
     const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
 
-    service = new DealService(acbsAuthenticationService, acbsDealService, dateStringTransformations, new CurrentDateProvider());
+    service = new DealService(acbsAuthenticationService, acbsDealService, dateStringTransformations, new CurrentDateProvider(), null);
   });
 
   describe('getDealByIdentifier', () => {

--- a/src/modules/deal/deal.service.ts
+++ b/src/modules/deal/deal.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { PROPERTIES } from '@ukef/constants/properties.constant';
 import { DateString } from '@ukef/helpers';
 import { roundTo2DecimalPlaces } from '@ukef/helpers/round-to-2-decimal-places.helper';
@@ -9,6 +9,7 @@ import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 
 import { Deal } from './deal.interface';
+import { DealBorrowingRestrictionService } from './deal-borrowing-restriction.service';
 import { DealToCreate } from './deal-to-create.interface';
 
 @Injectable()
@@ -18,6 +19,7 @@ export class DealService {
     private readonly acbsDealService: AcbsDealService,
     private readonly dateStringTransformations: DateStringTransformations,
     private readonly currentDateProvider: CurrentDateProvider,
+    private readonly dealBorrowingRestrictionService: DealBorrowingRestrictionService,
   ) {}
 
   async getDealByIdentifier(dealIdentifier: string): Promise<Deal> {
@@ -40,9 +42,9 @@ export class DealService {
   async createDeal(dealToCreate: DealToCreate): Promise<void> {
     const { portfolioIdentifier } = PROPERTIES.GLOBAL;
     const idToken = await this.getIdToken();
-
     const requestBody: AcbsCreateDealDto = this.buildAcbsRequestBodyToCreateDeal(dealToCreate, portfolioIdentifier);
     await this.acbsDealService.createDeal(portfolioIdentifier, requestBody, idToken);
+    return this.updateBorrowingRestrictionForNewDeal(dealToCreate.dealIdentifier);
   }
 
   private getIdToken(): Promise<string> {
@@ -235,5 +237,17 @@ export class DealService {
         RiskMitigationCode: defaultValues.riskMitigationCode,
       },
     };
+  }
+
+  private async updateBorrowingRestrictionForNewDeal(dealIdentifier: string): Promise<void> {
+    try {
+      await this.dealBorrowingRestrictionService.updateBorrowingRestrictionForDeal(dealIdentifier);
+    } catch (error: unknown) {
+      // TODO APIM-170: do we want more logging here?
+      throw new InternalServerErrorException('Internal server error', {
+        cause: error as Error,
+        description: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
+    }
   }
 }

--- a/test/deal/post-deal.api-test.ts
+++ b/test/deal/post-deal.api-test.ts
@@ -7,7 +7,7 @@ import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/req
 import { withNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
 import { Api } from '@ukef-test/support/api';
-import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
 import { CreateDealGenerator } from '@ukef-test/support/generator/create-deal-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import nock from 'nock';
@@ -23,6 +23,7 @@ describe('POST /deals', () => {
   const {
     createDealRequestItem: dealToCreate,
     acbsCreateDealRequest: acbsRequestBodyToCreateDeal,
+    acbsUpdateDealBorrowingRestrictionRequest: acbsRequestBodyToUpdateBorrowingRestriction,
     guaranteeCommencementDateForDescription,
   } = new CreateDealGenerator(valueGenerator, dateStringTransformations).generate({ numberToGenerate: 1 });
   const { dealIdentifier } = dealToCreate;
@@ -51,7 +52,10 @@ describe('POST /deals', () => {
   });
 
   const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
-    givenRequestWouldOtherwiseSucceed: () => givenRequestToCreateDealInAcbsSucceeds(),
+    givenRequestWouldOtherwiseSucceed: () => {
+      givenRequestToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
+    },
     makeRequest: () => api.post(createDealUrl, requestBodyToCreateDeal),
     successStatusCode: 201,
   });
@@ -60,85 +64,216 @@ describe('POST /deals', () => {
     givenTheRequestWouldOtherwiseSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
     makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
       api.postWithoutAuth(createDealUrl, requestBodyToCreateDeal, incorrectAuth?.headerName, incorrectAuth?.headerValue),
   });
 
-  it('returns a 201 response with the identifier of the new deal if ACBS responds with 201', async () => {
+  it('returns a 201 response with the identifier of the new deal if creating the deal and updating the borrowing restriction for the deal both succeed in ACBS', async () => {
     givenAuthenticationWithTheIdpSucceeds();
-    const acbsRequest = requestToCreateDealInAcbs().reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
+    const acbsRequestToCreateDeal = givenRequestToCreateDealInAcbsSucceeds();
+    const acbsRequestToUpdateDealBorrowingRestriction = givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
 
     const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
 
     expect(status).toBe(201);
     expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedDealIdentifierResponse)));
-    expect(acbsRequest.isDone()).toBe(true);
+    expect(acbsRequestToCreateDeal.isDone()).toBe(true);
+    expect(acbsRequestToUpdateDealBorrowingRestriction.isDone()).toBe(true);
   });
 
-  it('rounds the dealValue to 2dp', async () => {
-    givenAuthenticationWithTheIdpSucceeds();
-    const requestBodyWithDealValueToRound = [{ ...requestBodyToCreateDeal[0], dealValue: 1.234 }];
-    const acbsRequestBodyWithRoundedDealValue = {
-      ...acbsRequestBodyToCreateDeal,
-      LimitAmount: 1.23,
-    };
-    const acbsRequest = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithRoundedDealValue).reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
+  describe('transformations of the data for the deal to be created', () => {
+    beforeEach(() => {
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
+    });
 
-    const { status, body } = await api.post(createDealUrl, requestBodyWithDealValueToRound);
+    it('rounds the dealValue to 2dp', async () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      const requestBodyWithDealValueToRound = [{ ...requestBodyToCreateDeal[0], dealValue: 1.234 }];
+      const acbsRequestBodyWithRoundedDealValue = {
+        ...acbsRequestBodyToCreateDeal,
+        LimitAmount: 1.23,
+      };
+      const acbsRequest = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithRoundedDealValue).reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
 
-    expect(status).toBe(201);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedDealIdentifierResponse)));
-    expect(acbsRequest.isDone()).toBe(true);
+      const { status, body } = await api.post(createDealUrl, requestBodyWithDealValueToRound);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedDealIdentifierResponse)));
+      expect(acbsRequest.isDone()).toBe(true);
+    });
+
+    it('truncates the obligorName in the description after 19 characters', async () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      const requestBodyWithObligorNameToTruncate = [{ ...requestBodyToCreateDeal[0], obligorName: '123456789-123456789-123456789' }];
+      const acbsRequestBodyWithTruncatedObligorName = {
+        ...acbsRequestBodyToCreateDeal,
+        Description: CreateDealGenerator.getExpectedDescription({
+          obligorName: '123456789-123456789',
+          currency: dealToCreate.currency,
+          formattedDate: guaranteeCommencementDateForDescription,
+        }),
+      };
+      const acbsRequest = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithTruncatedObligorName).reply(201, undefined, {
+        location: `/Deal/${dealIdentifier}`,
+      });
+
+      const { status, body } = await api.post(createDealUrl, requestBodyWithObligorNameToTruncate);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedDealIdentifierResponse)));
+      expect(acbsRequest.isDone()).toBe(true);
+    });
+
+    it(`replaces the guaranteeCommencementdate with today's date if the specified effectiveDate is after today`, async () => {
+      const requestBodyWithFutureEffectiveDate = [{ ...requestBodyToCreateDeal[0], guaranteeCommencementDate: '9999-01-01' }];
+      const acbsRequestBodyWithTodayEffectiveDate = {
+        ...acbsRequestBodyToCreateDeal,
+        OriginalEffectiveDate: midnightToday,
+        TargetClosingDate: midnightToday,
+        OriginalApprovalDate: midnightToday,
+        Description: CreateDealGenerator.getExpectedDescription({
+          obligorName: dealToCreate.obligorName,
+          currency: dealToCreate.currency,
+          formattedDate: todayFormattedForDescription,
+        }),
+      };
+      givenAuthenticationWithTheIdpSucceeds();
+      const acbsRequestWithTodayEffectiveDate = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithTodayEffectiveDate).reply(201, undefined, {
+        location: `/Deal/${dealIdentifier}`,
+      });
+
+      const { status, body } = await api.post(createDealUrl, requestBodyWithFutureEffectiveDate);
+
+      expect(status).toBe(201);
+      expect(body).toStrictEqual({
+        dealIdentifier,
+      });
+      expect(acbsRequestWithTodayEffectiveDate.isDone()).toBe(true);
+    });
   });
 
-  it('truncates the obligorName in the description after 19 characters', async () => {
-    givenAuthenticationWithTheIdpSucceeds();
-    const requestBodyWithObligorNameToTruncate = [{ ...requestBodyToCreateDeal[0], obligorName: '123456789-123456789-123456789' }];
-    const acbsRequestBodyWithTruncatedObligorName = {
-      ...acbsRequestBodyToCreateDeal,
-      Description: CreateDealGenerator.getExpectedDescription({
-        obligorName: '123456789-123456789',
-        currency: dealToCreate.currency,
-        formattedDate: guaranteeCommencementDateForDescription,
-      }),
-    };
-    const acbsRequest = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithTruncatedObligorName).reply(201, undefined, {
-      location: `/Deal/${dealIdentifier}`,
+  describe('error cases when creating the deal in ACBS', () => {
+    beforeEach(() => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     });
 
-    const { status, body } = await api.post(createDealUrl, requestBodyWithObligorNameToTruncate);
+    it('returns a 400 response if ACBS responds with a 400 response that is not a string', async () => {
+      const acbsErrorMessage = { Message: 'error message' };
+      requestToCreateDealInAcbs().reply(400, acbsErrorMessage);
 
-    expect(status).toBe(201);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedDealIdentifierResponse)));
-    expect(acbsRequest.isDone()).toBe(true);
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({ message: 'Bad request', error: JSON.stringify(acbsErrorMessage), statusCode: 400 });
+    });
+
+    it('returns a 400 response if ACBS responds with a 400 response that is a string', async () => {
+      const acbsErrorMessage = 'ACBS error message';
+      requestToCreateDealInAcbs().reply(400, acbsErrorMessage);
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
+    });
+
+    it('returns a 500 response if ACBS responds with an error code that is not 400"', async () => {
+      requestToCreateDealInAcbs().reply(401, 'Unauthorized');
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+    });
+
+    it('returns a 500 response if ACBS times out"', async () => {
+      requestToCreateDealInAcbs()
+        .delay(TIME_EXCEEDING_ACBS_TIMEOUT)
+        .reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+    });
   });
 
-  it(`replaces the guaranteeCommencementdate with today's date if the specified effectiveDate is after today`, async () => {
-    const requestBodyWithFutureEffectiveDate = [{ ...requestBodyToCreateDeal[0], guaranteeCommencementDate: '9999-01-01' }];
-    const acbsRequestBodyWithTodayEffectiveDate = {
-      ...acbsRequestBodyToCreateDeal,
-      OriginalEffectiveDate: midnightToday,
-      TargetClosingDate: midnightToday,
-      OriginalApprovalDate: midnightToday,
-      Description: CreateDealGenerator.getExpectedDescription({
-        obligorName: dealToCreate.obligorName,
-        currency: dealToCreate.currency,
-        formattedDate: todayFormattedForDescription,
-      }),
-    };
-    givenAuthenticationWithTheIdpSucceeds();
-    const acbsRequestWithTodayEffectiveDate = requestToCreateDealInAcbsWithBody(acbsRequestBodyWithTodayEffectiveDate).reply(201, undefined, {
-      location: `/Deal/${dealIdentifier}`,
+  describe('error cases when updating the deal borrowing restriction in ACBS', () => {
+    beforeEach(() => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToCreateDealInAcbsSucceeds();
     });
 
-    const { status, body } = await api.post(createDealUrl, requestBodyWithFutureEffectiveDate);
+    it('returns a 500 response if ACBS responds with a 400 response that is a string containing "The deal not found"', async () => {
+      const acbsErrorMessage = 'The deal not found or the user does not have access to it.';
+      requestToUpdateDealBorrowingRestrictionInAcbs().reply(400, acbsErrorMessage);
 
-    expect(status).toBe(201);
-    expect(body).toStrictEqual({
-      dealIdentifier,
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        message: 'Internal server error',
+        statusCode: 500,
+        error: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
     });
-    expect(acbsRequestWithTodayEffectiveDate.isDone()).toBe(true);
+
+    it('returns a 500 response if ACBS responds with a 400 response that is a string that does not contain "The deal not found"', async () => {
+      const acbsErrorMessage = 'ACBS error message';
+      requestToUpdateDealBorrowingRestrictionInAcbs().reply(400, acbsErrorMessage);
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        message: 'Internal server error',
+        statusCode: 500,
+        error: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
+    });
+
+    it('returns a 500 response if ACBS responds with a 400 response that is not a string', async () => {
+      const acbsErrorMessage = { Message: 'error message' };
+      requestToUpdateDealBorrowingRestrictionInAcbs().reply(400, acbsErrorMessage);
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        message: 'Internal server error',
+        statusCode: 500,
+        error: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
+    });
+
+    it('returns a 500 response if ACBS responds with an error code that is not 400"', async () => {
+      requestToUpdateDealBorrowingRestrictionInAcbs().reply(401, 'Unauthorized');
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        message: 'Internal server error',
+        statusCode: 500,
+        error: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
+    });
+
+    it('returns a 500 response if ACBS times out"', async () => {
+      requestToUpdateDealBorrowingRestrictionInAcbs().delay(TIME_EXCEEDING_ACBS_TIMEOUT).reply(200);
+
+      const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        message: 'Internal server error',
+        statusCode: 500,
+        error: `Failed to update the deal borrowing restriction after creating deal ${dealIdentifier}`,
+      });
+    });
   });
 
   withStringFieldValidationApiTests({
@@ -151,6 +286,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateAnyDealBorrowingRestrictionInAcbsSucceeds();
     },
   });
 
@@ -161,6 +297,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
@@ -171,6 +308,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
@@ -181,6 +319,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
@@ -194,6 +333,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
@@ -208,6 +348,7 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
@@ -222,44 +363,11 @@ describe('POST /deals', () => {
     givenAnyRequestBodyWouldSucceed: () => {
       givenAuthenticationWithTheIdpSucceeds();
       givenAnyRequestBodyToCreateDealInAcbsSucceeds();
+      givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds();
     },
   });
 
-  it('returns a 400 response if ACBS responds with a 400 response that is not a string', async () => {
-    givenAuthenticationWithTheIdpSucceeds();
-    const acbsErrorMessage = { Message: 'error message' };
-    requestToCreateDealInAcbs().reply(400, acbsErrorMessage);
-
-    const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
-
-    expect(status).toBe(400);
-    expect(body).toStrictEqual({ message: 'Bad request', error: JSON.stringify(acbsErrorMessage), statusCode: 400 });
-  });
-
-  it('returns a 400 response if ACBS responds with a 400 response that is a string', async () => {
-    givenAuthenticationWithTheIdpSucceeds();
-    const acbsErrorMessage = 'ACBS error message';
-    requestToCreateDealInAcbs().reply(400, acbsErrorMessage);
-
-    const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
-
-    expect(status).toBe(400);
-    expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
-  });
-
-  it('returns a 500 response if ACBS responds with an error code that is not 400"', async () => {
-    givenAuthenticationWithTheIdpSucceeds();
-    requestToCreateDealInAcbs().reply(401, 'Unauthorized');
-
-    const { status, body } = await api.post(createDealUrl, requestBodyToCreateDeal);
-
-    expect(status).toBe(500);
-    expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
-  });
-
-  const givenRequestToCreateDealInAcbsSucceeds = (): void => {
-    requestToCreateDealInAcbs().reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
-  };
+  const givenRequestToCreateDealInAcbsSucceeds = (): nock.Scope => requestToCreateDealInAcbs().reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
 
   const requestToCreateDealInAcbs = (): nock.Interceptor => requestToCreateDealInAcbsWithBody(JSON.stringify(acbsRequestBodyToCreateDeal));
 
@@ -274,4 +382,20 @@ describe('POST /deals', () => {
       .matchHeader('authorization', `Bearer ${idToken}`)
       .reply(201, undefined, { location: `/Deal/${dealIdentifier}` });
   };
+
+  const givenRequestToUpdateDealBorrowingRestrictionForDealInAcbsSucceeds = (): nock.Scope => requestToUpdateDealBorrowingRestrictionInAcbs().reply(200);
+
+  const requestToUpdateDealBorrowingRestrictionInAcbs = (): nock.Interceptor =>
+    requestToUpdateDealBorrowingRestrictionInAcbsWithBody(JSON.stringify(acbsRequestBodyToUpdateBorrowingRestriction));
+
+  const requestToUpdateDealBorrowingRestrictionInAcbsWithBody = (requestBody: nock.RequestBodyMatcher): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .put(`/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/BorrowingRestriction`, requestBody)
+      .matchHeader('authorization', `Bearer ${idToken}`);
+
+  const givenRequestToUpdateAnyDealBorrowingRestrictionInAcbsSucceeds = (): nock.Scope =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .put(new RegExp(`/Portfolio/${portfolioIdentifier}/Deal/\\d{10}/BorrowingRestriction`), JSON.stringify(acbsRequestBodyToUpdateBorrowingRestriction))
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .reply(200);
 });

--- a/test/support/generator/create-deal-generator.ts
+++ b/test/support/generator/create-deal-generator.ts
@@ -1,6 +1,7 @@
 import { PROPERTIES } from '@ukef/constants';
 import { DateOnlyString, DateString } from '@ukef/helpers';
 import { AcbsCreateDealDto } from '@ukef/modules/acbs/dto/acbs-create-deal.dto';
+import { AcbsUpdateDealBorrowingRestrictionRequest } from '@ukef/modules/acbs/dto/acbs-update-deal-borrowing-restriction-request.dto';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { CreateDealRequestItem } from '@ukef/modules/deal/dto/create-deal-request.dto';
 import { TEST_CURRENCIES } from '@ukef-test/support/constants/test-currency.constant';
@@ -198,13 +199,29 @@ export class CreateDealGenerator extends AbstractGenerator<DealValues, GenerateR
       },
     };
 
+    const acbsUpdateDealBorrowingRestrictionRequest: AcbsUpdateDealBorrowingRestrictionRequest = this.buildAcbsUpdateDealBorrowingRestrictionRequest();
+
     return {
       acbsCreateDealRequest,
+      acbsUpdateDealBorrowingRestrictionRequest,
       createDealRequestItem,
       guaranteeCommencementDateAsDate: dealValues.guaranteeCommencementDateAsDate,
       guaranteeCommencementDateString: dealValues.guaranteeCommencementDateAsDateString,
       guaranteeCommencementDateForDescription: dealValues.guaranteeCommencementDateForDescription,
     };
+  }
+
+  private buildAcbsUpdateDealBorrowingRestrictionRequest() {
+    const borrowingRestrictionDefaultValues = PROPERTIES.DEAL_BORROWING_RESTRICTION.DEFAULT;
+    const acbsUpdateDealBorrowingRestrictionRequest: AcbsUpdateDealBorrowingRestrictionRequest = {
+      SequenceNumber: borrowingRestrictionDefaultValues.sequenceNumber,
+      RestrictGroupCategory: {
+        RestrictGroupCategoryCode: borrowingRestrictionDefaultValues.restrictGroupCategory.restrictGroupCategoryCode,
+      },
+      IncludingIndicator: borrowingRestrictionDefaultValues.includingIndicator,
+      IncludeExcludeAllItemsIndicator: borrowingRestrictionDefaultValues.includeExcludeAllItemsIndicator,
+    };
+    return acbsUpdateDealBorrowingRestrictionRequest;
   }
 }
 
@@ -224,6 +241,7 @@ interface DealValues {
 
 interface GenerateResult {
   acbsCreateDealRequest: AcbsCreateDealDto;
+  acbsUpdateDealBorrowingRestrictionRequest: AcbsUpdateDealBorrowingRestrictionRequest;
   createDealRequestItem: CreateDealRequestItem;
   guaranteeCommencementDateAsDate: Date;
   guaranteeCommencementDateString: string;


### PR DESCRIPTION
## Introduction

After creating a deal, we need to update a borrowing restriction for the deal using the `PUT /Portfolio/{portfolioId}/Deal/{dealId}/BorrowingRestriction` endpoint in ACBS.
All fields for the request are set from constants.

## Resolution

The ACBS service for sending the PUT request was created in an earlier PR.
In this PR, I've created a `DealBorrowingRestrictionService` that uses the `AcbsDealBorrowingRestrictionService` to update the deal borrowing restriction.
This service will translate any `AcbsResourceNotFoundException` or `AcbsBadRequestException` from `AcbsDealBorrowingRestrictionService` into a 500 error, since these errors would **not** be caused by the client but by something going wrong on the server's side or ACBS's side.

Note that this endpoint leaves the possibility for a deal to be successfully created with the borrowing restriction being updated correctly (as the existing Mulesoft endpoint also does).
In this case, we try to highlight this in the message to the user.

## Misc
I updated the keys we redact in the logs to make sure the necessary redactions happen with the new way that I'm throwing an error in this ticket.