### PR TITLE
feat(APIM-123): expand acbs service to put facility guarantee

### DIFF
--- a/src/modules/acbs/acbs-bundle-information.service.ts
+++ b/src/modules/acbs/acbs-bundle-information.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
 
@@ -17,6 +17,7 @@ import {
 } from './known-errors';
 import { createWrapAcbsHttpGetErrorCallback, createWrapAcbsHttpPostOrPutErrorCallback } from './wrap-acbs-http-error-callback';
 
+@Injectable()
 export class AcbsBundleInformationService {
   private static readonly bundleInformationPath = '/BundleInformation';
 

--- a/src/modules/acbs/acbs-facility-covenant.service.ts
+++ b/src/modules/acbs/acbs-facility-covenant.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import AcbsConfig from '@ukef/config/acbs.config';
 import { PROPERTIES } from '@ukef/constants';
 
@@ -10,6 +10,7 @@ import { AcbsGetFacilityCovenantsResponseDto } from './dto/acbs-get-facility-cov
 import { facilityNotFoundKnownAcbsError } from './known-errors';
 import { createWrapAcbsHttpGetErrorCallback, createWrapAcbsHttpPostOrPutErrorCallback } from './wrap-acbs-http-error-callback';
 
+@Injectable()
 export class AcbsFacilityCovenantService {
   private readonly acbsHttpService: AcbsHttpService;
 

--- a/src/modules/acbs/acbs-facility-fixed-fee.service.ts
+++ b/src/modules/acbs/acbs-facility-fixed-fee.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import AcbsConfig from '@ukef/config/acbs.config';
 
 import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
@@ -9,6 +9,7 @@ import { AcbsGetFacilityFixedFeeResponseDto } from './dto/acbs-get-facility-fixe
 import { postFixedFeeExistsAcbsError, postInvalidPortfolioAndFacilityIdCombinationKnownAcbsError } from './known-errors';
 import { createWrapAcbsHttpGetErrorCallback, createWrapAcbsHttpPostOrPutErrorCallback } from './wrap-acbs-http-error-callback';
 
+@Injectable()
 export class AcbsFacilityFixedFeeService {
   private readonly acbsHttpService: AcbsHttpService;
 

--- a/src/modules/acbs/acbs-facility-guarantee.service.get-guarantees.test.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.get-guarantees.test.ts
@@ -1,0 +1,126 @@
+import { HttpService } from '@nestjs/axios';
+import { PROPERTIES } from '@ukef/constants';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsFacilityGuaranteeService } from './acbs-facility-guarantee.service';
+import { AcbsGetFacilityGuaranteeDto, AcbsGetFacilityGuaranteesResponseDto } from './dto/acbs-get-facility-guarantees-response.dto';
+import { AcbsException } from './exception/acbs.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+
+describe('AcbsFacilityGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  let httpService: HttpService;
+  let service: AcbsFacilityGuaranteeService;
+
+  let httpServiceGet: jest.Mock;
+
+  const expectedHttpServiceGetArgs = [
+    `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityGuarantee`,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}` },
+    },
+  ];
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServiceGet = jest.fn();
+    httpService.get = httpServiceGet;
+
+    service = new AcbsFacilityGuaranteeService({ baseUrl }, httpService);
+  });
+
+  const generateFacilityGuarantee = (): AcbsGetFacilityGuaranteeDto => ({
+    EffectiveDate: valueGenerator.dateTimeString(),
+    GuarantorParty: {
+      PartyIdentifier: valueGenerator.acbsPartyId(),
+    },
+    LimitKey: valueGenerator.acbsPartyId(),
+    ExpirationDate: valueGenerator.dateTimeString(),
+    GuaranteedLimit: valueGenerator.nonnegativeFloat(),
+    GuaranteeType: {
+      GuaranteeTypeCode: valueGenerator.string(),
+    },
+  });
+
+  const facilityGuaranteesInAcbs: AcbsGetFacilityGuaranteesResponseDto = [generateFacilityGuarantee(), generateFacilityGuarantee()];
+
+  describe('getGuaranteesForFacility', () => {
+    it('returns the guarantees for the facility from ACBS if ACBS responds with the guarantees', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: facilityGuaranteesInAcbs,
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const guarantees = await service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(guarantees).toBe(facilityGuaranteesInAcbs);
+    });
+
+    it('returns an empty array if ACBS responds with an empty array', async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: [],
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const guarantees = await service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      expect(guarantees).toStrictEqual([]);
+    });
+
+    it('throws an AcbsException if the request to ACBS fails', async () => {
+      const getGuaranteesForFacilityError = new AxiosError();
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(throwError(() => getGuaranteesForFacilityError));
+
+      const getGuaranteesForFacilityPromise = service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      await expect(getGuaranteesForFacilityPromise).rejects.toBeInstanceOf(AcbsException);
+      await expect(getGuaranteesForFacilityPromise).rejects.toThrow(`Failed to get the guarantees for the facility with identifier ${facilityIdentifier}.`);
+      await expect(getGuaranteesForFacilityPromise).rejects.toHaveProperty('innerError', getGuaranteesForFacilityError);
+    });
+
+    it(`throws an AcbsResourceNotFoundException if ACBS responds with a 200 response where the response body is 'null'`, async () => {
+      when(httpServiceGet)
+        .calledWith(...expectedHttpServiceGetArgs)
+        .mockReturnValueOnce(
+          of({
+            data: null,
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      const getGuaranteesForFacilityPromise = service.getGuaranteesForFacility(portfolioIdentifier, facilityIdentifier, idToken);
+
+      await expect(getGuaranteesForFacilityPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(getGuaranteesForFacilityPromise).rejects.toThrow(`Guarantees for facility with identifier ${facilityIdentifier} were not found by ACBS.`);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-facility-guarantee.service.replace-guarantee.test.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.replace-guarantee.test.ts
@@ -1,0 +1,194 @@
+import { HttpService } from '@nestjs/axios';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { AxiosError } from 'axios';
+import { when } from 'jest-when';
+import { of, throwError } from 'rxjs';
+
+import { AcbsFacilityGuaranteeService } from './acbs-facility-guarantee.service';
+import { AcbsUpdateFacilityGuaranteeRequest } from './dto/acbs-update-facility-guarantee-request.dto';
+import { AcbsBadRequestException } from './exception/acbs-bad-request.exception';
+import { AcbsResourceNotFoundException } from './exception/acbs-resource-not-found.exception';
+import { AcbsUnexpectedException } from './exception/acbs-unexpected.exception';
+
+describe('AcbsFacilityGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const idToken = valueGenerator.string();
+  const baseUrl = valueGenerator.httpsUrl();
+  const facilityIdentifier = valueGenerator.ukefId();
+  const portfolioIdentifier = valueGenerator.portfolioId();
+
+  const acbsRequestBodyToPutFacilityGuarantee: AcbsUpdateFacilityGuaranteeRequest = {
+    GuarantorParty: {
+      PartyIdentifier: valueGenerator.acbsPartyId(),
+    },
+    LimitKey: valueGenerator.acbsPartyId(),
+    LimitType: {
+      LimitTypeCode: valueGenerator.string({ length: 2 }),
+    },
+    LenderType: {
+      LenderTypeCode: valueGenerator.string({ length: 3 }),
+    },
+    SectionIdentifier: valueGenerator.string({ length: 2 }),
+    GuaranteeType: {
+      GuaranteeTypeCode: valueGenerator.string({ length: 3 }),
+    },
+    EffectiveDate: valueGenerator.dateTimeString(),
+    ExpirationDate: valueGenerator.dateTimeString(),
+    GuaranteedLimit: valueGenerator.nonnegativeFloat(),
+    GuaranteedPercentage: valueGenerator.nonnegativeInteger(),
+  };
+
+  const expectedHttpServicePutArgs = [
+    `/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityGuarantee`,
+    acbsRequestBodyToPutFacilityGuarantee,
+    {
+      baseURL: baseUrl,
+      headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    },
+  ];
+
+  let httpService: HttpService;
+  let service: AcbsFacilityGuaranteeService;
+
+  let httpServicePut: jest.Mock;
+
+  beforeEach(() => {
+    httpService = new HttpService();
+
+    httpServicePut = jest.fn();
+    httpService.put = httpServicePut;
+
+    service = new AcbsFacilityGuaranteeService({ baseUrl }, httpService);
+  });
+
+  describe('replaceGuaranteeForFacility', () => {
+    it('sends a PUT to ACBS with the specified parameters', async () => {
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(
+          of({
+            data: '',
+            status: 200,
+            statusText: 'Ok',
+            config: undefined,
+            headers: undefined,
+          }),
+        );
+
+      await service.replaceGuaranteeForFacility(portfolioIdentifier, facilityIdentifier, acbsRequestBodyToPutFacilityGuarantee, idToken);
+
+      expect(httpServicePut).toHaveBeenCalledTimes(1);
+      expect(httpServicePut).toHaveBeenCalledWith(...expectedHttpServicePutArgs);
+    });
+
+    it('throws an AcbsResourceNotFoundException if ACBS responds with a 400 that is a string containing "The facility not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = 'The facility not found or the user does not have access to it.';
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const replaceGuaranteeForFacilityPromise = service.replaceGuaranteeForFacility(
+        portfolioIdentifier,
+        facilityIdentifier,
+        acbsRequestBodyToPutFacilityGuarantee,
+        idToken,
+      );
+
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toBeInstanceOf(AcbsResourceNotFoundException);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toThrow(`Facility with identifier ${facilityIdentifier} was not found by ACBS.`);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is a string that does not contain "The facility not found"', async () => {
+      const axiosError = new AxiosError();
+      const errorString = valueGenerator.string();
+      axiosError.response = {
+        data: errorString,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const replaceGuaranteeForFacilityPromise = service.replaceGuaranteeForFacility(
+        portfolioIdentifier,
+        facilityIdentifier,
+        acbsRequestBodyToPutFacilityGuarantee,
+        idToken,
+      );
+
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toThrow(`Failed to replace a guarantee for facility ${facilityIdentifier} in ACBS.`);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('errorBody', errorString);
+    });
+
+    it('throws an AcbsBadRequestException if ACBS responds with a 400 that is not a string', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const replaceGuaranteeForFacilityPromise = service.replaceGuaranteeForFacility(
+        portfolioIdentifier,
+        facilityIdentifier,
+        acbsRequestBodyToPutFacilityGuarantee,
+        idToken,
+      );
+
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toBeInstanceOf(AcbsBadRequestException);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toThrow(`Failed to replace a guarantee for facility ${facilityIdentifier} in ACBS.`);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('innerError', axiosError);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('errorBody', JSON.stringify(errorBody));
+    });
+
+    it('throws an AcbsUnexpectedException if ACBS responds with an error code that is not 400', async () => {
+      const axiosError = new AxiosError();
+      const errorBody = { errorMessage: valueGenerator.string() };
+      axiosError.response = {
+        data: errorBody,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: undefined,
+        config: undefined,
+      };
+
+      when(httpServicePut)
+        .calledWith(...expectedHttpServicePutArgs)
+        .mockReturnValueOnce(throwError(() => axiosError));
+
+      const replaceGuaranteeForFacilityPromise = service.replaceGuaranteeForFacility(
+        portfolioIdentifier,
+        facilityIdentifier,
+        acbsRequestBodyToPutFacilityGuarantee,
+        idToken,
+      );
+
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toBeInstanceOf(AcbsUnexpectedException);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toThrow(`Failed to replace a guarantee for facility ${facilityIdentifier} in ACBS.`);
+      await expect(replaceGuaranteeForFacilityPromise).rejects.toHaveProperty('innerError', axiosError);
+    });
+  });
+});

--- a/src/modules/acbs/acbs-facility-loan.service.ts
+++ b/src/modules/acbs/acbs-facility-loan.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import AcbsConfig from '@ukef/config/acbs.config';
 
 import { AcbsConfigBaseUrl } from './acbs-config-base-url.type';
@@ -8,6 +8,7 @@ import { AcbsGetFacilityLoanResponseDto } from './dto/acbs-get-facility-loan-res
 import { facilityNotFoundKnownAcbsError } from './known-errors';
 import { createWrapAcbsHttpGetErrorCallback } from './wrap-acbs-http-error-callback';
 
+@Injectable()
 export class AcbsFacilityLoanService {
   private readonly acbsHttpService: AcbsHttpService;
 

--- a/src/modules/acbs/dto/acbs-create-facility-guarantee.dto.ts
+++ b/src/modules/acbs/dto/acbs-create-facility-guarantee.dto.ts
@@ -1,22 +1,3 @@
-import { DateString } from '@ukef/helpers/date-string.type';
+import { AcbsBaseFacilityGuarantee } from './base-entities/acbs-base-facility-guarantee.interface';
 
-export interface AcbsCreateFacilityGuaranteeDto {
-  LenderType: {
-    LenderTypeCode: string;
-  };
-  SectionIdentifier: string;
-  LimitType: {
-    LimitTypeCode: string;
-  };
-  LimitKey: string;
-  GuarantorParty: {
-    PartyIdentifier: string;
-  };
-  GuaranteeType: {
-    GuaranteeTypeCode: string;
-  };
-  EffectiveDate: DateString;
-  ExpirationDate: DateString;
-  GuaranteedLimit: number;
-  GuaranteedPercentage: number;
-}
+export type AcbsCreateFacilityGuaranteeDto = AcbsBaseFacilityGuarantee;

--- a/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
@@ -1,16 +1,8 @@
-import { DateString } from '@ukef/helpers';
+import { AcbsBaseFacilityGuarantee } from './base-entities/acbs-base-facility-guarantee.interface';
 
 export type AcbsGetFacilityGuaranteesResponseDto = AcbsGetFacilityGuaranteeDto[];
 
-export interface AcbsGetFacilityGuaranteeDto {
-  EffectiveDate: DateString;
-  GuarantorParty: {
-    PartyIdentifier: string;
-  };
-  LimitKey: string;
-  ExpirationDate: DateString;
-  GuaranteedLimit: number;
-  GuaranteeType: {
-    GuaranteeTypeCode: string;
-  };
-}
+export type AcbsGetFacilityGuaranteeDto = Pick<
+  AcbsBaseFacilityGuarantee,
+  'EffectiveDate' | 'GuarantorParty' | 'LimitKey' | 'ExpirationDate' | 'GuaranteedLimit' | 'GuaranteeType'
+>;

--- a/src/modules/acbs/dto/acbs-update-facility-guarantee-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-update-facility-guarantee-request.dto.ts
@@ -1,15 +1,3 @@
-import { AcbsPartyId, DateString } from '@ukef/helpers';
+import { AcbsBaseFacilityGuarantee } from './base-entities/acbs-base-facility-guarantee.interface';
 
-// TODO APIM-123: compare to create request
-export interface AcbsUpdateFacilityGuaranteeRequest {
-  GuarantorParty: { PartyIdentifier: AcbsPartyId };
-  LimitKey: string;
-  LimitType: { LimitTypeCode: string };
-  LenderType: { LenderTypeCode: string };
-  SectionIdentifier: string;
-  GuaranteeType: { GuaranteeTypeCode: string };
-  EffectiveDate: DateString;
-  ExpirationDate: DateString;
-  GuaranteedLimit: number;
-  GuaranteedPercentage: number;
-}
+export type AcbsUpdateFacilityGuaranteeRequest = AcbsBaseFacilityGuarantee;

--- a/src/modules/acbs/dto/acbs-update-facility-guarantee-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-update-facility-guarantee-request.dto.ts
@@ -1,0 +1,15 @@
+import { AcbsPartyId, DateString } from '@ukef/helpers';
+
+// TODO APIM-123: compare to create request
+export interface AcbsUpdateFacilityGuaranteeRequest {
+  GuarantorParty: { PartyIdentifier: AcbsPartyId };
+  LimitKey: string;
+  LimitType: { LimitTypeCode: string };
+  LenderType: { LenderTypeCode: string };
+  SectionIdentifier: string;
+  GuaranteeType: { GuaranteeTypeCode: string };
+  EffectiveDate: DateString;
+  ExpirationDate: DateString;
+  GuaranteedLimit: number;
+  GuaranteedPercentage: number;
+}

--- a/src/modules/acbs/dto/base-entities/acbs-base-facility-guarantee.interface.ts
+++ b/src/modules/acbs/dto/base-entities/acbs-base-facility-guarantee.interface.ts
@@ -1,0 +1,22 @@
+import { DateString } from '@ukef/helpers';
+
+export interface AcbsBaseFacilityGuarantee {
+  GuarantorParty: {
+    PartyIdentifier: string;
+  };
+  LimitKey: string;
+  LimitType: {
+    LimitTypeCode: string;
+  };
+  LenderType: {
+    LenderTypeCode: string;
+  };
+  SectionIdentifier: string;
+  GuaranteeType: {
+    GuaranteeTypeCode: string;
+  };
+  EffectiveDate: DateString;
+  ExpirationDate: DateString;
+  GuaranteedLimit: number;
+  GuaranteedPercentage: number;
+}


### PR DESCRIPTION
## Introduction
As part of APIM-123, we need to be able to send PUT requests to ACBS to update facility guarantees.

(Note: this PR is only part of APIM-123 and does not complete it).

## Resolution

I've expanded the AcbsFacilityGuaranteeService to have a method for sending a PUT request to `/Portfolio/{portfolioId}/Facility/{facilityId}/FacilityGuarantee` in ACBS.

If ACBS responds with a 400 that says "The facility not found or the user does not have access" then the service throws an `AcbsResourceNotFoundException`. Any other 400 will result in an `AcbsBadRequestException`, and any unexpected error results in an `AcbsUnexpectedException`.

## Misc

- I noticed that some of our ACBS services didn't have the `@Injectable` decorator so I added them.
- I've commonised the interfaces for the different ACBS Facility Guarantee requests. We haven't done this before in other tickets so I'd be interested to know what people think about this approach.