### PR TITLE
fix(APIM-364): fix bug where GET loan transaction by bundle Id returns a 500

### DIFF
--- a/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
+++ b/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
@@ -106,49 +106,43 @@ export class GetFacilityLoanTransactionResponseDto {
     description:
       'The spread rate of the PAC accrual schedule to factor into the all-in rate if a rate calculation method is selected that includes the spread rate in the calculation.',
     example: EXAMPLES.SPREAD_RATE,
-    required: false,
   })
-  readonly spreadRate?: number;
+  readonly spreadRate: number | null;
 
   @ApiProperty({
     description:
       'The spread rate of the CTL accrual schedule to factor into the all-in rate if a rate calculation method is selected that includes the spread rate in the calculation.',
     example: EXAMPLES.SPREAD_RATE,
-    required: false,
   })
-  readonly spreadRateCTL?: number;
+  readonly spreadRateCTL: number | null;
 
   @ApiProperty({
     description: 'A code denoting the year basis for the accrual schedule.',
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.YEAR_BASIS,
-    required: false,
   })
-  readonly yearBasis?: string;
+  readonly yearBasis: string | null;
 
   @ApiProperty({
     description: 'The date the next payment will be due for the loan repayment schedule.',
     type: Date,
     format: 'date',
-    required: false,
   })
-  readonly nextDueDate?: DateOnlyString;
+  readonly nextDueDate: DateOnlyString | null;
 
   @ApiProperty({
     description: `A code denoting the index rate change frequency, which is used by ACBS to determine the frequency at which the rate should change when the change timing is set to 'On Anniversary'.`,
     minLength: 0,
     maxLength: 1,
-    required: false,
   })
-  readonly indexRateChangeFrequency?: string;
+  readonly indexRateChangeFrequency: string | null;
 
   @ApiProperty({
     description: `A code denoting the loan billing frequency type, which is used by ACBS to determine the frequency at which the bills should be generated.`,
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.LOAN_BILLING_FREQUENCY_TYPE,
-    required: false,
   })
-  readonly loanBillingFrequencyType?: string;
+  readonly loanBillingFrequencyType?: string | null;
 }

--- a/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
+++ b/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
@@ -106,8 +106,9 @@ export class GetFacilityLoanTransactionResponseDto {
     description:
       'The spread rate of the PAC accrual schedule to factor into the all-in rate if a rate calculation method is selected that includes the spread rate in the calculation.',
     example: EXAMPLES.SPREAD_RATE,
+    required: false,
   })
-  readonly spreadRate: number;
+  readonly spreadRate?: number;
 
   @ApiProperty({
     description:
@@ -115,35 +116,39 @@ export class GetFacilityLoanTransactionResponseDto {
     example: EXAMPLES.SPREAD_RATE,
     required: false,
   })
-  readonly spreadRateCTL: number;
+  readonly spreadRateCTL?: number;
 
   @ApiProperty({
     description: 'A code denoting the year basis for the accrual schedule.',
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.YEAR_BASIS,
+    required: false,
   })
-  readonly yearBasis: string;
+  readonly yearBasis?: string;
 
   @ApiProperty({
     description: 'The date the next payment will be due for the loan repayment schedule.',
     type: Date,
     format: 'date',
+    required: false,
   })
-  readonly nextDueDate: DateOnlyString;
+  readonly nextDueDate?: DateOnlyString;
 
   @ApiProperty({
     description: `A code denoting the index rate change frequency, which is used by ACBS to determine the frequency at which the rate should change when the change timing is set to 'On Anniversary'.`,
     minLength: 0,
     maxLength: 1,
+    required: false,
   })
-  readonly indexRateChangeFrequency: string;
+  readonly indexRateChangeFrequency?: string;
 
   @ApiProperty({
     description: `A code denoting the loan billing frequency type, which is used by ACBS to determine the frequency at which the bills should be generated.`,
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.LOAN_BILLING_FREQUENCY_TYPE,
+    required: false,
   })
-  readonly loanBillingFrequencyType: string;
+  readonly loanBillingFrequencyType?: string;
 }

--- a/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
+++ b/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
@@ -144,5 +144,5 @@ export class GetFacilityLoanTransactionResponseDto {
     maxLength: 1,
     example: EXAMPLES.LOAN_BILLING_FREQUENCY_TYPE,
   })
-  readonly loanBillingFrequencyType?: string | null;
+  readonly loanBillingFrequencyType: string | null;
 }

--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
@@ -56,12 +56,12 @@ export class FacilityLoanTransactionService {
       amount: loan.LoanAmount,
       issueDate: this.dateStringTransformations.removeTime(loan.EffectiveDate),
       expiryDate: this.dateStringTransformations.removeTime(loan.MaturityDate),
-      spreadRate: pacAccrual?.SpreadRate,
-      spreadRateCTL: ctlAccrual?.SpreadRate,
-      yearBasis: firstAccrual?.YearBasis?.YearBasisCode,
-      nextDueDate: this.dateStringTransformations.removeTimeIfExists(firstRepayment?.NextDueDate),
-      indexRateChangeFrequency: pacAccrual?.IndexRateChangeFrequency?.IndexRateChangeFrequencyCode,
-      loanBillingFrequencyType: firstRepayment?.LoanBillingFrequencyType?.LoanBillingFrequencyTypeCode,
+      spreadRate: pacAccrual?.SpreadRate ?? null,
+      spreadRateCTL: ctlAccrual?.SpreadRate ?? null,
+      yearBasis: firstAccrual?.YearBasis?.YearBasisCode ?? null,
+      nextDueDate: this.dateStringTransformations.removeTimeIfExists(firstRepayment?.NextDueDate) ?? null,
+      indexRateChangeFrequency: pacAccrual?.IndexRateChangeFrequency?.IndexRateChangeFrequencyCode ?? null,
+      loanBillingFrequencyType: firstRepayment?.LoanBillingFrequencyType?.LoanBillingFrequencyTypeCode ?? null,
     };
   }
 

--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
@@ -56,12 +56,12 @@ export class FacilityLoanTransactionService {
       amount: loan.LoanAmount,
       issueDate: this.dateStringTransformations.removeTime(loan.EffectiveDate),
       expiryDate: this.dateStringTransformations.removeTime(loan.MaturityDate),
-      spreadRate: pacAccrual.SpreadRate,
+      spreadRate: pacAccrual?.SpreadRate,
       spreadRateCTL: ctlAccrual?.SpreadRate,
-      yearBasis: firstAccrual.YearBasis.YearBasisCode,
-      nextDueDate: this.dateStringTransformations.removeTime(firstRepayment.NextDueDate),
-      indexRateChangeFrequency: pacAccrual.IndexRateChangeFrequency.IndexRateChangeFrequencyCode,
-      loanBillingFrequencyType: firstRepayment.LoanBillingFrequencyType.LoanBillingFrequencyTypeCode,
+      yearBasis: firstAccrual?.YearBasis?.YearBasisCode,
+      nextDueDate: this.dateStringTransformations.removeTimeIfExists(firstRepayment?.NextDueDate),
+      indexRateChangeFrequency: pacAccrual?.IndexRateChangeFrequency?.IndexRateChangeFrequencyCode,
+      loanBillingFrequencyType: firstRepayment?.LoanBillingFrequencyType?.LoanBillingFrequencyTypeCode,
     };
   }
 

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -3283,11 +3283,6 @@ components:
         - amount
         - issueDate
         - expiryDate
-        - spreadRate
-        - yearBasis
-        - nextDueDate
-        - indexRateChangeFrequency
-        - loanBillingFrequencyType
 security:
   - ApiKeyHeader: []
 "


### PR DESCRIPTION
### Introduction

The `GET /facility/{facilityId}/loanTransaction/{bundleId}` endpoint was returning a 500 response for the (valid) facility Id `0030615995` and bundle Id `0000258264`.

### Resolution

This loan transaction was created using the `POST` endpoint, and as creating accrual schedules had not been implemented yet, it had no accrual schedules, causing the code for the `GET` endpoint to error when we tried to access a property on this schedule without an existence check. As Mulesoft appears to be much more permissive when we try to properties on undefined/null objects (e.g. payload.nonExistentProperty.otherNonExistentProperty = null in the [Dataweave playground](https://dataweave.mulesoft.com/learn/dataweave), this wasn't causing errors in the Mulesoft implementation.

I fixed this by adding some existence checks. Note that I only added the existence checks needed to resolve this bug (in theory, if we want to match Dataweave's behaviour, we should add an existence check `?` every time we access a property, but I've raised a ticket for this https://ukef-dtfs.atlassian.net/browse/APIM-375).