### PR TITLE
refactor: remove todos for APIM-311

### DIFF
--- a/src/modules/acbs/dto/acbs-create-bundle-information-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-create-bundle-information-request.dto.ts
@@ -4,7 +4,6 @@ import { BundleAction } from './bundle-actions/bundle-action.type';
 
 export interface AcbsCreateBundleInformationRequestDto<BundleMessageListItem extends BundleAction = BundleAction> {
   PortfolioIdentifier: string;
-  // TODO APIM-311: Replace InitialBundleStatusCode with RequestedBundleStatus, as InitialBundleStatusCode is deprecated as of 01 dec 2024.
   InitialBundleStatusCode: number;
   InitiatingUserName: string;
   UseAPIUserIndicator: boolean;

--- a/src/modules/acbs/dto/acbs-get-bundle-information-response.dto.ts
+++ b/src/modules/acbs/dto/acbs-get-bundle-information-response.dto.ts
@@ -4,7 +4,6 @@ import { BundleAction } from './bundle-actions/bundle-action.type';
 
 export interface AcbsGetBundleInformationResponseDto<BundleMessageListItem extends BundleAction = BundleAction> {
   PortfolioIdentifier: string;
-  // TODO APIM-311: Replace InitialBundleStatusCode with RequestedBundleStatus, as InitialBundleStatusCode is deprecated as of 01 dec 2024.
   InitialBundleStatusCode: number;
   BundleStatus: {
     BundleStatusCode: string;


### PR DESCRIPTION
## Introduction

In a previous ticket, we left a TODO for APIM-311 (a future ticket to deal with a field in ACBS being deprecated at the end of 2024). It's looking unlikely that we'll do this ticket anytime soon (if at all), so I don't think it's worth keeping the TODOs in the code. When we do APIM-311, we can just search for `InitialBundleStatusCode` anyway

## Resolution

I've removed the 2 TODOs