### PR TITLE
fix(APIM-369): fix minor differences compared to TF-EA

### DIFF
--- a/src/constants/properties.constant.ts
+++ b/src/constants/properties.constant.ts
@@ -394,8 +394,6 @@ export const PROPERTIES = {
       cashEventList: {
         paymentInstructionCode: '',
         cashOffsetTypeCode: '02',
-        settlementCurrencyCode: null,
-        originatingGeneralLedgerUnit: null,
         dDAAccount: '',
         cashReferenceIdentifier: '',
       },

--- a/src/decorators/parse-required-and-nullable-validation.helper.ts
+++ b/src/decorators/parse-required-and-nullable-validation.helper.ts
@@ -12,7 +12,7 @@ export const parseRequiredAndNullable = ({ required, nullable }: RequiredAndNull
   return {
     shouldPropertyBeDocumentedAsRequired: typeof requiredOrDefault === 'function' ? false : requiredOrDefault,
     shouldPropertyBeDocumentedAsNullable: typeof nullableOrDefault === 'function' ? true : nullableOrDefault,
-    validationDecoratorsToApplyForRequiredOption: [
+    validationDecoratorsToApply: [
       ValidateIf(
         (currentObject, propertyValue) =>
           !getAllowedNullishValuesForProperty(currentObject, { required: requiredOrDefault, nullable: nullableOrDefault }).includes(propertyValue),
@@ -21,12 +21,12 @@ export const parseRequiredAndNullable = ({ required, nullable }: RequiredAndNull
   };
 };
 
-const asFunctionDependingOnCurrentObject = (x: BooleanOrBooleanDependingOnCurrentObject): BooleanDependingOnCurrentObject =>
+const asBooleanDependingOnCurrentObject = (x: BooleanOrBooleanDependingOnCurrentObject): BooleanDependingOnCurrentObject =>
   typeof x === 'function' ? x : () => x;
 
 const getAllowedNullishValuesForProperty = (currentObject: Record<string, unknown>, { required, nullable }: RequiredAndNullable): (undefined | null)[] => {
-  const propertyIsRequiredOnCurrentObject = asFunctionDependingOnCurrentObject(required);
-  const propertyIsNullableOnCurrentObject = asFunctionDependingOnCurrentObject(nullable);
+  const propertyIsRequiredOnCurrentObject = asBooleanDependingOnCurrentObject(required);
+  const propertyIsNullableOnCurrentObject = asBooleanDependingOnCurrentObject(nullable);
   const allowedNullishValues: (undefined | null)[] = [];
 
   if (propertyIsNullableOnCurrentObject(currentObject)) {
@@ -48,5 +48,5 @@ interface RequiredAndNullable<> {
 interface ParsedRequiredAndNullableOptions {
   shouldPropertyBeDocumentedAsRequired: boolean;
   shouldPropertyBeDocumentedAsNullable: boolean;
-  validationDecoratorsToApplyForRequiredOption: PropertyDecorator[];
+  validationDecoratorsToApply: PropertyDecorator[];
 }

--- a/src/decorators/parse-required-and-nullable-validation.helper.ts
+++ b/src/decorators/parse-required-and-nullable-validation.helper.ts
@@ -1,0 +1,52 @@
+import { ValidateIf } from 'class-validator';
+
+export type RequiredOption = OptionalBooleanOrBooleanDependingOnCurrentObject;
+export type NullableOption = OptionalBooleanOrBooleanDependingOnCurrentObject;
+
+type OptionalBooleanOrBooleanDependingOnCurrentObject = undefined | BooleanOrBooleanDependingOnCurrentObject;
+type BooleanOrBooleanDependingOnCurrentObject = boolean | BooleanDependingOnCurrentObject;
+type BooleanDependingOnCurrentObject = (currentObject: Record<string, unknown>) => boolean;
+export const parseRequiredAndNullable = ({ required, nullable }: RequiredAndNullable): ParsedRequiredAndNullableOptions => {
+  const requiredOrDefault = required ?? true;
+  const nullableOrDefault = nullable ?? false;
+  return {
+    shouldPropertyBeDocumentedAsRequired: typeof requiredOrDefault === 'function' ? false : requiredOrDefault,
+    shouldPropertyBeDocumentedAsNullable: typeof nullableOrDefault === 'function' ? true : nullableOrDefault,
+    validationDecoratorsToApplyForRequiredOption: [
+      ValidateIf(
+        (currentObject, propertyValue) =>
+          !getAllowedNullishValuesForProperty(currentObject, { required: requiredOrDefault, nullable: nullableOrDefault }).includes(propertyValue),
+      ),
+    ],
+  };
+};
+
+const asFunctionDependingOnCurrentObject = (x: BooleanOrBooleanDependingOnCurrentObject): BooleanDependingOnCurrentObject =>
+  typeof x === 'function' ? x : () => x;
+
+const getAllowedNullishValuesForProperty = (currentObject: Record<string, unknown>, { required, nullable }: RequiredAndNullable): (undefined | null)[] => {
+  const propertyIsRequiredOnCurrentObject = asFunctionDependingOnCurrentObject(required);
+  const propertyIsNullableOnCurrentObject = asFunctionDependingOnCurrentObject(nullable);
+  const allowedNullishValues: (undefined | null)[] = [];
+
+  if (propertyIsNullableOnCurrentObject(currentObject)) {
+    allowedNullishValues.push(null);
+  }
+
+  if (!propertyIsRequiredOnCurrentObject(currentObject)) {
+    allowedNullishValues.push(undefined);
+  }
+
+  return allowedNullishValues;
+};
+
+interface RequiredAndNullable<> {
+  required: RequiredOption;
+  nullable: NullableOption;
+}
+
+interface ParsedRequiredAndNullableOptions {
+  shouldPropertyBeDocumentedAsRequired: boolean;
+  shouldPropertyBeDocumentedAsNullable: boolean;
+  validationDecoratorsToApplyForRequiredOption: PropertyDecorator[];
+}

--- a/src/decorators/validated-boolean-api-property.decorator.ts
+++ b/src/decorators/validated-boolean-api-property.decorator.ts
@@ -1,34 +1,21 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsBoolean, IsNotEmpty } from 'class-validator';
 
 interface Options {
   description: string;
-  minimum?: number;
-  enum?: any;
-  required?: boolean;
-  example?: number;
-  default?: number;
 }
 
-export const ValidatedBooleanApiProperty = ({ description, required, example, default: theDefault }: Options) => {
+export const ValidatedRequiredBooleanApiProperty = ({ description }: Options) => {
   const decoratorsToApply = [
     ApiProperty({
       type: 'boolean',
       description,
-      example,
-      required,
-      default: theDefault,
+      required: true,
+      nullable: false,
     }),
     IsBoolean(),
+    IsNotEmpty(),
   ];
-
-  const isRequiredProperty = required ?? true;
-  if (isRequiredProperty) {
-    decoratorsToApply.push(IsNotEmpty());
-  } else {
-    decoratorsToApply.push(IsOptional());
-  }
-
   return applyDecorators(...decoratorsToApply);
 };

--- a/src/decorators/validated-date-only-api-property.decorator.ts
+++ b/src/decorators/validated-date-only-api-property.decorator.ts
@@ -2,41 +2,40 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { DATE_FORMATS } from '@ukef/constants';
 import { DateOnlyString } from '@ukef/helpers';
-import { IsISO8601, IsOptional, Matches, ValidateIf } from 'class-validator';
+import { IsISO8601, Matches } from 'class-validator';
+
+import { NullableOption, parseRequiredAndNullable, RequiredOption } from './parse-required-and-nullable-validation.helper';
 
 interface Options {
   description: string;
   example?: DateOnlyString;
-  required?: boolean;
+  required?: RequiredOption;
   default?: DateOnlyString | null;
-  nullable?: boolean;
+  nullable?: NullableOption;
 }
 
 export const ValidatedDateOnlyApiProperty = ({ description, example, required, default: theDefault, nullable }: Options) => {
+  const { shouldPropertyBeDocumentedAsRequired, shouldPropertyBeDocumentedAsNullable, validationDecoratorsToApplyForRequiredOption } = parseRequiredAndNullable(
+    {
+      required,
+      nullable,
+    },
+  );
   const decoratorsToApply = [
     ApiProperty({
       description,
       type: Date,
       format: 'date',
-      required,
+      required: shouldPropertyBeDocumentedAsRequired,
       example,
       default: theDefault,
-      nullable,
+      nullable: shouldPropertyBeDocumentedAsNullable,
     }),
     IsISO8601({ strict: true }),
     Matches(DATE_FORMATS.DATE_ONLY_STRING.regex),
   ];
 
-  const isRequiredProperty = required ?? true;
-  const isNullableProperty = nullable ?? false;
-
-  if (!isRequiredProperty && isNullableProperty) {
-    decoratorsToApply.push(IsOptional());
-  } else if (!isRequiredProperty) {
-    decoratorsToApply.push(ValidateIf((_object, value) => value !== undefined));
-  } else if (isNullableProperty) {
-    decoratorsToApply.push(ValidateIf((_object, value) => value !== null));
-  }
+  decoratorsToApply.push(...validationDecoratorsToApplyForRequiredOption);
 
   return applyDecorators(...decoratorsToApply);
 };

--- a/src/decorators/validated-date-only-api-property.decorator.ts
+++ b/src/decorators/validated-date-only-api-property.decorator.ts
@@ -15,12 +15,10 @@ interface Options {
 }
 
 export const ValidatedDateOnlyApiProperty = ({ description, example, required, default: theDefault, nullable }: Options) => {
-  const { shouldPropertyBeDocumentedAsRequired, shouldPropertyBeDocumentedAsNullable, validationDecoratorsToApplyForRequiredOption } = parseRequiredAndNullable(
-    {
-      required,
-      nullable,
-    },
-  );
+  const { shouldPropertyBeDocumentedAsRequired, shouldPropertyBeDocumentedAsNullable, validationDecoratorsToApply } = parseRequiredAndNullable({
+    required,
+    nullable,
+  });
   const decoratorsToApply = [
     ApiProperty({
       description,
@@ -35,7 +33,7 @@ export const ValidatedDateOnlyApiProperty = ({ description, example, required, d
     Matches(DATE_FORMATS.DATE_ONLY_STRING.regex),
   ];
 
-  decoratorsToApply.push(...validationDecoratorsToApplyForRequiredOption);
+  decoratorsToApply.push(...validationDecoratorsToApply);
 
   return applyDecorators(...decoratorsToApply);
 };

--- a/src/decorators/validated-number-api-property.decorator.ts
+++ b/src/decorators/validated-number-api-property.decorator.ts
@@ -1,13 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty, ApiPropertyOptions } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsNumber, IsOptional, Min, NotEquals, ValidateIf } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsNumber, Min, NotEquals, ValidateIf } from 'class-validator';
 
 interface Options {
   description: string;
   minimum?: number;
   enum?: any;
   required?: boolean;
-  nullable?: boolean;
   example?: number;
   default?: number;
   forbidZero?: boolean;
@@ -16,27 +15,18 @@ interface Options {
 export const ValidatedNumberApiProperty = (options: Options) => {
   const decoratorsToApply = [ApiProperty(buildSwaggerPropertyOptions(options)), IsNumber()];
 
-  const { minimum, enum: theEnum, required, nullable, forbidZero } = options;
+  const { minimum, enum: theEnum, required, forbidZero } = options;
 
   if (minimum || minimum === 0) {
     decoratorsToApply.push(Min(minimum));
   }
 
   const isRequiredProperty = required ?? true;
-  const isNullableProperty = nullable ?? false;
 
-  if (isRequiredProperty || !isNullableProperty) {
-    decoratorsToApply.push(IsNotEmpty());
+  decoratorsToApply.push(IsNotEmpty());
 
-    if (!isRequiredProperty) {
-      decoratorsToApply.push(ValidateIf((_object, value) => value !== undefined));
-    }
-
-    if (isNullableProperty) {
-      decoratorsToApply.push(ValidateIf((_object, value) => value !== null));
-    }
-  } else {
-    decoratorsToApply.push(IsOptional());
+  if (!isRequiredProperty) {
+    decoratorsToApply.push(ValidateIf((_object, value) => value !== undefined));
   }
 
   if (theEnum) {
@@ -66,6 +56,7 @@ const buildSwaggerPropertyOptions = ({
     example,
     enum: theEnum,
     required,
+    nullable: false,
     default: theDefault,
   };
 

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -2,7 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsString, Length, Matches } from 'class-validator';
 
-import { parseRequiredAndNullable } from './parse-required-and-nullable-validation.helper';
+import { parseRequiredAndNullable, RequiredOption } from './parse-required-and-nullable-validation.helper';
 
 interface Options {
   description: string;
@@ -15,8 +15,6 @@ interface Options {
   example?: string;
   default?: string;
 }
-
-type RequiredOption = undefined | boolean | ((currentObject: Record<string, unknown>) => boolean);
 
 export const ValidatedStringApiProperty = ({
   description,

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -30,7 +30,7 @@ export const ValidatedStringApiProperty = ({
   minLength = length ?? minLength ?? 0;
   maxLength = length ?? maxLength;
 
-  const { shouldPropertyBeDocumentedAsRequired, validationDecoratorsToApplyForRequiredOption } = parseRequiredAndNullable({
+  const { shouldPropertyBeDocumentedAsRequired, validationDecoratorsToApply } = parseRequiredAndNullable({
     required,
     nullable: true,
   });
@@ -50,7 +50,7 @@ export const ValidatedStringApiProperty = ({
     IsString(),
     Length(minLength, maxLength),
   ];
-  decoratorsToApply.push(...validationDecoratorsToApplyForRequiredOption);
+  decoratorsToApply.push(...validationDecoratorsToApply);
 
   if (pattern) {
     decoratorsToApply.push(Matches(pattern));

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -32,7 +32,7 @@ export const ValidatedStringApiProperty = ({
 
   const { shouldPropertyBeDocumentedAsRequired, validationDecoratorsToApply } = parseRequiredAndNullable({
     required,
-    nullable: true,
+    nullable: typeof required === 'function' ? (...args) => !required(...args) : !(required ?? true),
   });
 
   const decoratorsToApply = [

--- a/src/modules/acbs/dto/bundle-actions/new-loan-request.bundle-action.ts
+++ b/src/modules/acbs/dto/bundle-actions/new-loan-request.bundle-action.ts
@@ -100,8 +100,6 @@ interface NewLoanRequestCashEvent {
   Currency: {
     CurrencyCode: string;
   };
-  SettlementCurrencyCode: string;
-  OriginatingGeneralLedgerUnit: string;
   DDAAccount: string;
   CashDetailAmount: number;
   CashReferenceIdentifier: string;

--- a/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.controller.test.ts
@@ -31,12 +31,11 @@ describe('DealGuaranteeController', () => {
     const dealIdentifier = valueGenerator.ukefId();
     const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
     const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
-    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
     const effectiveDate = valueGenerator.dateOnlyString();
     const guaranteeExpiryDate = valueGenerator.dateOnlyString();
     const maximumLiability = valueGenerator.nonnegativeFloat();
 
-    const newGuarantee = new CreateDealGuaranteeRequestItem(effectiveDate, limitKey, guaranteeExpiryDate, maximumLiability, guarantorParty, guaranteeTypeCode);
+    const newGuarantee = new CreateDealGuaranteeRequestItem(effectiveDate, limitKey, guaranteeExpiryDate, maximumLiability, guarantorParty);
 
     it('creates a guarantee for the deal with the service from the request body', async () => {
       await controller.createGuaranteeForDeal(dealIdentifier, [newGuarantee]);

--- a/src/modules/deal-guarantee/deal-guarantee.service.create-guarantee.test.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.create-guarantee.test.ts
@@ -41,7 +41,6 @@ describe('DealGuaranteeService', () => {
     const dealIdentifier = valueGenerator.stringOfNumericCharacters();
     const limitKey = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
     const guarantorParty = valueGenerator.stringOfNumericCharacters({ maxLength: 8 });
-    const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ maxLength: 3 });
     const effectiveDate = TEST_DATES.A_PAST_EFFECTIVE_DATE_ONLY;
     const now = new Date();
     const todayAsDateOnlyString = dateStringTransformations.removeTime(now.toISOString());
@@ -54,7 +53,6 @@ describe('DealGuaranteeService', () => {
       limitKey,
       guaranteeExpiryDate: expirationDate,
       maximumLiability: maximumLiabilityWithOneDecimalPlace,
-      guaranteeTypeCode,
     };
 
     it('creates a guarantee in ACBS with a transformation of the requested new guarantee', async () => {
@@ -71,7 +69,7 @@ describe('DealGuaranteeService', () => {
           PartyIdentifier: guarantorParty,
         },
         GuaranteeType: {
-          GuaranteeTypeCode: guaranteeTypeCode,
+          GuaranteeTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
         },
         EffectiveDate: dateStringTransformations.addTimeToDateOnlyString(effectiveDate),
         ExpirationDate: dateStringTransformations.addTimeToDateOnlyString(expirationDate),
@@ -92,16 +90,6 @@ describe('DealGuaranteeService', () => {
       const guaranteeCreatedInAcbs = getGuaranteeCreatedInAcbs();
 
       expect(guaranteeCreatedInAcbs.GuarantorParty.PartyIdentifier).toBe(PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty);
-    });
-
-    it('adds a default value for guaranteeTypeCode before creating the new guarantee if it is not specified', async () => {
-      const { guaranteeTypeCode: _removed, ...newGuaranteeWithoutGuaranteeTypeCode } = newGuaranteeWithAllFields;
-
-      await service.createGuaranteeForDeal(dealIdentifier, newGuaranteeWithoutGuaranteeTypeCode);
-
-      const guaranteeCreatedInAcbs = getGuaranteeCreatedInAcbs();
-
-      expect(guaranteeCreatedInAcbs.GuaranteeType.GuaranteeTypeCode).toBe(PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode);
     });
 
     it(`replaces effectiveDate with today's date if effectiveDate is after today`, async () => {

--- a/src/modules/deal-guarantee/deal-guarantee.service.ts
+++ b/src/modules/deal-guarantee/deal-guarantee.service.ts
@@ -40,7 +40,7 @@ export class DealGuaranteeService {
         PartyIdentifier: newGuarantee.guarantorParty ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guarantorParty,
       },
       GuaranteeType: {
-        GuaranteeTypeCode: newGuarantee.guaranteeTypeCode ?? PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
+        GuaranteeTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
       },
       EffectiveDate: this.dateStringTransformations.addTimeToDateOnlyString(effectiveDateOnlyString),
       ExpirationDate: this.dateStringTransformations.addTimeToDateOnlyString(newGuarantee.guaranteeExpiryDate),

--- a/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
+++ b/src/modules/deal-guarantee/dto/create-deal-guarantee-request.dto.ts
@@ -40,28 +40,11 @@ export class CreateDealGuaranteeRequestItem {
   })
   readonly guarantorParty?: string;
 
-  @ValidatedStringApiProperty({
-    description: `The identifier for the type of the guarantee.`,
-    default: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
-    required: false,
-    minLength: 3,
-    maxLength: 3,
-  })
-  readonly guaranteeTypeCode?: string;
-
-  constructor(
-    effectiveDate: DateOnlyString,
-    limitKey: string,
-    guaranteeExpiryDate: DateOnlyString,
-    maximumLiability: number,
-    guarantorParty?: string,
-    guaranteeTypeCode?: string,
-  ) {
+  constructor(effectiveDate: DateOnlyString, limitKey: string, guaranteeExpiryDate: DateOnlyString, maximumLiability: number, guarantorParty?: string) {
     this.effectiveDate = effectiveDate;
     this.limitKey = limitKey;
     this.guaranteeExpiryDate = guaranteeExpiryDate;
     this.maximumLiability = maximumLiability;
     this.guarantorParty = guarantorParty;
-    this.guaranteeTypeCode = guaranteeTypeCode;
   }
 }

--- a/src/modules/facility-covenant/dto/update-facility-covenants-request.dto.ts
+++ b/src/modules/facility-covenant/dto/update-facility-covenants-request.dto.ts
@@ -8,7 +8,6 @@ export class UpdateFacilityCovenantsRequestDto {
     description: 'The amount used to determine if the covenant is in compliance or not. It is required if expirationDate is not provided.',
     minimum: 0,
     required: false,
-    nullable: false,
     example: EXAMPLES.DEAL_OR_FACILITY_VALUE,
   })
   readonly targetAmount?: number;

--- a/src/modules/facility-fixed-fee/dto/create-facility-fixed-fee-request.dto.ts
+++ b/src/modules/facility-fixed-fee/dto/create-facility-fixed-fee-request.dto.ts
@@ -1,6 +1,6 @@
 import { ENUMS, EXAMPLES, PROPERTIES } from '@ukef/constants';
 import { LenderTypeCodeEnum } from '@ukef/constants/enums/lender-type-code';
-import { ValidatedBooleanApiProperty } from '@ukef/decorators/validated-boolean-api-property.decorator';
+import { ValidatedRequiredBooleanApiProperty } from '@ukef/decorators/validated-boolean-api-property.decorator';
 import { ValidatedCurrencyApiProperty } from '@ukef/decorators/validated-currency-api-property-decorator';
 import { ValidatedDateOnlyApiProperty } from '@ukef/decorators/validated-date-only-api-property.decorator';
 import { ValidatedNumberApiProperty } from '@ukef/decorators/validated-number-api-property.decorator';
@@ -64,7 +64,7 @@ export class CreateFacilityFixedFeeRequestItem {
   })
   readonly incomeClassCode?: string;
 
-  @ValidatedBooleanApiProperty({
+  @ValidatedRequiredBooleanApiProperty({
     description:
       'Action indicator to be supplied together with the Fee to control propagation of the fee effects to other investors. Not applicable to output data.',
   })

--- a/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
+++ b/src/modules/facility-guarantee/dto/update-facility-guarantees-request.dto.ts
@@ -15,7 +15,6 @@ export class UpdateFacilityGuaranteesRequestDto {
     description: 'The maximum amount the guarantor will guarantee. It is required if expirationDate is not provided.',
     minimum: 0,
     required: false,
-    nullable: false,
     example: EXAMPLES.DEAL_OR_FACILITY_VALUE,
   })
   readonly guaranteedLimit?: number;

--- a/src/modules/facility-loan/dto/create-facility-loan-request.dto.ts
+++ b/src/modules/facility-loan/dto/create-facility-loan-request.dto.ts
@@ -106,7 +106,7 @@ export class CreateFacilityLoanRequestItem {
   readonly yearBasis: YearBasisCodeEnum;
 
   @ValidatedStringApiProperty({
-    description: `The frequency which the rate will change. This is required if productTypeGroup is ${ProductTypeGroupEnum.EWCS}.`,
+    description: `The frequency with which the rate will change. This is required if productTypeGroup is ${ProductTypeGroupEnum.EWCS}.`,
     required: ({ productTypeGroup }) => productTypeGroup === ProductTypeGroupEnum.EWCS,
     enum: ENUMS.FEE_FREQUENCY_TYPES,
     example: ENUMS.FEE_FREQUENCY_TYPES.WEEKLY,

--- a/src/modules/facility-loan/dto/create-facility-loan-request.dto.ts
+++ b/src/modules/facility-loan/dto/create-facility-loan-request.dto.ts
@@ -106,8 +106,8 @@ export class CreateFacilityLoanRequestItem {
   readonly yearBasis: YearBasisCodeEnum;
 
   @ValidatedStringApiProperty({
-    description: 'The frequency which the rate will change.',
-    required: false,
+    description: `The frequency which the rate will change. This is required if productTypeGroup is ${ProductTypeGroupEnum.EWCS}.`,
+    required: ({ productTypeGroup }) => productTypeGroup === ProductTypeGroupEnum.EWCS,
     enum: ENUMS.FEE_FREQUENCY_TYPES,
     example: ENUMS.FEE_FREQUENCY_TYPES.WEEKLY,
   })

--- a/src/modules/facility-loan/facility-loan.service.ts
+++ b/src/modules/facility-loan/facility-loan.service.ts
@@ -183,8 +183,6 @@ export class FacilityLoanService {
           Currency: {
             CurrencyCode: newFacilityLoan.currency,
           },
-          SettlementCurrencyCode: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.settlementCurrencyCode,
-          OriginatingGeneralLedgerUnit: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.originatingGeneralLedgerUnit,
           DDAAccount: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.dDAAccount,
           CashDetailAmount: newFacilityLoan.amount,
           CashReferenceIdentifier: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.cashReferenceIdentifier,

--- a/src/modules/facility/dto/base-facility-request.dto.ts
+++ b/src/modules/facility/dto/base-facility-request.dto.ts
@@ -160,8 +160,8 @@ export class BaseFacilityRequestItem {
 
   @ValidatedDateOnlyApiProperty({
     description: 'Issue Date for Bond or Disbursement Date for Loan/EWCS. Not required at commitment stage',
-    required: false,
-    nullable: true,
+    required: ({ facilityStageCode }) => facilityStageCode === ENUMS.FACILITY_STAGES.ISSUED,
+    nullable: ({ facilityStageCode }) => facilityStageCode !== ENUMS.FACILITY_STAGES.ISSUED,
     default: null,
   })
   readonly issueDate?: DateOnlyString | null;

--- a/src/modules/facility/dto/base-facility-request.dto.ts
+++ b/src/modules/facility/dto/base-facility-request.dto.ts
@@ -153,7 +153,7 @@ export class BaseFacilityRequestItem {
     description:
       'The code of the Capital Conversion Factor for the facility (e.g. 100% Conversion, 80% Conversion, No Conversion) from the T1125 table in ACBS. This field should be specified for GEF. When this field is not specified, a default will be chosen based on the productTypeId.',
     example: '1',
-    required: false,
+    required: ({ productTypeId }) => productTypeId === ENUMS.FACILITY_TYPE_IDS.GEF,
     maxLength: 2,
   })
   readonly capitalConversionFactorCode?: string;

--- a/test/common-tests/request-field-validation-api-tests/base-facility-fields-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/base-facility-fields-validation-api-tests.ts
@@ -25,13 +25,33 @@ export function withBaseFacilityFieldsValidationApiTests({
   includeIssueDate = true,
 }: withBaseFacilityFieldsValidationApiTestInterface) {
   if (includeIssueDate) {
-    withDateOnlyFieldValidationApiTests({
-      fieldName: 'issueDate',
-      required: false,
-      nullable: true,
-      validRequestBody,
-      makeRequest,
-      givenAnyRequestBodyWouldSucceed,
+    const notIssuedFacilityStageCodes = Object.values(ENUMS.FACILITY_STAGES)
+      .filter((code) => code !== ENUMS.FACILITY_STAGES.ISSUED)
+      .map((code) => ({ notIssuedCode: code }));
+    describe.each(notIssuedFacilityStageCodes)('when facilityStageCode is $notIssuedCode', ({ notIssuedCode }) => {
+      const validRequestBodyWithFacilityStageCode: BaseFacilityRequestItem[] | BaseFacilityRequestItem = Array.isArray(validRequestBody)
+        ? [{ ...validRequestBody[0], facilityStageCode: notIssuedCode }]
+        : { ...validRequestBody, facilityStageCode: notIssuedCode };
+
+      withDateOnlyFieldValidationApiTests<BaseFacilityRequestItem>({
+        fieldName: 'issueDate',
+        required: false,
+        nullable: true,
+        validRequestBody: validRequestBodyWithFacilityStageCode,
+        makeRequest,
+        givenAnyRequestBodyWouldSucceed,
+      });
+    });
+
+    describe(`when facilityStageCode is ${ENUMS.FACILITY_STAGES.ISSUED}`, () => {
+      withDateOnlyFieldValidationApiTests({
+        fieldName: 'issueDate',
+        required: true,
+        nullable: false,
+        validRequestBody,
+        makeRequest,
+        givenAnyRequestBodyWouldSucceed,
+      });
     });
   }
 

--- a/test/common-tests/request-field-validation-api-tests/base-facility-fields-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/base-facility-fields-validation-api-tests.ts
@@ -24,9 +24,12 @@ export function withBaseFacilityFieldsValidationApiTests({
   givenAnyRequestBodyWouldSucceed,
   includeIssueDate = true,
 }: withBaseFacilityFieldsValidationApiTestInterface) {
+  const gefProductTypeId = ENUMS.FACILITY_TYPE_IDS.GEF;
+  const issuedFacilityStageCode = ENUMS.FACILITY_STAGES.ISSUED;
+
   if (includeIssueDate) {
     const notIssuedFacilityStageCodes = Object.values(ENUMS.FACILITY_STAGES)
-      .filter((code) => code !== ENUMS.FACILITY_STAGES.ISSUED)
+      .filter((code) => code !== issuedFacilityStageCode)
       .map((code) => ({ notIssuedCode: code }));
     describe.each(notIssuedFacilityStageCodes)('when facilityStageCode is $notIssuedCode', ({ notIssuedCode }) => {
       const validRequestBodyWithFacilityStageCode: BaseFacilityRequestItem[] | BaseFacilityRequestItem = Array.isArray(validRequestBody)
@@ -43,7 +46,7 @@ export function withBaseFacilityFieldsValidationApiTests({
       });
     });
 
-    describe(`when facilityStageCode is ${ENUMS.FACILITY_STAGES.ISSUED}`, () => {
+    describe(`when facilityStageCode is ${issuedFacilityStageCode}`, () => {
       withDateOnlyFieldValidationApiTests({
         fieldName: 'issueDate',
         required: true,
@@ -243,14 +246,38 @@ export function withBaseFacilityFieldsValidationApiTests({
     givenAnyRequestBodyWouldSucceed,
   });
 
-  withStringFieldValidationApiTests({
-    fieldName: 'capitalConversionFactorCode',
-    minLength: 0,
-    maxLength: 2,
-    required: false,
-    generateFieldValueOfLength: (length) => valueGenerator.string({ length }),
-    validRequestBody,
-    makeRequest,
-    givenAnyRequestBodyWouldSucceed,
+  const nonGefFacilityTypeIds = Object.values(ENUMS.FACILITY_TYPE_IDS)
+    .filter((code) => code !== gefProductTypeId)
+    .map((id) => ({ nonGefId: id }));
+  describe.each(nonGefFacilityTypeIds)('when productTypeId is $nonGefId', ({ nonGefId }) => {
+    const validRequestBodyWithProductTypeId: BaseFacilityRequestItem[] | BaseFacilityRequestItem = Array.isArray(validRequestBody)
+      ? [{ ...validRequestBody[0], productTypeId: nonGefId }]
+      : { ...validRequestBody, productTypeId: nonGefId };
+    withStringFieldValidationApiTests({
+      fieldName: 'capitalConversionFactorCode',
+      minLength: 0,
+      maxLength: 2,
+      required: false,
+      generateFieldValueOfLength: (length) => valueGenerator.string({ length }),
+      validRequestBody: validRequestBodyWithProductTypeId,
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
+  });
+
+  describe(`when productTypeId is ${gefProductTypeId}`, () => {
+    const validRequestBodyWithGefProductTypeId: BaseFacilityRequestItem[] | BaseFacilityRequestItem = Array.isArray(validRequestBody)
+      ? [{ ...validRequestBody[0], productTypeId: gefProductTypeId }]
+      : { ...validRequestBody, productTypeId: gefProductTypeId };
+    withStringFieldValidationApiTests({
+      fieldName: 'capitalConversionFactorCode',
+      minLength: 0,
+      maxLength: 2,
+      required: true,
+      generateFieldValueOfLength: (length) => valueGenerator.string({ length }),
+      validRequestBody: validRequestBodyWithGefProductTypeId,
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
   });
 }

--- a/test/common-tests/request-field-validation-api-tests/boolean-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/boolean-field-validation-api-tests.ts
@@ -24,6 +24,7 @@ export function withBooleanFieldValidationApiTests<RequestBodyItem, RequestBodyI
     });
 
     if (required) {
+      const expectedRequiredFieldError = `${fieldName} should not be empty`;
       it(`returns a 400 response if ${fieldName} is not present`, async () => {
         const [{ [fieldNameSymbol]: _removed, ...requestWithoutTheField }] = validRequestBody;
 
@@ -32,15 +33,15 @@ export function withBooleanFieldValidationApiTests<RequestBodyItem, RequestBodyI
         expect(status).toBe(400);
         expect(body).toMatchObject({
           error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} should not be empty`]),
+          message: expect.arrayContaining([expectedRequiredFieldError]),
           statusCode: 400,
         });
       });
     } else {
       it(`returns a 201 response if ${fieldName} is not present`, async () => {
-        const [{ [fieldNameSymbol]: _removed, ...requestWithField }] = validRequestBody;
+        const [{ [fieldNameSymbol]: _removed, ...requestWithoutField }] = validRequestBody;
 
-        const { status } = await makeRequest([requestWithField]);
+        const { status } = await makeRequest([requestWithoutField]);
 
         expect(status).toBe(201);
       });

--- a/test/common-tests/request-field-validation-api-tests/enum-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/enum-field-validation-api-tests.ts
@@ -46,6 +46,8 @@ export function withEnumFieldValidationApiTests<RequestBodyItem, RequestBodyItem
     });
 
     if (required) {
+      const expectedRequiredFieldError = `${fieldName} must be one of the following values: ${Object.values(theEnum).join(', ')}`;
+
       it(`returns a 400 response if ${fieldName} is not present`, async () => {
         const { [fieldNameSymbol]: _removed, ...requestWithoutTheField } = requestBodyItem;
         const preparedRequestWithoutTheField = prepareModifiedRequest(requestIsAnArray, requestWithoutTheField);
@@ -55,7 +57,21 @@ export function withEnumFieldValidationApiTests<RequestBodyItem, RequestBodyItem
         expect(status).toBe(400);
         expect(body).toMatchObject({
           error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} must be one of the following values: ${Object.values(theEnum).join(', ')}`]),
+          message: expect.arrayContaining([expectedRequiredFieldError]),
+          statusCode: 400,
+        });
+      });
+
+      it(`returns a 400 response if ${fieldName} is null`, async () => {
+        const requestWithNullField = { ...requestBodyItem, [fieldNameSymbol]: null };
+        const preparedRequestWithNullField = prepareModifiedRequest(requestIsAnArray, requestWithNullField);
+
+        const { status, body } = await makeRequest(preparedRequestWithNullField);
+
+        expect(status).toBe(400);
+        expect(body).toMatchObject({
+          error: 'Bad Request',
+          message: expect.arrayContaining([expectedRequiredFieldError]),
           statusCode: 400,
         });
       });
@@ -65,6 +81,16 @@ export function withEnumFieldValidationApiTests<RequestBodyItem, RequestBodyItem
         const preparedRequestWithField = prepareModifiedRequest(requestIsAnArray, requestWithField);
 
         const { status } = await makeRequest(preparedRequestWithField);
+
+        expect(status).toBeGreaterThanOrEqual(200);
+        expect(status).toBeLessThan(300);
+      });
+
+      it(`returns a 2xx response if ${fieldName} is null`, async () => {
+        const requestWithNullField = { ...requestBodyItem, [fieldNameSymbol]: null };
+        const preparedRequestWithNullField = prepareModifiedRequest(requestIsAnArray, requestWithNullField);
+
+        const { status } = await makeRequest(preparedRequestWithNullField);
 
         expect(status).toBeGreaterThanOrEqual(200);
         expect(status).toBeLessThan(300);

--- a/test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests.ts
@@ -26,6 +26,7 @@ export function withNonNegativeNumberFieldValidationApiTests<RequestBodyItem>({
 
   const requestIsAnArray = Array.isArray(validRequestBody);
   const requestBodyItem = requestIsAnArray ? validRequestBody[0] : validRequestBody;
+  const expectedNonEmptyFieldError = `${fieldName} should not be empty`;
 
   required = required ?? true;
 
@@ -44,20 +45,7 @@ export function withNonNegativeNumberFieldValidationApiTests<RequestBodyItem>({
         expect(status).toBe(400);
         expect(body).toMatchObject({
           error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} should not be empty`]),
-          statusCode: 400,
-        });
-      });
-
-      it(`returns a 400 response if ${fieldName} is null`, async () => {
-        const requestWithNullField = { ...validRequestBody[0], [fieldNameSymbol]: null };
-
-        const { status, body } = await makeRequest([requestWithNullField]);
-
-        expect(status).toBe(400);
-        expect(body).toMatchObject({
-          error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} should not be empty`]),
+          message: expect.arrayContaining([expectedNonEmptyFieldError]),
           statusCode: 400,
         });
       });
@@ -72,6 +60,20 @@ export function withNonNegativeNumberFieldValidationApiTests<RequestBodyItem>({
         expect(status).toBeLessThan(300);
       });
     }
+
+    it(`returns a 400 response if ${fieldName} is null`, async () => {
+      const requestWithNullField = { ...validRequestBody[0], [fieldNameSymbol]: null };
+      const preparedRequestWithNullField = prepareModifiedRequest(requestIsAnArray, requestWithNullField);
+
+      const { status, body } = await makeRequest(preparedRequestWithNullField);
+
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([expectedNonEmptyFieldError]),
+        statusCode: 400,
+      });
+    });
 
     it(`returns a 400 response if ${fieldName} is less than 0`, async () => {
       const requestWithNegativeField = { ...requestBodyItem, [fieldNameSymbol]: -0.01 };

--- a/test/common-tests/request-field-validation-api-tests/number-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/number-field-validation-api-tests.ts
@@ -28,6 +28,7 @@ export function withNumberFieldValidationApiTests<RequestBodyItem>({
   const valueGenerator = new RandomValueGenerator();
   required = required ?? true;
   const [validRequestItem] = validRequestBody;
+  const expectedNonEmptyFieldError = `${fieldName} should not be empty`;
 
   describe(`${fieldName} validation`, () => {
     beforeEach(() => {
@@ -43,20 +44,7 @@ export function withNumberFieldValidationApiTests<RequestBodyItem>({
         expect(status).toBe(400);
         expect(body).toMatchObject({
           error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} should not be empty`]),
-          statusCode: 400,
-        });
-      });
-
-      it(`returns a 400 response if ${fieldName} is null`, async () => {
-        const requestWithNullField = { ...validRequestItem, [fieldNameSymbol]: null };
-
-        const { status, body } = await makeRequest([requestWithNullField]);
-
-        expect(status).toBe(400);
-        expect(body).toMatchObject({
-          error: 'Bad Request',
-          message: expect.arrayContaining([`${fieldName} should not be empty`]),
+          message: expect.arrayContaining([expectedNonEmptyFieldError]),
           statusCode: 400,
         });
       });
@@ -69,6 +57,19 @@ export function withNumberFieldValidationApiTests<RequestBodyItem>({
         expect(status).toBe(201);
       });
     }
+
+    it(`returns a 400 response if ${fieldName} is null`, async () => {
+      const requestWithNullField = { ...validRequestItem, [fieldNameSymbol]: null };
+
+      const { status, body } = await makeRequest([requestWithNullField]);
+
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([expectedNonEmptyFieldError]),
+        statusCode: 400,
+      });
+    });
 
     it(`returns a 400 response if ${fieldName} is string`, async () => {
       const requestWithNullField = { ...validRequestBody[0], [fieldNameSymbol]: 'true' };

--- a/test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests.ts
+++ b/test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests.ts
@@ -76,8 +76,9 @@ export function withStringFieldValidationApiTests<RequestBodyItem, RequestBodyIt
       } else {
         it(`returns a 400 response if ${fieldName} is not present`, async () => {
           const { [fieldNameSymbol]: _removed, ...requestWithoutTheField } = requestBodyItem;
+          const preparedRequestWithoutField = prepareModifiedRequest(requestIsAnArray, requestWithoutTheField);
 
-          const { status, body } = await makeRequest([requestWithoutTheField]);
+          const { status, body } = await makeRequest(preparedRequestWithoutField);
 
           expect(status).toBe(400);
           expect(body).toMatchObject({

--- a/test/deal-guarantee/post-deal-guarantee.api-test.ts
+++ b/test/deal-guarantee/post-deal-guarantee.api-test.ts
@@ -1,5 +1,6 @@
 import { PROPERTIES } from '@ukef/constants';
 import { DateStringTransformations } from '@ukef/modules/date/date-string.transformations';
+import { CreateDealGuaranteeRequestItem } from '@ukef/modules/deal-guarantee/dto/create-deal-guarantee-request.dto';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
 import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
@@ -24,13 +25,13 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     lenderType: { lenderTypeCode },
     limitType: { limitTypeCode },
     sectionIdentifier,
+    guaranteeTypeCode,
   } = PROPERTIES.DEAL_GUARANTEE.DEFAULT;
 
   const guarantorParty = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const limitKey = valueGenerator.stringOfNumericCharacters({ length: 8 });
   const effectiveDateInPast = TEST_DATES.A_PAST_EFFECTIVE_DATE_ONLY;
   const guaranteeExpiryDateInFuture = TEST_DATES.A_FUTURE_EXPIRY_DATE_ONLY;
-  const guaranteeTypeCode = valueGenerator.stringOfNumericCharacters({ length: 3 });
   const maximumLiability = 12345.6;
 
   const acbsRequestBodyToCreateDealGuarantee = {
@@ -54,14 +55,12 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
     GuaranteedPercentage: guaranteedPercentage,
   };
 
-  const requestItemToCreateDealGuarantee = {
-    dealIdentifier,
+  const requestItemToCreateDealGuarantee: CreateDealGuaranteeRequestItem = {
     guarantorParty,
     limitKey,
     effectiveDate: effectiveDateInPast,
     guaranteeExpiryDate: guaranteeExpiryDateInFuture,
     maximumLiability,
-    guaranteeTypeCode,
   };
 
   const requestBodyToCreateDealGuarantee = [requestItemToCreateDealGuarantee];
@@ -128,33 +127,6 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
       dealIdentifier,
     });
     expect(acbsRequestWithDefaultGuarantorParty.isDone()).toBe(true);
-  });
-
-  it('sets the default guaranteeTypeCode if it is not specified in the request', async () => {
-    const { guaranteeTypeCode: _removed, ...newDealGuaranteeWithoutGuaranteeTypeCode } = requestItemToCreateDealGuarantee;
-    const requestBodyWithoutGuaranteeTypeCode = [newDealGuaranteeWithoutGuaranteeTypeCode];
-    const acbsRequestBodyWithDefaultGuaranteeTypeCode = {
-      ...acbsRequestBodyToCreateDealGuarantee,
-      GuaranteeType: {
-        GuaranteeTypeCode: PROPERTIES.DEAL_GUARANTEE.DEFAULT.guaranteeTypeCode,
-      },
-    };
-    givenAuthenticationWithTheIdpSucceeds();
-    const acbsRequestWithDefaultGuaranteeTypeCode = requestToCreateDealGuaranteeInAcbsWithBody(acbsRequestBodyWithDefaultGuaranteeTypeCode).reply(
-      201,
-      undefined,
-      {
-        location: `/Portfolio/${portfolioIdentifier}/Deal/${dealIdentifier}/DealGuarantee?accountOwnerIdentifier=00000000&lenderTypeCode=${lenderTypeCode}&sectionIdentifier=${sectionIdentifier}&limitTypeCode=${limitTypeCode}&limitKey=${limitKey}&guarantorPartyIdentifier=${guarantorParty}`,
-      },
-    );
-
-    const { status, body } = await api.post(createDealGuaranteeUrl, requestBodyWithoutGuaranteeTypeCode);
-
-    expect(status).toBe(201);
-    expect(body).toStrictEqual({
-      dealIdentifier,
-    });
-    expect(acbsRequestWithDefaultGuaranteeTypeCode.isDone()).toBe(true);
   });
 
   it('rounds the maximumLiability to 2dp', async () => {
@@ -247,19 +219,6 @@ describe('POST /deals/{dealIdentifier}/guarantees', () => {
   withStringFieldValidationApiTests({
     fieldName: 'guarantorParty',
     length: 8,
-    required: false,
-    generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
-    validRequestBody: requestBodyToCreateDealGuarantee,
-    makeRequest: (body) => api.post(createDealGuaranteeUrl, body),
-    givenAnyRequestBodyWouldSucceed: () => {
-      givenAuthenticationWithTheIdpSucceeds();
-      givenAnyRequestBodyToCreateDealGuaranteeInAcbsSucceeds();
-    },
-  });
-
-  withStringFieldValidationApiTests({
-    fieldName: 'guaranteeTypeCode',
-    length: 3,
     required: false,
     generateFieldValueOfLength: (length: number) => valueGenerator.stringOfNumericCharacters({ length }),
     validRequestBody: requestBodyToCreateDealGuarantee,

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1114,6 +1114,7 @@ components:
             a date earlier than the Facility effective date. Use the earliest
             Effective Date on facilities in Workflow under this Deal, i.e.
             Guarantee Commencement Date.
+          nullable: false
         obligorPartyIdentifier:
           type: string
           description: The obligor party identifier.
@@ -1156,6 +1157,7 @@ components:
           description: >-
             The date that this guarantee will take effect. This will be replaced
             by today's date if a date in the future is provided.
+          nullable: false
         limitKey:
           type: string
           description: An ACBS party identifier.
@@ -1166,6 +1168,7 @@ components:
           format: date
           type: string
           description: The date that this guarantee will expire on.
+          nullable: false
         maximumLiability:
           type: number
           description: The maximum amount the guarantor will guarantee.
@@ -1313,6 +1316,7 @@ components:
             The effective date on the deal investor record. If the date provided
             is in the future, it will be replaced by today's date.
           example: '2023-03-24'
+          nullable: false
         expiryDate:
           format: date
           type: string
@@ -1697,14 +1701,17 @@ components:
           description: >-
             The date from which the borrower can draw funds from the facility.
             If this is a future date then it will be replaced with today's date.
+          nullable: false
         guaranteeExpiryDate:
           format: date
           type: string
           description: The expiration date of the facility.
+          nullable: false
         nextQuarterEndDate:
           format: date
           type: string
           description: The end date of the next quarter.
+          nullable: false
         maximumLiability:
           type: number
           description: The overall limit for the facility.
@@ -1916,14 +1923,17 @@ components:
           description: >-
             The date from which the borrower can draw funds from the facility.
             If this is a future date then it will be replaced with today's date.
+          nullable: false
         guaranteeExpiryDate:
           format: date
           type: string
           description: The expiration date of the facility.
+          nullable: false
         nextQuarterEndDate:
           format: date
           type: string
           description: The end date of the next quarter.
+          nullable: false
         maximumLiability:
           type: number
           description: The overall limit for the facility.
@@ -2083,11 +2093,13 @@ components:
             The expiration date of the covenant. It is called expiration date in
             ACBS.
           example: '2023-04-19'
+          nullable: false
         effectiveDate:
           format: date
           type: string
           description: The effective date of the covenant.
           example: '2023-04-19'
+          nullable: false
       required:
         - covenantIdentifier
         - covenantType
@@ -2324,6 +2336,7 @@ components:
           format: date
           type: string
           description: The effective date of this accruing/fixed fee schedule.
+          nullable: false
         amountAmendment:
           type: number
           description: >-
@@ -2362,20 +2375,24 @@ components:
           format: date
           type: string
           description: The effective date of this accruing/fixed fee schedule.
+          nullable: false
         expirationDate:
           format: date
           type: string
           description: The expiration date of this accruing/fixed fee schedule.
+          nullable: false
         nextDueDate:
           format: date
           type: string
           description: Date the next fee bill is due for this fee schedule.
+          nullable: false
         nextAccrueToDate:
           format: date
           type: string
           description: >-
             End date for the current accrual period. This date can be different
             than the Next Due Date.
+          nullable: false
         period:
           type: string
           description: >-
@@ -2502,6 +2519,7 @@ components:
           description: >-
             The date that this guarantee will take effect. This will be replaced
             by today's date if a date in the future is provided.
+          nullable: false
         limitKey:
           type: string
           description: An ACBS party identifier.
@@ -2513,6 +2531,7 @@ components:
           format: date
           type: string
           description: The date that this guarantee will expire on.
+          nullable: false
         maximumLiability:
           type: number
           description: The maximum amount the guarantor will guarantee.
@@ -2580,10 +2599,12 @@ components:
           format: date
           type: string
           description: The date from which this limit is effective.
+          nullable: false
         guaranteeExpiryDate:
           format: date
           type: string
           description: The date on which this limit will expire.
+          nullable: false
         currency:
           type: string
           description: >-
@@ -2777,6 +2798,7 @@ components:
           format: date
           type: string
           description: The date of the action.
+          nullable: false
         borrowerPartyIdentifier:
           type: string
           description: The customer identifier representing the borrower for the loan.
@@ -2839,16 +2861,19 @@ components:
           format: date
           type: string
           description: The facility issue date.
+          nullable: false
         expiryDate:
           format: date
           type: string
           description: The facility expiry date.
+          nullable: false
         nextDueDate:
           format: date
           type: string
           description: >-
             The next payment due date of the repayment schedule & date the next
             rate will be set for accrual schedules.
+          nullable: false
         loanBillingFrequencyType:
           type: string
           description: The frequency at which loan bills should be generated.
@@ -2929,6 +2954,7 @@ components:
           format: date
           type: string
           description: The new expiry date of the loan.
+          nullable: false
       required:
         - expiryDate
     UpdateLoanExpiryDateResponse:
@@ -2950,6 +2976,7 @@ components:
           format: date
           type: string
           description: The date that this amendment is effective.
+          nullable: false
         amountAmendment:
           type: number
           description: >-
@@ -3135,6 +3162,7 @@ components:
           format: date
           type: string
           description: The date of creation.
+          nullable: false
         countryCode:
           type: string
           description: The country code for the party's primary address.

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -2437,6 +2437,7 @@ components:
             Action indicator to be supplied together with the Fee to control
             propagation of the fee effects to other investors. Not applicable to
             output data.
+          nullable: false
       required:
         - amount
         - effectiveDate

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1106,6 +1106,7 @@ components:
           type: number
           description: The value of the deal.
           minimum: 0
+          nullable: false
         guaranteeCommencementDate:
           format: date
           type: string
@@ -1173,6 +1174,7 @@ components:
           type: number
           description: The maximum amount the guarantor will guarantee.
           minimum: 0
+          nullable: false
         guarantorParty:
           type: string
           description: >-
@@ -1355,6 +1357,7 @@ components:
             - 1
             - 2
             - 3
+          nullable: false
         lenderTypeCode:
           type: string
           description: >-
@@ -1716,6 +1719,7 @@ components:
           type: number
           description: The overall limit for the facility.
           minimum: 0
+          nullable: false
         agentBankIdentifier:
           type: string
           description: The party identifier of the Agent Bank for this facility.
@@ -1769,6 +1773,7 @@ components:
             Bank Rate, this can be for Bond facility corresponding fee rate or
             for Loan/EWCS interest rate.
           minimum: 0
+          nullable: false
         obligorPartyIdentifier:
           type: string
           description: The party identifier of the obligor.
@@ -1780,12 +1785,14 @@ components:
           type: number
           description: Forecast % Derive from FACILITY:Stage, i.e. Commitment or Issued
           minimum: 0
+          nullable: false
         probabilityOfDefault:
           type: number
           description: >-
             A percentage indicating how likely it is that a default on the
             credit will occur. This should be specified for GEF.
           minimum: 0
+          nullable: false
           default: 0
         capitalConversionFactorCode:
           type: string
@@ -1938,6 +1945,7 @@ components:
           type: number
           description: The overall limit for the facility.
           minimum: 0
+          nullable: false
         agentBankIdentifier:
           type: string
           description: The party identifier of the Agent Bank for this facility.
@@ -1989,6 +1997,7 @@ components:
             Bank Rate, this can be for Bond facility corresponding fee rate or
             for Loan/EWCS interest rate.
           minimum: 0
+          nullable: false
         obligorPartyIdentifier:
           type: string
           description: The party identifier of the obligor.
@@ -2000,12 +2009,14 @@ components:
           type: number
           description: Forecast % Derive from FACILITY:Stage, i.e. Commitment or Issued
           minimum: 0
+          nullable: false
         probabilityOfDefault:
           type: number
           description: >-
             A percentage indicating how likely it is that a default on the
             credit will occur. This should be specified for GEF.
           minimum: 0
+          nullable: false
           default: 0
         capitalConversionFactorCode:
           type: string
@@ -2078,6 +2089,7 @@ components:
             The amount used to determine if the covenant is in compliance or
             not. It is called target amount in ACBS.
           minimum: 0
+          nullable: false
         currency:
           type: string
           description: >-
@@ -2192,6 +2204,7 @@ components:
             not. It is required if expirationDate is not provided.
           minimum: 0
           example: 501927.25
+          nullable: false
         expirationDate:
           format: date
           type: string
@@ -2343,6 +2356,7 @@ components:
             Fee amount amendment. For example: if current Fee amount is 352.10
             GBP and you want to set Fee to 0, then set amount to -352.10
           example: -352.1
+          nullable: false
           not:
             enum:
               - 0
@@ -2371,6 +2385,7 @@ components:
             charged, this field is required.
           minimum: 0
           example: 501927.25
+          nullable: false
         effectiveDate:
           format: date
           type: string
@@ -2537,6 +2552,7 @@ components:
           type: number
           description: The maximum amount the guarantor will guarantee.
           minimum: 0
+          nullable: false
         guarantorParty:
           type: string
           description: >-
@@ -2593,6 +2609,7 @@ components:
             expirationDate is not provided.
           minimum: 0
           example: 501927.25
+          nullable: false
     CreateFacilityInvestorRequestItem:
       type: object
       properties:
@@ -2618,6 +2635,7 @@ components:
           type: number
           description: The investor's share of the current limit amount.
           minimum: 0
+          nullable: false
         lenderType:
           type: string
           description: >-
@@ -2844,6 +2862,7 @@ components:
           description: >-
             The exchange rate between the loan currency and the deal currency.
             Required when loan currency differs from deal currency.
+          nullable: false
         dealCustomerUsageOperationType:
           type: string
           description: >-
@@ -2858,6 +2877,7 @@ components:
           type: number
           description: The amount of the loan.
           minimum: 0
+          nullable: false
         issueDate:
           format: date
           type: string
@@ -2893,12 +2913,14 @@ components:
           type: number
           description: The guarantee fee percentage.
           minimum: 0
+          nullable: false
         spreadRateCtl:
           type: number
           description: >-
             The corresponding fee rate. If it is null then the interest rate
             will be used.
           minimum: 0
+          nullable: false
         yearBasis:
           type: string
           description: The year basis for the accrual schedule.
@@ -2985,6 +3007,7 @@ components:
             the loan amount, a negative number decreases the loan amount. 0 is
             not allowed.
           example: 1000000
+          nullable: false
           not:
             enum:
               - 0

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -1178,12 +1178,6 @@ components:
           minLength: 8
           maxLength: 8
           default: '00000141'
-        guaranteeTypeCode:
-          type: string
-          description: The identifier for the type of the guarantee.
-          minLength: 3
-          maxLength: 3
-          default: '450'
       required:
         - effectiveDate
         - limitKey

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -2909,7 +2909,7 @@ components:
         indexRateChangeFrequency:
           type: string
           description: >-
-            The frequency which the rate will change. This is required if
+            The frequency with which the rate will change. This is required if
             productTypeGroup is EW.
           minLength: 0
           enum:

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -2883,7 +2883,9 @@ components:
           example: '1'
         indexRateChangeFrequency:
           type: string
-          description: The frequency which the rate will change.
+          description: >-
+            The frequency which the rate will change. This is required if
+            productTypeGroup is EW.
           minLength: 0
           enum:
             - A

--- a/test/facility-fixed-fee/post-facility-fixed-fees.api-test.ts
+++ b/test/facility-fixed-fee/post-facility-fixed-fees.api-test.ts
@@ -7,7 +7,7 @@ import { DateStringTransformations } from '@ukef/modules/date/date-string.transf
 import { CreateFacilityFixedFeeRequest } from '@ukef/modules/facility-fixed-fee/dto/create-facility-fixed-fee-request.dto';
 import { withAcbsAuthenticationApiTests } from '@ukef-test/common-tests/acbs-authentication-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
-import { withBooleanFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/boolean-field-validation-api-tests';
+import { withRequiredBooleanFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/boolean-field-validation-api-tests';
 import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withNonNegativeNumberFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/non-negative-number-field-validation-api-tests';
 import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
@@ -391,9 +391,8 @@ describe('POST /facilities/{facilityIdentifier}/fixed-fees', () => {
       givenAnyRequestBodyWouldSucceed,
     });
 
-    withBooleanFieldValidationApiTests({
+    withRequiredBooleanFieldValidationApiTests({
       fieldName: 'spreadToInvestorsIndicator',
-      required: true,
       validRequestBody: requestBodyToCreateFacilityFixedFee,
       makeRequest,
       givenAnyRequestBodyWouldSucceed,

--- a/test/facility/put-facility-by-facility-identifier.api-test.ts
+++ b/test/facility/put-facility-by-facility-identifier.api-test.ts
@@ -6,6 +6,7 @@ import { withAcbsGetFacilityServiceCommonTests } from '@ukef-test/common-tests/a
 import { withAcbsUpdateFacilityByIdentifierServiceTests } from '@ukef-test/common-tests/acbs-update-facility-by-identifier-api-tests';
 import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
 import { withBaseFacilityFieldsValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/base-facility-fields-validation-api-tests';
+import { withDateOnlyFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/date-only-field-validation-api-tests';
 import { withIssueFacilityTests } from '@ukef-test/facility/put-facility-by-facility-identifier.test-parts/issue-facility-api-tests';
 import { withPutFacilityQueryParameterTests } from '@ukef-test/facility/put-facility-by-facility-identifier.test-parts/put-facility-by-facility-query-parameter-api-tests';
 import { Api } from '@ukef-test/support/api';
@@ -122,6 +123,15 @@ describe('PUT /facilities', () => {
         },
         updateFacilityRequest,
         makeRequestWithBody: (body: unknown) => makeRequestWithBody(body),
+      });
+
+      withDateOnlyFieldValidationApiTests({
+        fieldName: 'issueDate',
+        required: true,
+        nullable: false,
+        validRequestBody: updateFacilityRequest,
+        makeRequest: (body: unknown) => makeRequestWithBody(body),
+        givenAnyRequestBodyWouldSucceed: () => givenAnyRequestBodyWouldSucceed(),
       });
     }
 

--- a/test/facility/put-facility-by-facility-identifier.test-parts/issue-facility-api-tests.ts
+++ b/test/facility/put-facility-by-facility-identifier.test-parts/issue-facility-api-tests.ts
@@ -13,41 +13,5 @@ export const withIssueFacilityTests = ({ givenTheRequestWouldOtherwiseSucceed, u
       expect(status).toBe(400);
       expect(body).toStrictEqual({ message: 'Bad request', error: 'Facility stage code is not issued', statusCode: 400 });
     });
-
-    it('returns a 400 response if request has no issue date', async () => {
-      givenTheRequestWouldOtherwiseSucceed();
-
-      const modifiedUpdateFacilityRequest = { ...updateFacilityRequest };
-      delete modifiedUpdateFacilityRequest.issueDate;
-
-      const { status, body } = await makeRequestWithBody(modifiedUpdateFacilityRequest);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({ message: 'Bad request', error: 'Issue date is not present', statusCode: 400 });
-    });
-
-    it('returns a 400 response if request has an issue date of null', async () => {
-      givenTheRequestWouldOtherwiseSucceed();
-
-      const modifiedUpdateFacilityRequest = { ...updateFacilityRequest };
-      modifiedUpdateFacilityRequest.issueDate = null;
-
-      const { status, body } = await makeRequestWithBody(modifiedUpdateFacilityRequest);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({ message: 'Bad request', error: 'Issue date is not present', statusCode: 400 });
-    });
-
-    it('returns a 400 response if request has an issue date of undefined', async () => {
-      givenTheRequestWouldOtherwiseSucceed();
-
-      const modifiedUpdateFacilityRequest = { ...updateFacilityRequest };
-      modifiedUpdateFacilityRequest.issueDate = undefined;
-
-      const { status, body } = await makeRequestWithBody(modifiedUpdateFacilityRequest);
-
-      expect(status).toBe(400);
-      expect(body).toStrictEqual({ message: 'Bad request', error: 'Issue date is not present', statusCode: 400 });
-    });
   });
 };

--- a/test/support/generator/create-facility-loan-generator.ts
+++ b/test/support/generator/create-facility-loan-generator.ts
@@ -206,8 +206,6 @@ export class CreateFacilityLoanGenerator extends AbstractGenerator<CreateFacilit
           Currency: {
             CurrencyCode: facilityLoan.currency,
           },
-          SettlementCurrencyCode: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.settlementCurrencyCode,
-          OriginatingGeneralLedgerUnit: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.originatingGeneralLedgerUnit,
           DDAAccount: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.dDAAccount,
           CashDetailAmount: facilityLoan.amount,
           CashReferenceIdentifier: PROPERTIES.FACILITY_LOAN.DEFAULT.cashEventList.cashReferenceIdentifier,


### PR DESCRIPTION
## Introduction
In testing for APIM-369, we found a few small differences between TFS (Node) and TF-EA (Mule) that are not urgent but would be good to resolve.

## Resolution
- removed `guaranteeTypeCode` from POST /deals/{dealId}/guarantees request as it has only 1 allowed value
- removed null values for CashEventList that were being set by POST /facilities/{facilityId}/loans
- made `indexRateChangeFrequency` required for EWCS loans in POST /facilities/{facilityId}/loans
- made `issueDate` required when `facilityStageCode` is 07 for POST /facilities and PUT /facilities/{facilityId}
- made `capitalConversionCode` required for GEF facilities for POST /facilities and PUT /facilities/{facilityId} 