### PR TITLE
feat(APIM-364): add tests to check we handle missing GET loan transaction fields correctly

### DIFF
--- a/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
+++ b/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
@@ -106,6 +106,7 @@ export class GetFacilityLoanTransactionResponseDto {
     description:
       'The spread rate of the PAC accrual schedule to factor into the all-in rate if a rate calculation method is selected that includes the spread rate in the calculation.',
     example: EXAMPLES.SPREAD_RATE,
+    required: false,
   })
   readonly spreadRate: number | null;
 
@@ -121,6 +122,7 @@ export class GetFacilityLoanTransactionResponseDto {
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.YEAR_BASIS,
+    required: false,
   })
   readonly yearBasis: string | null;
 
@@ -128,6 +130,7 @@ export class GetFacilityLoanTransactionResponseDto {
     description: 'The date the next payment will be due for the loan repayment schedule.',
     type: Date,
     format: 'date',
+    required: false,
   })
   readonly nextDueDate: DateOnlyString | null;
 
@@ -135,6 +138,7 @@ export class GetFacilityLoanTransactionResponseDto {
     description: `A code denoting the index rate change frequency, which is used by ACBS to determine the frequency at which the rate should change when the change timing is set to 'On Anniversary'.`,
     minLength: 0,
     maxLength: 1,
+    required: false,
   })
   readonly indexRateChangeFrequency: string | null;
 
@@ -143,6 +147,7 @@ export class GetFacilityLoanTransactionResponseDto {
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.LOAN_BILLING_FREQUENCY_TYPE,
+    required: false,
   })
   readonly loanBillingFrequencyType: string | null;
 }

--- a/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
+++ b/src/modules/facility-loan-transaction/dto/get-facility-loan-transaction-response.dto.ts
@@ -106,7 +106,6 @@ export class GetFacilityLoanTransactionResponseDto {
     description:
       'The spread rate of the PAC accrual schedule to factor into the all-in rate if a rate calculation method is selected that includes the spread rate in the calculation.',
     example: EXAMPLES.SPREAD_RATE,
-    required: false,
   })
   readonly spreadRate: number | null;
 
@@ -122,7 +121,6 @@ export class GetFacilityLoanTransactionResponseDto {
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.YEAR_BASIS,
-    required: false,
   })
   readonly yearBasis: string | null;
 
@@ -130,7 +128,6 @@ export class GetFacilityLoanTransactionResponseDto {
     description: 'The date the next payment will be due for the loan repayment schedule.',
     type: Date,
     format: 'date',
-    required: false,
   })
   readonly nextDueDate: DateOnlyString | null;
 
@@ -138,7 +135,6 @@ export class GetFacilityLoanTransactionResponseDto {
     description: `A code denoting the index rate change frequency, which is used by ACBS to determine the frequency at which the rate should change when the change timing is set to 'On Anniversary'.`,
     minLength: 0,
     maxLength: 1,
-    required: false,
   })
   readonly indexRateChangeFrequency: string | null;
 
@@ -147,7 +143,6 @@ export class GetFacilityLoanTransactionResponseDto {
     minLength: 0,
     maxLength: 1,
     example: EXAMPLES.LOAN_BILLING_FREQUENCY_TYPE,
-    required: false,
   })
   readonly loanBillingFrequencyType: string | null;
 }

--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
@@ -67,7 +67,7 @@ describe('FacilityLoanTransactionService', () => {
     it('returns a transformation of the loan transaction from ACBS when it has a null operation type code', async () => {
       const loanTransactionInAcbsWithNullOperationTypeCode = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
       loanTransactionInAcbsWithNullOperationTypeCode.BundleMessageList[0].DealCustomerUsageOperationType.OperationTypeCode = null;
-      const expectedFacilityLoanTransactionsWithNullValue: GetFacilityLoanTransactionResponseDto = {
+      const expectedLoanTransactionWithNullValue: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         dealCustomerUsageOperationType: null,
       };
@@ -76,13 +76,13 @@ describe('FacilityLoanTransactionService', () => {
 
       const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
 
-      expect(loanTransactions).toStrictEqual(expectedFacilityLoanTransactionsWithNullValue);
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNullValue);
     });
 
     it('returns a transformation of the loan transaction from ACBS when it has an empty operation type code', async () => {
       const loanTransactionInAcbsWithEmptyOperationTypeCode = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
       loanTransactionInAcbsWithEmptyOperationTypeCode.BundleMessageList[0].DealCustomerUsageOperationType.OperationTypeCode = '';
-      const expectedFacilityLoanTransactionsWithNullValue: GetFacilityLoanTransactionResponseDto = {
+      const expectedLoanTransactionWithNullValue: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         dealCustomerUsageOperationType: null,
       };
@@ -91,7 +91,7 @@ describe('FacilityLoanTransactionService', () => {
 
       const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
 
-      expect(loanTransactions).toStrictEqual(expectedFacilityLoanTransactionsWithNullValue);
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNullValue);
     });
 
     it(`returns a transformation of the loan transaction from ACBS when it has more than one accrual with the category code 'PAC01'`, async () => {
@@ -108,7 +108,7 @@ describe('FacilityLoanTransactionService', () => {
           IndexRateChangeFrequencyCode: '',
         },
       });
-      const expectedFacilityLoanTransactionsWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
+      const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         spreadRate: 0,
         indexRateChangeFrequency: '',
@@ -118,7 +118,7 @@ describe('FacilityLoanTransactionService', () => {
 
       const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
 
-      expect(loanTransactions).toStrictEqual(expectedFacilityLoanTransactionsWithAdditionalAccrual);
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithAdditionalAccrual);
     });
 
     it(`returns a transformation of the loan transaction from ACBS when it has more than one accrual with the category code 'CTL01'`, async () => {
@@ -135,7 +135,7 @@ describe('FacilityLoanTransactionService', () => {
           IndexRateChangeFrequencyCode: '',
         },
       });
-      const expectedFacilityLoanTransactionsWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
+      const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         spreadRateCTL: 0,
       };
@@ -144,7 +144,72 @@ describe('FacilityLoanTransactionService', () => {
 
       const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
 
-      expect(loanTransactions).toStrictEqual(expectedFacilityLoanTransactionsWithAdditionalAccrual);
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithAdditionalAccrual);
+    });
+
+    it(`returns a transformation of the loan transaction from ACBS when it has no accruals with the category code 'PAC01'`, async () => {
+      const loanTransactionInAcbsWithNoPacAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+      loanTransactionInAcbsWithNoPacAccruals.BundleMessageList[0].AccrualScheduleList.splice(1, 1);
+      const expectedLoanTransactionWithNoPacAccruals: GetFacilityLoanTransactionResponseDto = {
+        ...expectedLoanTransaction,
+        spreadRate: null,
+        indexRateChangeFrequency: null,
+      };
+
+      when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoPacAccruals);
+
+      const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
+
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNoPacAccruals);
+    });
+
+    it(`returns a transformation of the loan transaction from ACBS when it has no accruals with the category code 'CTL01'`, async () => {
+      const loanTransactionInAcbsWithNoCtlAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+      loanTransactionInAcbsWithNoCtlAccruals.BundleMessageList[0].AccrualScheduleList.splice(2, 1);
+      const expectedLoanTransactionWithNoCtlAccruals: GetFacilityLoanTransactionResponseDto = {
+        ...expectedLoanTransaction,
+        spreadRateCTL: null,
+      };
+
+      when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoCtlAccruals);
+
+      const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
+
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNoCtlAccruals);
+    });
+
+    it(`returns a transformation of the loan transaction from ACBS when it has no accruals`, async () => {
+      const loanTransactionInAcbsWithNoAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+      loanTransactionInAcbsWithNoAccruals.BundleMessageList[0].AccrualScheduleList = [];
+      const expectedLoanTransactionWithNoAccruals: GetFacilityLoanTransactionResponseDto = {
+        ...expectedLoanTransaction,
+        spreadRate: null,
+        spreadRateCTL: null,
+        yearBasis: null,
+        indexRateChangeFrequency: null,
+      };
+
+      when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoAccruals);
+
+      const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
+
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNoAccruals);
+    });
+
+    it(`returns a transformation of the loan transaction from ACBS when it has no repayments`, async () => {
+      const loanTransactionInAcbsWithNoRepayments = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+      loanTransactionInAcbsWithNoRepayments.BundleMessageList[0].RepaymentScheduleList = [];
+      const expectedLoanTransactionWithNoRepayments: GetFacilityLoanTransactionResponseDto = {
+        ...expectedLoanTransaction,
+        nextDueDate: null,
+        loanBillingFrequencyType: null,
+      };
+
+      when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoRepayments);
+
+      const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
+
+      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithNoRepayments);
     });
 
     it('throws a BadRequestException if the 0th element of the bundle message list is NOT a new loan request', async () => {

--- a/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
+++ b/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
@@ -88,7 +88,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
   it('returns a 200 response with the loan transaction if it is returned by ACBS and OperationTypeCode is null', async () => {
     const loanTransactionInAcbsWithNullOperationTypeCode = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
     loanTransactionInAcbsWithNullOperationTypeCode.BundleMessageList[0].DealCustomerUsageOperationType.OperationTypeCode = null;
-    const expectedFacilityLoanTransactionsWithNullValue: GetFacilityLoanTransactionResponseDto = {
+    const expectedLoanTransactionWithNullValue: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       dealCustomerUsageOperationType: null,
     };
@@ -99,13 +99,13 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const { status, body } = await api.get(getFacilityLoanTransactionUrl);
 
     expect(status).toBe(200);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedFacilityLoanTransactionsWithNullValue)));
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNullValue)));
   });
 
   it('returns a 200 response with the loan transaction if it is returned by ACBS and OperationTypeCode is empty', async () => {
     const loanTransactionInAcbsWithEmptyOperationTypeCode = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
     loanTransactionInAcbsWithEmptyOperationTypeCode.BundleMessageList[0].DealCustomerUsageOperationType.OperationTypeCode = '';
-    const expectedFacilityLoanTransactionsWithNullValue: GetFacilityLoanTransactionResponseDto = {
+    const expectedLoanTransactionWithNullValue: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       dealCustomerUsageOperationType: null,
     };
@@ -116,7 +116,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const { status, body } = await api.get(getFacilityLoanTransactionUrl);
 
     expect(status).toBe(200);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedFacilityLoanTransactionsWithNullValue)));
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNullValue)));
   });
 
   it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has more than one accrual with the category code 'PAC01'`, async () => {
@@ -133,7 +133,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
         IndexRateChangeFrequencyCode: '',
       },
     });
-    const expectedFacilityLoanTransactionsWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
+    const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       spreadRate: 0,
       indexRateChangeFrequency: '',
@@ -145,7 +145,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const { status, body } = await api.get(getFacilityLoanTransactionUrl);
 
     expect(status).toBe(200);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedFacilityLoanTransactionsWithAdditionalAccrual)));
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithAdditionalAccrual)));
   });
 
   it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has more than one accrual with the category code 'CTL01'`, async () => {
@@ -162,7 +162,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
         IndexRateChangeFrequencyCode: '',
       },
     });
-    const expectedFacilityLoanTransactionsWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
+    const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       spreadRateCTL: 0,
     };
@@ -173,7 +173,80 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const { status, body } = await api.get(getFacilityLoanTransactionUrl);
 
     expect(status).toBe(200);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedFacilityLoanTransactionsWithAdditionalAccrual)));
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithAdditionalAccrual)));
+  });
+
+  it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has no accruals with the category code 'PAC01'`, async () => {
+    const loanTransactionInAcbsWithNoPacAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+    loanTransactionInAcbsWithNoPacAccruals.BundleMessageList[0].AccrualScheduleList.splice(1, 1);
+    const expectedLoanTransactionWithNoPacAccruals: GetFacilityLoanTransactionResponseDto = {
+      ...expectedLoanTransaction,
+      spreadRate: null,
+      indexRateChangeFrequency: null,
+    };
+
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithNoPacAccruals);
+
+    const { status, body } = await api.get(getFacilityLoanTransactionUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNoPacAccruals)));
+  });
+
+  it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has no accruals with the category code 'CTL01'`, async () => {
+    const loanTransactionInAcbsWithNoCtlAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+    loanTransactionInAcbsWithNoCtlAccruals.BundleMessageList[0].AccrualScheduleList.splice(2, 1);
+    const expectedLoanTransactionWithNoCtlAccruals: GetFacilityLoanTransactionResponseDto = {
+      ...expectedLoanTransaction,
+      spreadRateCTL: null,
+    };
+
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithNoCtlAccruals);
+
+    const { status, body } = await api.get(getFacilityLoanTransactionUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNoCtlAccruals)));
+  });
+
+  it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has no accruals`, async () => {
+    const loanTransactionInAcbsWithNoAccruals = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+    loanTransactionInAcbsWithNoAccruals.BundleMessageList[0].AccrualScheduleList = [];
+    const expectedLoanTransactionWithNoAccruals: GetFacilityLoanTransactionResponseDto = {
+      ...expectedLoanTransaction,
+      spreadRate: null,
+      spreadRateCTL: null,
+      yearBasis: null,
+      indexRateChangeFrequency: null,
+    };
+
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithNoAccruals);
+
+    const { status, body } = await api.get(getFacilityLoanTransactionUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNoAccruals)));
+  });
+
+  it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has no repayments`, async () => {
+    const loanTransactionInAcbsWithNoRepayments = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
+    loanTransactionInAcbsWithNoRepayments.BundleMessageList[0].RepaymentScheduleList = [];
+    const expectedLoanTransactionWithNoRepayments: GetFacilityLoanTransactionResponseDto = {
+      ...expectedLoanTransaction,
+      nextDueDate: null,
+      loanBillingFrequencyType: null,
+    };
+
+    givenAuthenticationWithTheIdpSucceeds();
+    requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithNoRepayments);
+
+    const { status, body } = await api.get(getFacilityLoanTransactionUrl);
+
+    expect(status).toBe(200);
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithNoRepayments)));
   });
 
   it(`returns a 400 response if the loan transaction is returned by ACBS and the 0th element of BundleMessageList is NOT a 'NewLoanRequest'`, async () => {


### PR DESCRIPTION
### Introduction

As part of the bug fix [APIM-364](https://ukef-dtfs.atlassian.net/browse/APIM-364), we added behaviour that handles when accrual/repayment schedules are missing. This PR adds API and unit tests to test this new behaviour.

### Resolution

I added test cases for:

1. No accrual schedules with category code `PAC01`
2. No accrual schedules with category code `CTL01`
3. No accrual schedules of any kind
4. No repayment schedules