### PR TITLE
fix(APIM-492): remove field FacilityOverallStatus from Facility POST and PUT

### DIFF
--- a/src/modules/acbs/dto/acbs-base-facility-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-base-facility-request.dto.ts
@@ -129,9 +129,7 @@ export interface AcbsBaseFacilityRequest {
   AccountStructure: {
     AccountStructureCode: string;
   };
-  FacilityOverallStatus: {
-    FacilityStatusCode: string;
-  };
+  // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
   LenderType: {
     LenderTypeCode: string;
   };

--- a/src/modules/facility/facility.service.ts
+++ b/src/modules/facility/facility.service.ts
@@ -129,6 +129,9 @@ export class FacilityService {
     // causes issue with old facilities which were manually created using old adminstrative profile.
     delete existingAcbsFacilityData.AdministrativeUserIdentifier;
 
+    // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
+    delete existingAcbsFacilityData.FacilityOverallStatus;
+
     const acbsMergedUpdateFacilityRequest: AcbsUpdateFacilityRequest = {
       ...existingAcbsFacilityData,
       ...acbsUpdateFacilityRequest,
@@ -296,9 +299,7 @@ export class FacilityService {
       AccountStructure: {
         AccountStructureCode: defaultValues.accountStructureCode,
       },
-      FacilityOverallStatus: {
-        FacilityStatusCode: defaultValues.facilityStatusCode,
-      },
+      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultValues.lenderTypeCode,
       },

--- a/test/support/generator/create-facility-generator.ts
+++ b/test/support/generator/create-facility-generator.ts
@@ -186,9 +186,7 @@ export class CreateFacilityGenerator extends AbstractGenerator<FacilityValues, G
       AccountStructure: {
         AccountStructureCode: defaultValues.accountStructureCode,
       },
-      FacilityOverallStatus: {
-        FacilityStatusCode: defaultValues.facilityStatusCode,
-      },
+      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultValues.lenderTypeCode,
       },

--- a/test/support/generator/update-facility-generator.ts
+++ b/test/support/generator/update-facility-generator.ts
@@ -198,9 +198,7 @@ export class UpdateFacilityGenerator extends AbstractGenerator<FacilityValues, G
       AccountStructure: {
         AccountStructureCode: defaultFacilityValues.accountStructureCode,
       },
-      FacilityOverallStatus: {
-        FacilityStatusCode: defaultFacilityValues.facilityStatusCode,
-      },
+      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultFacilityValues.lenderTypeCode,
       },


### PR DESCRIPTION
### Introduction
After last ACBS update field FacilityOverallStatus is not accepted anymore for Facility creation and update.

### Resolution
Remove field FacilityOverallStatus.

### Todo
- This might be temporary change. 
- We need to be careful releasing this to Production, field FacilityOverallStatus might be required in Production.