### PR TITLE
fix(APIM-361): validate loan identifier has length 9

### DIFF
--- a/src/constants/acbs-id.constant.ts
+++ b/src/constants/acbs-id.constant.ts
@@ -8,6 +8,7 @@ export const ACBSID = {
     REGEX: /^0{4}\d{6}$/,
   },
   LOAN_ID: {
-    REGEX: /^\d{10}$/,
+    REGEX: /^\d{9}$/,
+    LENGTH: 9,
   },
 };

--- a/src/decorators/validated-loan-identifier-api-property.ts
+++ b/src/decorators/validated-loan-identifier-api-property.ts
@@ -9,7 +9,7 @@ interface Options {
 export const ValidatedLoanIdentifierApiProperty = ({ description }: Options) =>
   ValidatedStringApiProperty({
     description,
-    length: 10,
+    length: ACBSID.LOAN_ID.LENGTH,
     pattern: ACBSID.LOAN_ID.REGEX,
     example: EXAMPLES.LOAN_ID,
   });

--- a/test/common-tests/request-url-param-validation-api-tests/loan-identifier-url-validation-api-tests.ts
+++ b/test/common-tests/request-url-param-validation-api-tests/loan-identifier-url-validation-api-tests.ts
@@ -1,7 +1,7 @@
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import request from 'supertest';
 
-const expectedLoanIdentifierMustMatchPatternErrorMessage = `loanIdentifier must match /^\\d{10}$/ regular expression`;
+const expectedLoanIdentifierMustMatchPatternErrorMessage = `loanIdentifier must match /^\\d{9}$/ regular expression`;
 
 export const withLoanIdentifierUrlValidationApiTests = ({
   makeRequestWithLoanId,
@@ -25,36 +25,36 @@ export const withLoanIdentifierUrlValidationApiTests = ({
       expect(status).toBe(expectedSuccessStatusCode);
     });
 
-    it('returns a 400 response if the loanId in the URL has fewer than 10 digits', async () => {
-      const fewerThan10Digits = '001234567';
-      givenRequestWouldOtherwiseSucceedForLoanId(fewerThan10Digits);
+    it('returns a 400 response if the loanId in the URL has fewer than 9 digits', async () => {
+      const fewerThan9Digits = '12345678';
+      givenRequestWouldOtherwiseSucceedForLoanId(fewerThan9Digits);
 
-      const { status, body } = await makeRequestWithLoanId(fewerThan10Digits);
+      const { status, body } = await makeRequestWithLoanId(fewerThan9Digits);
 
       expect(status).toBe(400);
       expect(body).toMatchObject({
         error: 'Bad Request',
-        message: expect.arrayContaining([`loanIdentifier must be longer than or equal to 10 characters`]),
+        message: expect.arrayContaining([`loanIdentifier must be longer than or equal to 9 characters`]),
         statusCode: 400,
       });
     });
 
-    it('returns a 400 response if the loanId in the URL has more than 10 digits', async () => {
-      const moreThan10Digits = '00123456789';
-      givenRequestWouldOtherwiseSucceedForLoanId(moreThan10Digits);
+    it('returns a 400 response if the loanId in the URL has more than 9 digits', async () => {
+      const moreThan9Digits = '1234567890';
+      givenRequestWouldOtherwiseSucceedForLoanId(moreThan9Digits);
 
-      const { status, body } = await makeRequestWithLoanId(moreThan10Digits);
+      const { status, body } = await makeRequestWithLoanId(moreThan9Digits);
 
       expect(status).toBe(400);
       expect(body).toMatchObject({
         error: 'Bad Request',
-        message: expect.arrayContaining([`loanIdentifier must be shorter than or equal to 10 characters`]),
+        message: expect.arrayContaining([`loanIdentifier must be shorter than or equal to 9 characters`]),
         statusCode: 400,
       });
     });
 
     it('returns a 400 response if the loanId in the URL has an alphabetic character', async () => {
-      const withAnAlphaCharacter = '00123a4567';
+      const withAnAlphaCharacter = '00123a456';
       givenRequestWouldOtherwiseSucceedForLoanId(withAnAlphaCharacter);
 
       const { status, body } = await makeRequestWithLoanId(withAnAlphaCharacter);
@@ -68,7 +68,7 @@ export const withLoanIdentifierUrlValidationApiTests = ({
     });
 
     it('returns a 400 response if the loanId in the URL has a non-alphanumeric character', async () => {
-      const withAnNonAlphaNumericCharacter = '0012345!78';
+      const withAnNonAlphaNumericCharacter = '0012345!7';
       givenRequestWouldOtherwiseSucceedForLoanId(withAnNonAlphaNumericCharacter);
 
       const { status, body } = await makeRequestWithLoanId(withAnNonAlphaNumericCharacter);

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -762,9 +762,9 @@ paths:
           description: The identifier of the loan in ACBS.
           example: '000272017'
           schema:
-            minLength: 10
-            maxLength: 10
-            pattern: ^\\d{10}$
+            minLength: 9
+            maxLength: 9
+            pattern: ^\\d{9}$
             type: string
         - name: facilityIdentifier
           required: true

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -111,7 +111,7 @@ export class RandomValueGenerator {
   }
 
   loanId(): string {
-    return this.stringOfNumericCharacters({ length: 10 });
+    return this.stringOfNumericCharacters({ length: ACBSID.LOAN_ID.LENGTH });
   }
 
   dateTimeString(): DateString {


### PR DESCRIPTION
## Introduction

In #157 we introduced `loanIdentifier` validation that said the length of a loan id would be 10 characters, but it is actually 9.

## Resolution

I've changed the validation for `loanIdentifier` to validate that the length is 9 instead of 10.