### PR TITLE
fix: typo fix in incomeClass enum

### DIFF
--- a/src/constants/enums/income-class-code.ts
+++ b/src/constants/enums/income-class-code.ts
@@ -1,6 +1,6 @@
 // These enums are as specified in the documentation, however note that these appear incomplete
 export enum IncomeClassCodeEnum {
   BPM = 'BPM',
-  EPM = 'EMP',
+  EPM = 'EPM',
   FGT = 'FGT',
 }

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -2416,7 +2416,7 @@ components:
           minLength: 0
           enum:
             - BPM
-            - EMP
+            - EPM
             - FGT
           example: BPM
           default: BPM


### PR DESCRIPTION
### Introduction

Noticed that Fixed Fee creation doesn't work for EWCS facilities.

### Resolution

Simple typo fix. Confirmed in ACBS reference list.