### PR TITLE
feat(APIM-449): fix incorrect date format in description field for post deals endpoint

### DIFF
--- a/src/modules/date/date-string.transformations.test.ts
+++ b/src/modules/date/date-string.transformations.test.ts
@@ -86,13 +86,13 @@ describe('DateStringTransformations', () => {
     it('returns the date in DD/MM/YYYY format', () => {
       const dateTime = new Date('1987-04-23T01:00:00Z');
 
-      expect(dateStringTransformations.getDisplayDateFromDate(dateTime)).toBe('23/04/1987');
+      expect(dateStringTransformations.getDisplayDateFromDate(dateTime)).toBe('23/04/87');
     });
 
     it('returns the date in DD/MM/YYYY format even if the day number could be a single digit', () => {
       const dateTime = new Date('1987-12-03T01:00:00Z');
 
-      expect(dateStringTransformations.getDisplayDateFromDate(dateTime)).toBe('03/12/1987');
+      expect(dateStringTransformations.getDisplayDateFromDate(dateTime)).toBe('03/12/87');
     });
   });
 

--- a/src/modules/date/date-string.transformations.ts
+++ b/src/modules/date/date-string.transformations.ts
@@ -43,7 +43,7 @@ export class DateStringTransformations {
   }
 
   getDisplayDateFromDate(date: Date): string {
-    return new Intl.DateTimeFormat('en-GB').format(date);
+    return date.toLocaleDateString('en-GB', { year: '2-digit', month: '2-digit', day: '2-digit' });
   }
 
   getDayFromDateOnlyString(dateOnlyString: DateOnlyString): number {

--- a/src/modules/deal/deal.service.create-deal.test.ts
+++ b/src/modules/deal/deal.service.create-deal.test.ts
@@ -47,7 +47,7 @@ describe('DealService', () => {
     const { portfolioIdentifier } = PROPERTIES.GLOBAL;
     const now = new Date();
     const midnightToday = dateStringTransformations.getDateStringFromDate(now);
-    const todayFormattedForDescription = dateStringTransformations.getDateOnlyStringFromDate(now).split('-').reverse().join('/');
+    const todayFormattedForDescription = dateStringTransformations.getDateOnlyStringFromDate(now).substring(2).split('-').reverse().join('/');
 
     const {
       createDealRequestItem: dealToCreate,

--- a/test/deal/post-deal.api-test.ts
+++ b/test/deal/post-deal.api-test.ts
@@ -30,7 +30,7 @@ describe('POST /deals', () => {
 
   const now = new Date();
   const midnightToday = dateStringTransformations.getDateStringFromDate(now);
-  const todayFormattedForDescription = dateStringTransformations.getDateOnlyStringFromDate(now).split('-').reverse().join('/');
+  const todayFormattedForDescription = dateStringTransformations.getDateOnlyStringFromDate(now).substring(2).split('-').reverse().join('/');
 
   const requestBodyToCreateDeal = [dealToCreate];
 

--- a/test/support/generator/create-deal-generator.ts
+++ b/test/support/generator/create-deal-generator.ts
@@ -28,7 +28,7 @@ export class CreateDealGenerator extends AbstractGenerator<DealValues, GenerateR
       guaranteeCommencementDateAsDate,
       guaranteeCommencementDateAsDateOnlyString: this.dateStringTransformations.getDateOnlyStringFromDate(guaranteeCommencementDateAsDate),
       guaranteeCommencementDateAsDateString: this.dateStringTransformations.getDateStringFromDate(guaranteeCommencementDateAsDate),
-      guaranteeCommencementDateForDescription: '02/01/2019',
+      guaranteeCommencementDateForDescription: '02/01/19',
       midnightToday: this.dateStringTransformations.getDateStringFromDate(new Date()),
       obligorPartyIdentifier: this.valueGenerator.stringOfNumericCharacters({ length: 8 }),
       obligorName: this.valueGenerator.string({ maxLength: 19 }),


### PR DESCRIPTION
### Introduction

In the POST deals endpoint, we construct the Description field that we send to ACBS by appending various fields from the request to our API, including a string representation of the effectiveDate (the earliest date out of today and the guaranteeCommencementDate provided in the API request). In TFS, this was in DD/MM/YYYY format, but in the Mulesoft API, it is in DD/MM/YY format.

### Resolution

I changed the TFS implementation to use DD/MM/YY format so as to match Mulesoft, and updated the tests to reflect this.

