### PR TITLE
feat(APIM-123):  add endpoint to patch facility guarantees

### DIFF
--- a/src/modules/acbs/acbs-facility-guarantee.service.get-guarantees.test.ts
+++ b/src/modules/acbs/acbs-facility-guarantee.service.get-guarantees.test.ts
@@ -50,6 +50,10 @@ describe('AcbsFacilityGuaranteeService', () => {
     GuaranteeType: {
       GuaranteeTypeCode: valueGenerator.string(),
     },
+    SectionIdentifier: valueGenerator.string({ length: 2 }),
+    GuaranteedPercentage: valueGenerator.nonnegativeInteger(),
+    LimitType: { LimitTypeCode: valueGenerator.string({ length: 2 }) },
+    LenderType: { LenderTypeCode: valueGenerator.string({ length: 3 }) },
   });
 
   const facilityGuaranteesInAcbs: AcbsGetFacilityGuaranteesResponseDto = [generateFacilityGuarantee(), generateFacilityGuarantee()];

--- a/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-facility-guarantees-response.dto.ts
@@ -2,7 +2,4 @@ import { AcbsBaseFacilityGuarantee } from './base-entities/acbs-base-facility-gu
 
 export type AcbsGetFacilityGuaranteesResponseDto = AcbsGetFacilityGuaranteeDto[];
 
-export type AcbsGetFacilityGuaranteeDto = Pick<
-  AcbsBaseFacilityGuarantee,
-  'EffectiveDate' | 'GuarantorParty' | 'LimitKey' | 'ExpirationDate' | 'GuaranteedLimit' | 'GuaranteeType'
->;
+export type AcbsGetFacilityGuaranteeDto = AcbsBaseFacilityGuarantee;

--- a/src/modules/facility-covenant/facility-covenant.controller.test.ts
+++ b/src/modules/facility-covenant/facility-covenant.controller.test.ts
@@ -108,8 +108,6 @@ describe('FacilityCovenantController', () => {
     });
 
     it('returns the facility identifier if updating the covenants succeeds', async () => {
-      await controller.updateCovenantsForFacility({ facilityIdentifier }, updateCovenantRequest);
-
       const response = await controller.updateCovenantsForFacility({ facilityIdentifier }, updateCovenantRequest);
 
       expect(response).toStrictEqual(new CreateOrUpdateFacilityCovenantsResponseDto(facilityIdentifier));

--- a/src/modules/facility-covenant/facility-covenant.service.ts
+++ b/src/modules/facility-covenant/facility-covenant.service.ts
@@ -106,22 +106,22 @@ export class FacilityCovenantService {
   async updateCovenantsForFacility(facilityIdentifier: string, updateCovenantRequest: UpdateFacilityCovenantsRequestDto): Promise<void> {
     const { portfolioIdentifier } = PROPERTIES.GLOBAL;
     const idToken = await this.acbsAuthenticationService.getIdToken();
-
     const covenantsToUpdate = await this.acbsFacilityCovenantService.getCovenantsForFacility(portfolioIdentifier, facilityIdentifier, idToken);
 
-    const { expirationDate, targetAmount } = updateCovenantRequest;
-
-    const fieldsToUpdate = {
-      ...(expirationDate && {
-        ExpirationDate: this.dateStringTransformations.addTimeToDateOnlyString(expirationDate),
-      }),
-      ...(targetAmount && { TargetAmount: targetAmount }),
-    };
-
+    const covenantFieldsToUpdate = this.getCovenantFieldsToUpdate(updateCovenantRequest);
     for (const covenant of covenantsToUpdate) {
-      const updatedCovenant = { ...covenant, ...fieldsToUpdate };
+      const updatedCovenant = { ...covenant, ...covenantFieldsToUpdate };
 
       await this.acbsFacilityCovenantService.replaceCovenantForFacility(portfolioIdentifier, facilityIdentifier, updatedCovenant, idToken);
     }
+  }
+
+  private getCovenantFieldsToUpdate({ expirationDate, targetAmount }: UpdateFacilityCovenantsRequestDto): Partial<AcbsCreateFacilityCovenantRequestDto> {
+    return {
+      ...(expirationDate && {
+        ExpirationDate: this.dateStringTransformations.addTimeToDateOnlyString(expirationDate),
+      }),
+      ...((targetAmount || targetAmount === 0) && { TargetAmount: targetAmount }),
+    };
   }
 }

--- a/src/modules/facility-covenant/facility-covenant.service.update-covenants.test.ts
+++ b/src/modules/facility-covenant/facility-covenant.service.update-covenants.test.ts
@@ -51,15 +51,97 @@ describe('FacilityCovenantService', () => {
     const targetAmount = valueGenerator.nonnegativeFloat();
 
     it('updates the covenants in ACBS with the supplied fields', async () => {
+      const updateRequest = { expirationDate: expirationDateOnlyString, targetAmount };
       when(acbsFacilityCovenantServiceGetCovenantsForFacility)
         .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
         .mockResolvedValueOnce(facilityCovenantsInAcbs);
 
-      await service.updateCovenantsForFacility(facilityIdentifier, { expirationDate: expirationDateOnlyString, targetAmount });
+      await service.updateCovenantsForFacility(facilityIdentifier, updateRequest);
 
       const updatedCovenants = [
         { ...facilityCovenantsInAcbs[0], ExpirationDate: expirationDateTimeString, TargetAmount: targetAmount },
         { ...facilityCovenantsInAcbs[1], ExpirationDate: expirationDateTimeString, TargetAmount: targetAmount },
+      ];
+
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[0]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[0],
+        idToken,
+      ]);
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[1]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[1],
+        idToken,
+      ]);
+    });
+
+    it('does not update ExpirationDate if expirationDate is not defined in the update request', async () => {
+      const updateRequest = { targetAmount };
+      when(acbsFacilityCovenantServiceGetCovenantsForFacility)
+        .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
+        .mockResolvedValueOnce(facilityCovenantsInAcbs);
+
+      await service.updateCovenantsForFacility(facilityIdentifier, updateRequest);
+
+      const updatedCovenants = [
+        { ...facilityCovenantsInAcbs[0], TargetAmount: targetAmount },
+        { ...facilityCovenantsInAcbs[1], TargetAmount: targetAmount },
+      ];
+
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[0]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[0],
+        idToken,
+      ]);
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[1]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[1],
+        idToken,
+      ]);
+    });
+
+    it('does not update TargetAmount if targetAmount is not defined in the update request', async () => {
+      const updateRequest = { expirationDate: expirationDateOnlyString };
+      when(acbsFacilityCovenantServiceGetCovenantsForFacility)
+        .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
+        .mockResolvedValueOnce(facilityCovenantsInAcbs);
+
+      await service.updateCovenantsForFacility(facilityIdentifier, updateRequest);
+
+      const updatedCovenants = [
+        { ...facilityCovenantsInAcbs[0], ExpirationDate: expirationDateTimeString },
+        { ...facilityCovenantsInAcbs[1], ExpirationDate: expirationDateTimeString },
+      ];
+
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[0]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[0],
+        idToken,
+      ]);
+      expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[1]).toStrictEqual([
+        portfolioIdentifier,
+        facilityIdentifier,
+        updatedCovenants[1],
+        idToken,
+      ]);
+    });
+
+    it('does update TargetAmount if targetAmount is 0 in the update request', async () => {
+      const updateRequest = { targetAmount: 0 };
+      when(acbsFacilityCovenantServiceGetCovenantsForFacility)
+        .calledWith(portfolioIdentifier, facilityIdentifier, idToken)
+        .mockResolvedValueOnce(facilityCovenantsInAcbs);
+
+      await service.updateCovenantsForFacility(facilityIdentifier, updateRequest);
+
+      const updatedCovenants = [
+        { ...facilityCovenantsInAcbs[0], TargetAmount: 0 },
+        { ...facilityCovenantsInAcbs[1], TargetAmount: 0 },
       ];
 
       expect(acbsFacilityCovenantServiceReplaceCovenantForFacility.mock.calls[0]).toStrictEqual([

--- a/src/modules/facility-guarantee/dto/create-facility-guarantee-response.dto.ts
+++ b/src/modules/facility-guarantee/dto/create-facility-guarantee-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiResponseProperty } from '@nestjs/swagger';
 import { EXAMPLES } from '@ukef/constants';
 
-export class CreateFacilityGuaranteeResponse {
+export class CreateOrUpdateFacilityGuaranteeResponse {
   @ApiResponseProperty({ example: EXAMPLES.FACILITY_ID })
   readonly facilityIdentifier: string;
 

--- a/src/modules/facility-guarantee/dto/facility-guarantees-params.dto.ts
+++ b/src/modules/facility-guarantee/dto/facility-guarantees-params.dto.ts
@@ -1,13 +1,9 @@
-import { EXAMPLES, UKEFID } from '@ukef/constants';
-import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
+import { ValidatedFacilityIdentifierApiProperty } from '@ukef/decorators/validated-facility-identifier-api-property';
 import { UkefId } from '@ukef/helpers';
 
 export class FacilityGuaranteesParamsDto {
-  @ValidatedStringApiProperty({
+  @ValidatedFacilityIdentifierApiProperty({
     description: 'The identifier of the facility in ACBS.',
-    example: EXAMPLES.FACILITY_ID,
-    length: 10,
-    pattern: UKEFID.MAIN_ID.TEN_DIGIT_REGEX,
   })
   facilityIdentifier: UkefId;
 }

--- a/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
+++ b/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
@@ -1,6 +1,22 @@
+import { EXAMPLES } from '@ukef/constants';
+import { ValidatedDateOnlyApiProperty } from '@ukef/decorators/validated-date-only-api-property.decorator';
+import { ValidatedNumberApiProperty } from '@ukef/decorators/validated-number-api-property.decorator';
 import { DateOnlyString } from '@ukef/helpers';
 
 export class UpdateFacilityGuaranteesRequestDto {
+  @ValidatedDateOnlyApiProperty({
+    description: 'The date that the guarantee will expire on. It is required if guaranteedLimit is not provided.',
+    required: false,
+    nullable: false,
+  })
   readonly expirationDate?: DateOnlyString;
+
+  @ValidatedNumberApiProperty({
+    description: 'The maximum amount the guarantor will guarantee. It is required if expirationDate is not provided.',
+    minimum: 0,
+    required: false,
+    nullable: false,
+    example: EXAMPLES.DEAL_OR_FACILITY_VALUE,
+  })
   readonly guaranteedLimit?: number;
 }

--- a/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
+++ b/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
@@ -1,0 +1,6 @@
+import { DateOnlyString } from '@ukef/helpers';
+
+export class UpdateFacilityGuaranteesRequestDto {
+  readonly expirationDate?: DateOnlyString;
+  readonly guaranteedLimit?: number;
+}

--- a/src/modules/facility-guarantee/facility-guarantee.controller.create-guarantee.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.create-guarantee.test.ts
@@ -1,0 +1,53 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { CreateFacilityGuaranteeRequestItem } from './dto/create-facility-guarantee-request.dto';
+import { CreateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
+import { FacilityGuaranteeController } from './facility-guarantee.controller';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeController', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let facilityGuaranteeServiceCreateGuaranteeForFacility: jest.Mock;
+  let controller: FacilityGuaranteeController;
+
+  beforeEach(() => {
+    const facilityGuaranteeService = new FacilityGuaranteeService(null, null, null, null);
+    facilityGuaranteeServiceCreateGuaranteeForFacility = jest.fn();
+    facilityGuaranteeService.createGuaranteeForFacility = facilityGuaranteeServiceCreateGuaranteeForFacility;
+
+    controller = new FacilityGuaranteeController(facilityGuaranteeService);
+  });
+
+  describe('createGuaranteeForFacility', () => {
+    const facilityIdentifier = valueGenerator.facilityId();
+    const limitKey = valueGenerator.acbsPartyId();
+    const guarantorParty = valueGenerator.acbsPartyId();
+    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
+    const effectiveDate = valueGenerator.dateOnlyString();
+    const guaranteeExpiryDate = valueGenerator.dateOnlyString();
+    const maximumLiability = valueGenerator.nonnegativeFloat();
+
+    const newGuarantee = new CreateFacilityGuaranteeRequestItem(
+      facilityIdentifier,
+      effectiveDate,
+      limitKey,
+      guaranteeExpiryDate,
+      maximumLiability,
+      guarantorParty,
+      guaranteeTypeCode,
+    );
+
+    it('creates a guarantee for the facility with the service from the request body', async () => {
+      await controller.createGuaranteeForFacility({ facilityIdentifier }, [newGuarantee]);
+
+      expect(facilityGuaranteeServiceCreateGuaranteeForFacility).toHaveBeenCalledWith(facilityIdentifier, newGuarantee);
+    });
+
+    it('returns the facility identifier if creating the guarantee succeeds', async () => {
+      const response = await controller.createGuaranteeForFacility({ facilityIdentifier }, [newGuarantee]);
+
+      expect(response).toStrictEqual(new CreateFacilityGuaranteeResponse(facilityIdentifier));
+    });
+  });
+});

--- a/src/modules/facility-guarantee/facility-guarantee.controller.create-guarantee.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.create-guarantee.test.ts
@@ -1,7 +1,7 @@
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 
 import { CreateFacilityGuaranteeRequestItem } from './dto/create-facility-guarantee-request.dto';
-import { CreateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
+import { CreateOrUpdateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
 import { FacilityGuaranteeController } from './facility-guarantee.controller';
 import { FacilityGuaranteeService } from './facility-guarantee.service';
 
@@ -47,7 +47,7 @@ describe('FacilityGuaranteeController', () => {
     it('returns the facility identifier if creating the guarantee succeeds', async () => {
       const response = await controller.createGuaranteeForFacility({ facilityIdentifier }, [newGuarantee]);
 
-      expect(response).toStrictEqual(new CreateFacilityGuaranteeResponse(facilityIdentifier));
+      expect(response).toStrictEqual(new CreateOrUpdateFacilityGuaranteeResponse(facilityIdentifier));
     });
   });
 });

--- a/src/modules/facility-guarantee/facility-guarantee.controller.get-guarantees.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.get-guarantees.test.ts
@@ -3,8 +3,6 @@ import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { CreateFacilityGuaranteeRequestItem } from './dto/create-facility-guarantee-request.dto';
-import { CreateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
 import { FacilityGuaranteeController } from './facility-guarantee.controller';
 import { FacilityGuaranteeService } from './facility-guarantee.service';
 
@@ -20,16 +18,12 @@ describe('FacilityGuaranteeController', () => {
   });
 
   let getFacilityGuaranteesService: jest.Mock;
-  let facilityGuaranteeServiceCreateGuaranteeForFacility: jest.Mock;
   let controller: FacilityGuaranteeController;
 
   beforeEach(() => {
     const facilityGuaranteeService = new FacilityGuaranteeService(null, null, null, null);
     getFacilityGuaranteesService = jest.fn();
     facilityGuaranteeService.getGuaranteesForFacility = getFacilityGuaranteesService;
-
-    facilityGuaranteeServiceCreateGuaranteeForFacility = jest.fn();
-    facilityGuaranteeService.createGuaranteeForFacility = facilityGuaranteeServiceCreateGuaranteeForFacility;
 
     controller = new FacilityGuaranteeController(facilityGuaranteeService);
   });
@@ -53,38 +47,6 @@ describe('FacilityGuaranteeController', () => {
       const guarantees = await controller.getGuaranteesForFacility({ facilityIdentifier });
 
       expect(guarantees).toStrictEqual(guaranteesFromService);
-    });
-  });
-
-  describe('createGuaranteeForFacility', () => {
-    const facilityIdentifier = valueGenerator.facilityId();
-    const limitKey = valueGenerator.acbsPartyId();
-    const guarantorParty = valueGenerator.acbsPartyId();
-    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
-    const effectiveDate = valueGenerator.dateOnlyString();
-    const guaranteeExpiryDate = valueGenerator.dateOnlyString();
-    const maximumLiability = valueGenerator.nonnegativeFloat();
-
-    const newGuarantee = new CreateFacilityGuaranteeRequestItem(
-      facilityIdentifier,
-      effectiveDate,
-      limitKey,
-      guaranteeExpiryDate,
-      maximumLiability,
-      guarantorParty,
-      guaranteeTypeCode,
-    );
-
-    it('creates a guarantee for the facility with the service from the request body', async () => {
-      await controller.createGuaranteeForFacility({ facilityIdentifier }, [newGuarantee]);
-
-      expect(facilityGuaranteeServiceCreateGuaranteeForFacility).toHaveBeenCalledWith(facilityIdentifier, newGuarantee);
-    });
-
-    it('returns the facility identifier if creating the guarantee succeeds', async () => {
-      const response = await controller.createGuaranteeForFacility({ facilityIdentifier }, [newGuarantee]);
-
-      expect(response).toStrictEqual(new CreateFacilityGuaranteeResponse(facilityIdentifier));
     });
   });
 });

--- a/src/modules/facility-guarantee/facility-guarantee.controller.update-guarantees.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.controller.update-guarantees.test.ts
@@ -1,0 +1,40 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { CreateOrUpdateFacilityGuaranteeResponse } from './dto/create-facility-guarantee-response.dto';
+import { UpdateFacilityGuaranteesRequestDto } from './dto/update-facility-guarantees-request.dto';
+import { FacilityGuaranteeController } from './facility-guarantee.controller';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeController', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  let updateFacilityGuaranteesService: jest.Mock;
+  let controller: FacilityGuaranteeController;
+
+  beforeEach(() => {
+    const facilityGuaranteeService = new FacilityGuaranteeService(null, null, null, null);
+    updateFacilityGuaranteesService = jest.fn();
+    facilityGuaranteeService.updateGuaranteesForFacility = updateFacilityGuaranteesService;
+
+    controller = new FacilityGuaranteeController(facilityGuaranteeService);
+  });
+
+  describe('updateGuaranteesForFacility', () => {
+    const expirationDate = valueGenerator.dateOnlyString();
+    const guaranteedLimit = valueGenerator.nonnegativeFloat();
+    const updateGuaranteesRequest: UpdateFacilityGuaranteesRequestDto = { expirationDate, guaranteedLimit };
+
+    it('updates the guarantees for the facility with the service using the fields supplied in the request body', async () => {
+      await controller.updateGuaranteesForFacility({ facilityIdentifier }, updateGuaranteesRequest);
+
+      expect(updateFacilityGuaranteesService).toHaveBeenCalledWith(facilityIdentifier, updateGuaranteesRequest);
+    });
+
+    it('returns the facility identifier if updating the guarantees succeeds', async () => {
+      const response = await controller.updateGuaranteesForFacility({ facilityIdentifier }, updateGuaranteesRequest);
+
+      expect(response).toStrictEqual(new CreateOrUpdateFacilityGuaranteeResponse(facilityIdentifier));
+    });
+  });
+});

--- a/src/modules/facility-guarantee/facility-guarantee.service.create-guarantee.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.create-guarantee.test.ts
@@ -6,7 +6,6 @@ import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
 import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
 import { TEST_DATES } from '@ukef-test/support/constants/test-date.constant';
-import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
@@ -14,21 +13,13 @@ import { FacilityGuaranteeService } from './facility-guarantee.service';
 import { FacilityGuaranteeToCreate } from './facility-guarantee-to-create.interface';
 
 describe('FacilityGuaranteeService', () => {
-  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
   const valueGenerator = new RandomValueGenerator();
   const dateStringTransformations = new DateStringTransformations();
   const idToken = valueGenerator.string();
-  const facilityIdentifier = valueGenerator.facilityId();
-
-  const { facilityGuarantees: expectedFacilityGuarantees, facilityGuaranteesInAcbs } = new GetFacilityGuaranteeGenerator(
-    valueGenerator,
-    new DateStringTransformations(),
-  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
 
   let acbsAuthenticationService: AcbsAuthenticationService;
   let service: FacilityGuaranteeService;
 
-  let getFacilityGuaranteesAcbsService: jest.Mock;
   let createFacilityGuaranteesAcbsService: jest.Mock;
 
   beforeEach(() => {
@@ -38,30 +29,10 @@ describe('FacilityGuaranteeService', () => {
     when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
 
     const acbsService = new AcbsFacilityGuaranteeService(null, null);
-    getFacilityGuaranteesAcbsService = jest.fn();
-    acbsService.getGuaranteesForFacility = getFacilityGuaranteesAcbsService;
     createFacilityGuaranteesAcbsService = jest.fn();
     acbsService.createGuaranteeForFacility = createFacilityGuaranteesAcbsService;
 
     service = new FacilityGuaranteeService(acbsAuthenticationService, acbsService, dateStringTransformations, new CurrentDateProvider());
-  });
-
-  describe('getGuaranteesForFacility', () => {
-    it('returns a transformation of the guarantees from ACBS', async () => {
-      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
-
-      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
-
-      expect(guarantees).toStrictEqual(expectedFacilityGuarantees);
-    });
-
-    it('returns an empty array if ACBS returns an empty array', async () => {
-      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
-
-      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
-
-      expect(guarantees).toStrictEqual([]);
-    });
   });
 
   describe('createGuaranteeForFacility', () => {

--- a/src/modules/facility-guarantee/facility-guarantee.service.get-guarantees.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.get-guarantees.test.ts
@@ -1,0 +1,60 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsFacilityGuaranteeService } from '@ukef/modules/acbs/acbs-facility-guarantee.service';
+import { AcbsAuthenticationService } from '@ukef/modules/acbs-authentication/acbs-authentication.service';
+import { CurrentDateProvider } from '@ukef/modules/date/current-date.provider';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeService', () => {
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+  const valueGenerator = new RandomValueGenerator();
+  const dateStringTransformations = new DateStringTransformations();
+  const idToken = valueGenerator.string();
+  const facilityIdentifier = valueGenerator.facilityId();
+
+  const { facilityGuarantees: expectedFacilityGuarantees, facilityGuaranteesInAcbs } = new GetFacilityGuaranteeGenerator(
+    valueGenerator,
+    new DateStringTransformations(),
+  ).generate({ numberToGenerate: 2, facilityIdentifier, portfolioIdentifier });
+
+  let acbsAuthenticationService: AcbsAuthenticationService;
+  let service: FacilityGuaranteeService;
+
+  let getFacilityGuaranteesAcbsService: jest.Mock;
+
+  beforeEach(() => {
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    const acbsService = new AcbsFacilityGuaranteeService(null, null);
+    getFacilityGuaranteesAcbsService = jest.fn();
+    acbsService.getGuaranteesForFacility = getFacilityGuaranteesAcbsService;
+
+    service = new FacilityGuaranteeService(acbsAuthenticationService, acbsService, dateStringTransformations, new CurrentDateProvider());
+  });
+
+  describe('getGuaranteesForFacility', () => {
+    it('returns a transformation of the guarantees from ACBS', async () => {
+      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual(expectedFacilityGuarantees);
+    });
+
+    it('returns an empty array if ACBS returns an empty array', async () => {
+      when(getFacilityGuaranteesAcbsService).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce([]);
+
+      const guarantees = await service.getGuaranteesForFacility(facilityIdentifier);
+
+      expect(guarantees).toStrictEqual([]);
+    });
+  });
+});

--- a/src/modules/facility-guarantee/facility-guarantee.service.update-guarantees.test.ts
+++ b/src/modules/facility-guarantee/facility-guarantee.service.update-guarantees.test.ts
@@ -1,0 +1,111 @@
+import { PROPERTIES } from '@ukef/constants';
+import { getMockAcbsAuthenticationService } from '@ukef-test/support/abcs-authentication.service.mock';
+import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { AcbsFacilityGuaranteeService } from '../acbs/acbs-facility-guarantee.service';
+import { CurrentDateProvider } from '../date/current-date.provider';
+import { DateStringTransformations } from '../date/date-string.transformations';
+import { FacilityGuaranteeService } from './facility-guarantee.service';
+
+describe('FacilityGuaranteeService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const dateStringTransformations = new DateStringTransformations();
+  const currentDateProvider = new CurrentDateProvider();
+  const idToken = valueGenerator.string();
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+  const facilityIdentifier = valueGenerator.ukefId();
+
+  let service: FacilityGuaranteeService;
+
+  let getGuaranteesForFacilityFromAcbs: jest.Mock;
+  let replaceGuaranteeForFacilityInAcbs: jest.Mock;
+
+  beforeEach(() => {
+    const acbsFacilityGuaranteeService = new AcbsFacilityGuaranteeService(null, null);
+    getGuaranteesForFacilityFromAcbs = jest.fn();
+    acbsFacilityGuaranteeService.getGuaranteesForFacility = getGuaranteesForFacilityFromAcbs;
+    replaceGuaranteeForFacilityInAcbs = jest.fn();
+    acbsFacilityGuaranteeService.replaceGuaranteeForFacility = replaceGuaranteeForFacilityInAcbs;
+
+    const mockAcbsAuthenticationService = getMockAcbsAuthenticationService();
+    const acbsAuthenticationService = mockAcbsAuthenticationService.service;
+    const acbsAuthenticationServiceGetIdToken = mockAcbsAuthenticationService.getIdToken;
+    when(acbsAuthenticationServiceGetIdToken).calledWith().mockResolvedValueOnce(idToken);
+
+    service = new FacilityGuaranteeService(acbsAuthenticationService, acbsFacilityGuaranteeService, dateStringTransformations, currentDateProvider);
+  });
+
+  describe('updateGuaranteesForFacility', () => {
+    const { facilityGuaranteesInAcbs } = new GetFacilityGuaranteeGenerator(valueGenerator, dateStringTransformations).generate({
+      numberToGenerate: 2,
+      facilityIdentifier,
+      portfolioIdentifier,
+    });
+
+    const expirationDateOnlyString = valueGenerator.dateOnlyString();
+    const expirationDateTimeString = dateStringTransformations.addTimeToDateOnlyString(expirationDateOnlyString);
+    const guaranteedLimit = valueGenerator.nonnegativeFloat();
+
+    it('updates the guarantees in ACBS with the supplied fields', async () => {
+      const updateRequest = { expirationDate: expirationDateOnlyString, guaranteedLimit };
+      when(getGuaranteesForFacilityFromAcbs).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      await service.updateGuaranteesForFacility(facilityIdentifier, updateRequest);
+
+      const updatedGuarantees = [
+        { ...facilityGuaranteesInAcbs[0], ExpirationDate: expirationDateTimeString, GuaranteedLimit: guaranteedLimit },
+        { ...facilityGuaranteesInAcbs[1], ExpirationDate: expirationDateTimeString, GuaranteedLimit: guaranteedLimit },
+      ];
+
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[0]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[0], idToken]);
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[1]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[1], idToken]);
+    });
+
+    it('does not update ExpirationDate if expirationDate is not defined in the update request', async () => {
+      const updateRequest = { guaranteedLimit };
+      when(getGuaranteesForFacilityFromAcbs).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      await service.updateGuaranteesForFacility(facilityIdentifier, updateRequest);
+
+      const updatedGuarantees = [
+        { ...facilityGuaranteesInAcbs[0], GuaranteedLimit: guaranteedLimit },
+        { ...facilityGuaranteesInAcbs[1], GuaranteedLimit: guaranteedLimit },
+      ];
+
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[0]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[0], idToken]);
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[1]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[1], idToken]);
+    });
+
+    it('does not update GuaranteedLimit if guaranteedLimit is not defined in the update request', async () => {
+      const updateRequest = { expirationDate: expirationDateOnlyString };
+      when(getGuaranteesForFacilityFromAcbs).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      await service.updateGuaranteesForFacility(facilityIdentifier, updateRequest);
+
+      const updatedGuarantees = [
+        { ...facilityGuaranteesInAcbs[0], ExpirationDate: expirationDateTimeString },
+        { ...facilityGuaranteesInAcbs[1], ExpirationDate: expirationDateTimeString },
+      ];
+
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[0]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[0], idToken]);
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[1]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[1], idToken]);
+    });
+
+    it('does update GuaranteedLimit if guaranteedLimit is 0 in the update request', async () => {
+      const updateRequest = { guaranteedLimit: 0 };
+      when(getGuaranteesForFacilityFromAcbs).calledWith(portfolioIdentifier, facilityIdentifier, idToken).mockResolvedValueOnce(facilityGuaranteesInAcbs);
+
+      await service.updateGuaranteesForFacility(facilityIdentifier, updateRequest);
+
+      const updatedGuarantees = [
+        { ...facilityGuaranteesInAcbs[0], GuaranteedLimit: 0 },
+        { ...facilityGuaranteesInAcbs[1], GuaranteedLimit: 0 },
+      ];
+
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[0]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[0], idToken]);
+      expect(replaceGuaranteeForFacilityInAcbs.mock.calls[1]).toStrictEqual([portfolioIdentifier, facilityIdentifier, updatedGuarantees[1], idToken]);
+    });
+  });
+});

--- a/test/common-tests/request-field-validation-api-tests/non-empty-object-request-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/non-empty-object-request-validation-api-tests.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+
+export const withNonEmptyObjectRequestValidationApiTests = ({
+  makeRequest,
+  givenAnyRequestBodyWouldSucceed,
+}: {
+  makeRequest: (body: string | object) => request.Test;
+  givenAnyRequestBodyWouldSucceed: () => void;
+}) => {
+  it('returns a 400 response if the request body is the empty object', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status, body } = await makeRequest({});
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'The request body cannot be the empty object.', error: 'Bad Request', statusCode: 400 });
+  });
+
+  it('returns a 400 response if the request body is an array', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status, body } = await makeRequest([{ x: 1 }]);
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({ message: 'The request body cannot be an array.', error: 'Bad Request', statusCode: 400 });
+  });
+
+  it('returns a 400 response if the request body is a string', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status } = await makeRequest('test string');
+
+    expect(status).toBe(400);
+  });
+
+  it('returns a 400 response if the request body is a number', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status } = await makeRequest(JSON.stringify(2));
+
+    expect(status).toBe(400);
+  });
+
+  it('returns a 400 response if the request body is null', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status } = await makeRequest(null);
+
+    expect(status).toBe(400);
+  });
+
+  it('returns a 400 response if the request body is the boolean value true', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status } = await makeRequest(JSON.stringify(true));
+
+    expect(status).toBe(400);
+  });
+
+  it('returns a 400 response if the request body is the boolean value false', async () => {
+    givenAnyRequestBodyWouldSucceed();
+
+    const { status } = await makeRequest(JSON.stringify(false));
+
+    expect(status).toBe(400);
+  });
+};

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -520,11 +520,47 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateFacilityGuaranteeResponse'
+                $ref: '#/components/schemas/CreateOrUpdateFacilityGuaranteeResponse'
         '400':
           description: Bad request.
         '404':
           description: The facility was not found.
+        '500':
+          description: An internal server error has occurred.
+    patch:
+      operationId: FacilityGuaranteeController_updateGuaranteesForFacility
+      summary: Update all guarantees for a facility.
+      parameters:
+        - name: facilityIdentifier
+          required: true
+          in: path
+          description: The identifier of the facility in ACBS.
+          example: '0030000322'
+          schema:
+            minLength: 10
+            maxLength: 10
+            pattern: ^00\\d{8}$
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFacilityGuaranteesRequestDto'
+      responses:
+        '200':
+          description: The guarantees for the facility have been updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateOrUpdateFacilityGuaranteeResponse'
+        '400':
+          description: Bad request.
+        '404':
+          description: >-
+            The specified facility, or the guarantees for that facility, were
+            not found. (Due to limitations of ACBS, a 404 response does not
+            guarantee that the facility does not exist.)
         '500':
           description: An internal server error has occurred.
   /api/v1/facilities/{facilityIdentifier}/investors:
@@ -2213,7 +2249,7 @@ components:
         - maximumLiability
         - guarantorParty
         - guaranteeTypeCode
-    CreateFacilityGuaranteeResponse:
+    CreateOrUpdateFacilityGuaranteeResponse:
       type: object
       properties:
         facilityIdentifier:
@@ -2222,6 +2258,23 @@ components:
           example: '0030000322'
       required:
         - facilityIdentifier
+    UpdateFacilityGuaranteesRequestDto:
+      type: object
+      properties:
+        expirationDate:
+          format: date
+          type: string
+          description: >-
+            The date that the guarantee will expire on. It is required if
+            guaranteedLimit is not provided.
+          nullable: false
+        guaranteedLimit:
+          type: number
+          description: >-
+            The maximum amount the guarantor will guarantee. It is required if
+            expirationDate is not provided.
+          minimum: 0
+          example: 501927.25
     CreateFacilityInvestorRequestItem:
       type: object
       properties:

--- a/test/facility-guarantee/patch-facility-guarantees.api-test.ts
+++ b/test/facility-guarantee/patch-facility-guarantees.api-test.ts
@@ -1,0 +1,360 @@
+import { PROPERTIES } from '@ukef/constants';
+import { AcbsGetFacilityGuaranteeDto } from '@ukef/modules/acbs/dto/acbs-get-facility-guarantees-response.dto';
+import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
+import { withNonEmptyObjectRequestValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/non-empty-object-request-validation-api-tests';
+import { withNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests';
+import { withFacilityIdentifierUrlValidationApiTests } from '@ukef-test/common-tests/request-url-param-validation-api-tests/facility-identifier-url-validation-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES, TIME_EXCEEDING_ACBS_TIMEOUT } from '@ukef-test/support/environment-variables';
+import { GetFacilityGuaranteeGenerator } from '@ukef-test/support/generator/get-facility-guarantee-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import nock from 'nock';
+
+describe('PATCH /facilities/{facilityIdentifier}/guarantees', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const dateStringTransformations = new DateStringTransformations();
+  const facilityIdentifier = valueGenerator.facilityId();
+  const { portfolioIdentifier } = PROPERTIES.GLOBAL;
+  const expirationDateOnlyString = valueGenerator.dateOnlyString();
+  const expirationDateTimeString = dateStringTransformations.addTimeToDateOnlyString(expirationDateOnlyString);
+  const guaranteedLimit = valueGenerator.nonnegativeFloat();
+  const requestBodyToUpdateFacilityGuarantees = { expirationDate: expirationDateOnlyString, guaranteedLimit };
+  const getUpdateFacilityGuaranteeUrlForFacilityId = (facilityId: string) => `/api/v1/facilities/${facilityId}/guarantees`;
+  const numberOfGuaranteesForFacility = 3;
+
+  const updateFacilityGuaranteesUrl = getUpdateFacilityGuaranteeUrlForFacilityId(facilityIdentifier);
+
+  const { facilityGuaranteesInAcbs } = new GetFacilityGuaranteeGenerator(valueGenerator, dateStringTransformations).generate({
+    numberToGenerate: numberOfGuaranteesForFacility,
+    facilityIdentifier,
+    portfolioIdentifier,
+  });
+
+  const guaranteesWithOnlyExpirationDateUpdated = facilityGuaranteesInAcbs.map((guaranteeInAcbs) => ({
+    ...guaranteeInAcbs,
+    ExpirationDate: expirationDateTimeString,
+  }));
+
+  const guaranteesWithOnlyGuaranteedLimitUpdated = facilityGuaranteesInAcbs.map((guaranteeInAcbs) => ({
+    ...guaranteeInAcbs,
+    GuaranteedLimit: guaranteedLimit,
+  }));
+
+  const guaranteesWithBothExpirationDateAndGuaranteedLimitUpdated = facilityGuaranteesInAcbs.map((guaranteeInAcbs) => ({
+    ...guaranteeInAcbs,
+    ExpirationDate: expirationDateTimeString,
+    GuaranteedLimit: guaranteedLimit,
+  }));
+
+  const updatedGuarantees = guaranteesWithBothExpirationDateAndGuaranteedLimitUpdated;
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const { idToken, givenAuthenticationWithTheIdpSucceeds } = withAcbsAuthenticationApiTests({
+    givenRequestWouldOtherwiseSucceed: () => {
+      givenRequestToGetGuaranteesSucceeds();
+      givenAllRequestsToReplaceGuaranteesSucceed();
+    },
+    makeRequest: () => api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees),
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToGetGuaranteesSucceeds();
+      givenAllRequestsToReplaceGuaranteesSucceed();
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.patchWithoutAuth(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees, incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  it('returns a 200 response with the facility identifier if getting the facility guarantees succeeds and the facility covenants have all been successfully updated in ACBS', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    givenRequestToGetGuaranteesSucceeds();
+    const acbsRequests = givenAllRequestsToReplaceGuaranteesSucceed();
+
+    const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual({
+      facilityIdentifier,
+    });
+    acbsRequests.forEach((request) => {
+      expect(request.isDone()).toBe(true);
+    });
+  });
+
+  it('returns a 200 response if ACBS returns a 200 response with an empty array when getting the facility guarantees', async () => {
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetGuaranteesForFacilityWithId(facilityIdentifier).reply(200, []);
+
+    const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual({
+      facilityIdentifier,
+    });
+  });
+
+  describe('partial update requests', () => {
+    beforeEach(() => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToGetGuaranteesSucceeds();
+    });
+
+    it('only updates the GuaranteedLimit of the facility guarantees if guaranteedLimit is the only field in the request', async () => {
+      const expectedAcbsUpdateRequests = guaranteesWithOnlyGuaranteedLimitUpdated.map((guarantee) =>
+        givenRequestToReplaceGuaranteeSucceeds(facilityIdentifier, guarantee),
+      );
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, { guaranteedLimit });
+
+      expect(status).toBe(200);
+      expect(body).toStrictEqual({
+        facilityIdentifier,
+      });
+      expectedAcbsUpdateRequests.forEach((request) => {
+        expect(request.isDone()).toBe(true);
+      });
+    });
+
+    it('only updates the ExpirationDate of the facility guarantees if expirationDate is the only field in the request', async () => {
+      const expectedAcbsUpdateRequests = guaranteesWithOnlyExpirationDateUpdated.map((guarantee) =>
+        givenRequestToReplaceGuaranteeSucceeds(facilityIdentifier, guarantee),
+      );
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, { expirationDate: expirationDateOnlyString });
+
+      expect(status).toBe(200);
+      expect(body).toStrictEqual({
+        facilityIdentifier,
+      });
+      expectedAcbsUpdateRequests.forEach((request) => {
+        expect(request.isDone()).toBe(true);
+      });
+    });
+
+    it('updates both ExpirationDate and GuaranteedLimit of the facility guarantees if both expirationDate and guaranteedLimit are specified in the request', async () => {
+      const expectedAcbsUpdateRequests = guaranteesWithBothExpirationDateAndGuaranteedLimitUpdated.map((guarantee) =>
+        givenRequestToReplaceGuaranteeSucceeds(facilityIdentifier, guarantee),
+      );
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, { guaranteedLimit, expirationDate: expirationDateOnlyString });
+
+      expect(status).toBe(200);
+      expect(body).toStrictEqual({
+        facilityIdentifier,
+      });
+      expectedAcbsUpdateRequests.forEach((request) => {
+        expect(request.isDone()).toBe(true);
+      });
+    });
+  });
+
+  describe('error cases when getting the facility guarantees', () => {
+    beforeEach(() => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenAllRequestsToReplaceGuaranteesSucceed();
+    });
+
+    it('returns a 404 response if ACBS returns a 200 response with null as the response body when getting the facility guarantees', async () => {
+      requestToGetGuaranteesForFacilityWithId(facilityIdentifier).reply(200, null);
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(404);
+      expect(body).toStrictEqual({
+        statusCode: 404,
+        message: 'Not found',
+      });
+    });
+
+    it('returns a 500 response if ACBS responds with an error code that is not 200 when getting the facility guarantees', async () => {
+      requestToGetGuaranteesForFacilityWithId(facilityIdentifier).reply(401, 'Unauthorized');
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+    });
+
+    it('returns a 500 response if ACBS times out when getting the facility guarantees', async () => {
+      requestToGetGuaranteesForFacilityWithId(facilityIdentifier).delay(TIME_EXCEEDING_ACBS_TIMEOUT).reply(200, facilityGuaranteesInAcbs);
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+    });
+  });
+
+  describe.each([
+    {
+      errorCaseDescription: 'replacing the first facility guarantee',
+      indexesOfGuaranteesUpdatedWithoutError: [1, 2],
+      indexOfGuaranteeUpdatedWithError: 0,
+    },
+    {
+      errorCaseDescription: 'replacing a middle facility guarantee',
+      indexesOfGuaranteesUpdatedWithoutError: [0, 2],
+      indexOfGuaranteeUpdatedWithError: 1,
+    },
+    {
+      errorCaseDescription: 'replacing the last facility guarantee',
+      indexesOfGuaranteesUpdatedWithoutError: [0, 1],
+      indexOfGuaranteeUpdatedWithError: 2,
+    },
+  ])('error cases when $errorCaseDescription', ({ indexesOfGuaranteesUpdatedWithoutError, indexOfGuaranteeUpdatedWithError }) => {
+    beforeEach(() => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToGetGuaranteesSucceeds();
+      indexesOfGuaranteesUpdatedWithoutError.forEach((guaranteeIndex) =>
+        givenRequestToReplaceGuaranteeSucceeds(facilityIdentifier, updatedGuarantees[guaranteeIndex]),
+      );
+    });
+
+    it('returns a 404 response if ACBS responds with a 400 response that is a string containing "The facility not found" when replacing the facility guarantee', async () => {
+      requestToReplaceGuarantee(facilityIdentifier, updatedGuarantees[indexOfGuaranteeUpdatedWithError]).reply(
+        400,
+        'The facility not found or the user does not have access to it.',
+      );
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(404);
+      expect(body).toStrictEqual({ message: 'Not found', statusCode: 404 });
+    });
+
+    it('returns a 400 response if ACBS responds with a 400 response that is not a string when replacing the facility covenant', async () => {
+      const acbsErrorMessage = JSON.stringify({ Message: 'error message' });
+      requestToReplaceGuarantee(facilityIdentifier, updatedGuarantees[indexOfGuaranteeUpdatedWithError]).reply(400, acbsErrorMessage);
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
+    });
+
+    it('returns a 400 response if ACBS responds with a 400 response that is a string that does not contain "The facility not found" when replacing the facility covenant', async () => {
+      const acbsErrorMessage = 'ACBS error message';
+      requestToReplaceGuarantee(facilityIdentifier, updatedGuarantees[indexOfGuaranteeUpdatedWithError]).reply(400, acbsErrorMessage);
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(400);
+      expect(body).toStrictEqual({ message: 'Bad request', error: acbsErrorMessage, statusCode: 400 });
+    });
+
+    it('returns a 500 response if ACBS responds with an error code that is not 400 when replacing the facility covenant', async () => {
+      requestToReplaceGuarantee(facilityIdentifier, updatedGuarantees[indexOfGuaranteeUpdatedWithError]).reply(401, 'Unauthorized');
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+    });
+
+    it('returns a 500 response if ACBS times out when creating the facility covenant', async () => {
+      requestToReplaceGuarantee(facilityIdentifier, updatedGuarantees[indexOfGuaranteeUpdatedWithError]).delay(TIME_EXCEEDING_ACBS_TIMEOUT).reply(201);
+
+      const { status, body } = await api.patch(updateFacilityGuaranteesUrl, requestBodyToUpdateFacilityGuarantees);
+
+      expect(status).toBe(500);
+      expect(body).toStrictEqual({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('request body validation', () => {
+    const makeRequest = (body: string | object) => api.patch(updateFacilityGuaranteesUrl, body);
+    const givenAnyRequestBodyWouldSucceed = () => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToGetGuaranteesSucceeds();
+      updatedGuarantees.forEach(() => givenAnyRequestBodyToReplaceFacilityGuaranteeSucceeds());
+    };
+
+    withNonNegativeNumberFieldValidationApiTests({
+      fieldName: 'guaranteedLimit',
+      required: false,
+      validRequestBody: requestBodyToUpdateFacilityGuarantees,
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
+
+    withDateOnlyFieldValidationApiTests({
+      fieldName: 'expirationDate',
+      required: false,
+      nullable: false,
+      validRequestBody: requestBodyToUpdateFacilityGuarantees,
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
+
+    withNonEmptyObjectRequestValidationApiTests({
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
+  });
+
+  withFacilityIdentifierUrlValidationApiTests({
+    givenRequestWouldOtherwiseSucceedForFacilityId: (facilityId) => {
+      givenAuthenticationWithTheIdpSucceeds();
+      givenRequestToGetGuaranteesSucceedsForFacilityWithId(facilityId);
+      givenAllRequestsToReplaceGuaranteesSucceedForFacilityWithId(facilityId);
+    },
+    makeRequestWithFacilityId: (facilityId) => api.patch(getUpdateFacilityGuaranteeUrlForFacilityId(facilityId), requestBodyToUpdateFacilityGuarantees),
+  });
+
+  const givenRequestToGetGuaranteesSucceeds = () => givenRequestToGetGuaranteesSucceedsForFacilityWithId(facilityIdentifier);
+
+  const givenRequestToGetGuaranteesSucceedsForFacilityWithId = (facilityId: string): nock.Scope => {
+    return requestToGetGuaranteesForFacilityWithId(facilityId).reply(200, facilityGuaranteesInAcbs);
+  };
+
+  const requestToGetGuaranteesForFacilityWithId = (facilityId: string) =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .get(`/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/FacilityGuarantee`)
+      .matchHeader('authorization', `Bearer ${idToken}`);
+
+  const givenAllRequestsToReplaceGuaranteesSucceed = () => givenAllRequestsToReplaceGuaranteesSucceedForFacilityWithId(facilityIdentifier);
+
+  const givenAllRequestsToReplaceGuaranteesSucceedForFacilityWithId = (facilityId: string): nock.Scope[] =>
+    updatedGuarantees.map((updatedGuarantee) => givenRequestToReplaceGuaranteeSucceeds(facilityId, updatedGuarantee));
+
+  const givenRequestToReplaceGuaranteeSucceeds = (facilityId: string, requestBody: AcbsGetFacilityGuaranteeDto): nock.Scope => {
+    return requestToReplaceGuarantee(facilityId, requestBody).reply(200);
+  };
+
+  const requestToReplaceGuarantee = (facilityId: string, requestBody: AcbsGetFacilityGuaranteeDto): nock.Interceptor =>
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .put(`/Portfolio/${portfolioIdentifier}/Facility/${facilityId}/FacilityGuarantee`, JSON.stringify(requestBody))
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .matchHeader('Content-Type', 'application/json');
+
+  const givenAnyRequestBodyToReplaceFacilityGuaranteeSucceeds = (): void => {
+    const requestBodyPlaceholder = '*';
+    nock(ENVIRONMENT_VARIABLES.ACBS_BASE_URL)
+      .filteringRequestBody(() => requestBodyPlaceholder)
+      .put(`/Portfolio/${portfolioIdentifier}/Facility/${facilityIdentifier}/FacilityGuarantee`, requestBodyPlaceholder)
+      .matchHeader('authorization', `Bearer ${idToken}`)
+      .reply(200);
+  };
+});

--- a/test/support/generator/get-facility-guarantee-generator.ts
+++ b/test/support/generator/get-facility-guarantee-generator.ts
@@ -20,6 +20,10 @@ export class GetFacilityGuaranteeGenerator extends AbstractGenerator<FacilityGua
       expirationDateInAcbs: this.valueGenerator.dateTimeString(),
       guaranteedLimit: this.valueGenerator.nonnegativeFloat(),
       guaranteeTypeCode: this.valueGenerator.string(),
+      sectionIdentifier: this.valueGenerator.string({ length: 2 }),
+      guaranteedPercentage: this.valueGenerator.nonnegativeInteger(),
+      limitTypeCode: this.valueGenerator.string({ length: 2 }),
+      lenderTypeCode: this.valueGenerator.string({ length: 3 }),
     };
   }
 
@@ -38,6 +42,10 @@ export class GetFacilityGuaranteeGenerator extends AbstractGenerator<FacilityGua
       GuaranteeType: {
         GuaranteeTypeCode: v.guaranteeTypeCode,
       },
+      SectionIdentifier: v.sectionIdentifier,
+      GuaranteedPercentage: v.guaranteedPercentage,
+      LimitType: { LimitTypeCode: v.limitTypeCode },
+      LenderType: { LenderTypeCode: v.lenderTypeCode },
     }));
 
     const facilityGuarantees: FacilityGuarantee[] = values.map((v) => ({
@@ -69,6 +77,10 @@ interface FacilityGuaranteeValues {
   expirationDateInAcbs: DateString;
   guaranteedLimit: number;
   guaranteeTypeCode: string;
+  sectionIdentifier: string;
+  guaranteedPercentage: number;
+  limitTypeCode: string;
+  lenderTypeCode: string;
 }
 
 interface GenerateOptions {


### PR DESCRIPTION
## Introduction

The `PATCH /facility/{facilityId}/guarantee` endpoint in Mulesoft allows the client to edit the expiration date and/or guaranteed limit of all the guarantees of a facility.

## Resolution

I've migrated that to `PATCH /facilities/{facilityId}/guarantees` in TFS. This:
1. validates that the request body is not an empty object (and is an object)
2. validates the optional fields `guaranteedLimit` and `expirationDate`
3. gets all guarantees for the facility from ACBS
    - We throw a 404 error if ACBS returns a `200 null` response. This happens if the facility doesn't exist, but a limitation in ACBS means this also sometimes happens if the facility _does_ exist.
4. for each guarantee, sends a PUT request to `/Portfolio/{portfolioId}/Facility/{facilityId}/FacilityGuarantee` to update the guarantee with the new fields
5. returns a 200 OK response with the `facilityIdentifier` if all of the above was successful.

## Misc

I fixed `PATCH /facilities/{facilityId}/covenants` to allow `targetAmount` to be updated to 0 when updating covenants - previously our validation allowed `targetAmount: 0` but then accidentally ignored it when sending the `PUT` request because 0 is falsey.