### PR TITLE
feat(apim-453): Make `indexRateChangeFrequency` useful in `GET /facilities/{facilityId}/loan-transactions/{bundleId}`

### DIFF
--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
@@ -111,7 +111,6 @@ describe('FacilityLoanTransactionService', () => {
       const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         spreadRate: 0,
-        indexRateChangeFrequency: '',
       };
 
       when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithMoreThanOnePacAccrual);
@@ -123,28 +122,13 @@ describe('FacilityLoanTransactionService', () => {
 
     it(`returns a transformation of the loan transaction from ACBS when it has more than one accrual with the category code 'CTL01'`, async () => {
       const loanTransactionInAcbsWithMoreThanOneCtlAccrual = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
-      loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, {
-        AccrualCategory: {
-          AccrualCategoryCode: PROPERTIES.FACILITY_LOAN.DEFAULT.accrualScheduleList.accrualCategory.accrualCategoryCode.ctl,
-        },
-        SpreadRate: 0,
-        YearBasis: {
-          YearBasisCode: '',
-        },
-        IndexRateChangeFrequency: {
-          IndexRateChangeFrequencyCode: '',
-        },
-      });
-      const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
-        ...expectedLoanTransaction,
-        spreadRateCTL: 0,
-      };
+      loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2]);
 
       when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithMoreThanOneCtlAccrual);
 
       const loanTransactions = await service.getLoanTransactionsByBundleIdentifier(bundleIdentifier);
 
-      expect(loanTransactions).toStrictEqual(expectedLoanTransactionWithAdditionalAccrual);
+      expect(loanTransactions).toStrictEqual(expectedLoanTransaction);
     });
 
     it(`returns a transformation of the loan transaction from ACBS when it has no accruals with the category code 'PAC01'`, async () => {
@@ -153,7 +137,6 @@ describe('FacilityLoanTransactionService', () => {
       const expectedLoanTransactionWithNoPacAccruals: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         spreadRate: null,
-        indexRateChangeFrequency: null,
       };
 
       when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoPacAccruals);
@@ -169,6 +152,7 @@ describe('FacilityLoanTransactionService', () => {
       const expectedLoanTransactionWithNoCtlAccruals: GetFacilityLoanTransactionResponseDto = {
         ...expectedLoanTransaction,
         spreadRateCTL: null,
+        indexRateChangeFrequency: null,
       };
 
       when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithNoCtlAccruals);

--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.get-loan-transaction-by-bundle-id.test.ts
@@ -122,7 +122,11 @@ describe('FacilityLoanTransactionService', () => {
 
     it(`returns a transformation of the loan transaction from ACBS when it has more than one accrual with the category code 'CTL01'`, async () => {
       const loanTransactionInAcbsWithMoreThanOneCtlAccrual = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
-      loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2]);
+      loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(
+        1,
+        0,
+        loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2],
+      );
 
       when(getBundleInformationAcbsService).calledWith(bundleIdentifier, idToken).mockResolvedValueOnce(loanTransactionInAcbsWithMoreThanOneCtlAccrual);
 

--- a/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
+++ b/src/modules/facility-loan-transaction/facility-loan-transaction.service.ts
@@ -60,7 +60,7 @@ export class FacilityLoanTransactionService {
       spreadRateCTL: ctlAccrual?.SpreadRate ?? null,
       yearBasis: firstAccrual?.YearBasis?.YearBasisCode ?? null,
       nextDueDate: this.dateStringTransformations.removeTimeIfExists(firstRepayment?.NextDueDate) ?? null,
-      indexRateChangeFrequency: pacAccrual?.IndexRateChangeFrequency?.IndexRateChangeFrequencyCode ?? null,
+      indexRateChangeFrequency: ctlAccrual?.IndexRateChangeFrequency?.IndexRateChangeFrequencyCode ?? null,
       loanBillingFrequencyType: firstRepayment?.LoanBillingFrequencyType?.LoanBillingFrequencyTypeCode ?? null,
     };
   }

--- a/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
+++ b/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
@@ -136,7 +136,6 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       spreadRate: 0,
-      indexRateChangeFrequency: '',
     };
 
     givenAuthenticationWithTheIdpSucceeds();
@@ -150,22 +149,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
 
   it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has more than one accrual with the category code 'CTL01'`, async () => {
     const loanTransactionInAcbsWithMoreThanOneCtlAccrual = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
-    loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, {
-      AccrualCategory: {
-        AccrualCategoryCode: PROPERTIES.FACILITY_LOAN.DEFAULT.accrualScheduleList.accrualCategory.accrualCategoryCode.ctl,
-      },
-      SpreadRate: 0,
-      YearBasis: {
-        YearBasisCode: '',
-      },
-      IndexRateChangeFrequency: {
-        IndexRateChangeFrequencyCode: '',
-      },
-    });
-    const expectedLoanTransactionWithAdditionalAccrual: GetFacilityLoanTransactionResponseDto = {
-      ...expectedLoanTransaction,
-      spreadRateCTL: 0,
-    };
+    loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2]);
 
     givenAuthenticationWithTheIdpSucceeds();
     requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithMoreThanOneCtlAccrual);
@@ -173,7 +157,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const { status, body } = await api.get(getFacilityLoanTransactionUrl);
 
     expect(status).toBe(200);
-    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransactionWithAdditionalAccrual)));
+    expect(body).toStrictEqual(JSON.parse(JSON.stringify(expectedLoanTransaction)));
   });
 
   it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has no accruals with the category code 'PAC01'`, async () => {
@@ -182,7 +166,6 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const expectedLoanTransactionWithNoPacAccruals: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       spreadRate: null,
-      indexRateChangeFrequency: null,
     };
 
     givenAuthenticationWithTheIdpSucceeds();
@@ -200,6 +183,7 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
     const expectedLoanTransactionWithNoCtlAccruals: GetFacilityLoanTransactionResponseDto = {
       ...expectedLoanTransaction,
       spreadRateCTL: null,
+      indexRateChangeFrequency: null,
     };
 
     givenAuthenticationWithTheIdpSucceeds();

--- a/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
+++ b/test/facility-loan-transaction/get-facility-loan-transaction.api-test.ts
@@ -149,7 +149,11 @@ describe('GET /facilities/{facilityIdentifier}/loan-transactions/{bundleIdentifi
 
   it(`returns a 200 response with the loan transaction if it is returned by ACBS and it has more than one accrual with the category code 'CTL01'`, async () => {
     const loanTransactionInAcbsWithMoreThanOneCtlAccrual = JSON.parse(JSON.stringify(acbsFacilityLoanTransaction));
-    loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(1, 0, loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2]);
+    loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList.splice(
+      1,
+      0,
+      loanTransactionInAcbsWithMoreThanOneCtlAccrual.BundleMessageList[0].AccrualScheduleList[2],
+    );
 
     givenAuthenticationWithTheIdpSucceeds();
     requestToGetFacilityLoanTransaction().reply(200, loanTransactionInAcbsWithMoreThanOneCtlAccrual);

--- a/test/support/generator/get-facility-loan-transaction-generator.ts
+++ b/test/support/generator/get-facility-loan-transaction-generator.ts
@@ -108,7 +108,7 @@ export class GetFacilityLoanTransactionGenerator extends AbstractGenerator<Facil
                 YearBasisCode: '',
               },
               IndexRateChangeFrequency: {
-                IndexRateChangeFrequencyCode: firstFacilityLoanTransaction.indexRateChangeFrequencyCode,
+                IndexRateChangeFrequencyCode: '',
               },
             },
             {
@@ -120,7 +120,7 @@ export class GetFacilityLoanTransactionGenerator extends AbstractGenerator<Facil
                 YearBasisCode: '',
               },
               IndexRateChangeFrequency: {
-                IndexRateChangeFrequencyCode: '',
+                IndexRateChangeFrequencyCode: firstFacilityLoanTransaction.indexRateChangeFrequencyCode,
               },
             },
           ],


### PR DESCRIPTION
## Introduction

In the `GET /facilities/{facilityId}/loan-transactions/{bundleId}` endpoint the `indexRateChangeFrequency` value is taken from the pac accrual schedule. This is never set in the POST request so will always be null. 

## Resolution 

`indexRateChangeFrequency` is only set in the Contractual Interest, non Risk Free Rate accrual schedules (when Product Group = EWCS and Currency = USD). So the ctl accrual schedule is used to set the `indexRateCHangeFrequency` value instead.