### PR TITLE
fix(APIM-531): fix swagger regex field

### DIFF
--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -1,4 +1,4 @@
 // This helper function is used to convert the regex pattern to a string so that it can be used in the swagger documentation.
 export const regexToString = (regex: RegExp): string => {
-  return regex.toString().replace(/^\/|\/$/g, '');
+  return regex.source;
 };


### PR DESCRIPTION
# Introduction

nestjs/swagger decorator `apiProperty` takes a string for `pattern`, and not a Regexp. As a result, we turn our existing regexp into strings to be used in swagger.

In the old implementation of this, regex expressions were getting split prematurely if there was an additional `/` in the expression. 

# Solution

I've created a helper function to avoid this occurring, as apposed to relying on `split`
