### PR TITLE
feat(APIM-468): Allow numeric environment variables to be set to 0

### DIFF
--- a/src/config/acbs-authentication.config.ts
+++ b/src/config/acbs-authentication.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config';
+import { getIntConfig } from '@ukef/helpers/get-int-config';
 
 export interface AcbsAuthenticationConfig {
   apiKey: string;
@@ -21,12 +22,12 @@ export default registerAs(
     apiKeyHeaderName: process.env.ACBS_AUTHENTICATION_API_KEY_HEADER_NAME,
     baseUrl: process.env.ACBS_AUTHENTICATION_BASE_URL,
     clientId: process.env.ACBS_AUTHENTICATION_CLIENT_ID,
-    idTokenCacheTtlInMilliseconds: parseInt(process.env.ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL_IN_MILLISECONDS) || 60000,
+    idTokenCacheTtlInMilliseconds: getIntConfig(process.env.ACBS_AUTHENTICATION_ID_TOKEN_CACHE_TTL_IN_MILLISECONDS, 60000),
     loginName: process.env.ACBS_AUTHENTICATION_LOGIN_NAME,
-    maxRedirects: parseInt(process.env.ACBS_AUTHENTICATION_MAX_REDIRECTS) || 5,
-    maxNumberOfRetries: parseInt(process.env.ACBS_AUTHENTICATION_MAX_NUMBER_OF_RETRIES) || 1,
+    maxRedirects: getIntConfig(process.env.ACBS_AUTHENTICATION_MAX_REDIRECTS, 5),
+    maxNumberOfRetries: getIntConfig(process.env.ACBS_AUTHENTICATION_MAX_NUMBER_OF_RETRIES, 1),
     password: process.env.ACBS_AUTHENTICATION_PASSWORD,
-    retryDelayInMilliseconds: parseInt(process.env.ACBS_AUTHENTICATION_RETRY_DELAY_IN_MILLISECONDS) || 500,
-    timeout: parseInt(process.env.ACBS_AUTHENTICATION_TIMEOUT) || 30000,
+    retryDelayInMilliseconds: getIntConfig(process.env.ACBS_AUTHENTICATION_RETRY_DELAY_IN_MILLISECONDS, 500),
+    timeout: getIntConfig(process.env.ACBS_AUTHENTICATION_TIMEOUT, 30000),
   }),
 );

--- a/src/config/acbs.config.test.ts
+++ b/src/config/acbs.config.test.ts
@@ -1,10 +1,8 @@
-import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { withEnvironmentVariableParsingUnitTests } from '@ukef-test/common-tests/environment-variable-parsing-unit-tests';
 
-import acbsConfig from './acbs.config';
+import acbsConfig, { AcbsConfig } from './acbs.config';
 
 describe('acbsConfig', () => {
-  const valueGenerator = new RandomValueGenerator();
-
   let originalProcessEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -15,57 +13,46 @@ describe('acbsConfig', () => {
     process.env = originalProcessEnv;
   });
 
-  describe('parsing ACBS_USE_RETURN_EXCEPTION_HEADER', () => {
-    it('sets useReturnExceptionHeader to true if ACBS_USE_RETURN_EXCEPTION_HEADER is true', () => {
-      replaceEnvironmentVariables({
-        ACBS_USE_RETURN_EXCEPTION_HEADER: 'true',
-      });
+  const configDirectlyFromEnvironmentVariables: { configPropertyName: keyof AcbsConfig; environmentVariableName: string }[] = [
+    {
+      configPropertyName: 'baseUrl',
+      environmentVariableName: 'ACBS_BASE_URL',
+    },
+  ];
 
-      const config = acbsConfig();
+  const configParsedBooleanFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AcbsConfig;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
+  }[] = [
+    {
+      configPropertyName: 'useReturnExceptionHeader',
+      environmentVariableName: 'ACBS_USE_RETURN_EXCEPTION_HEADER',
+      defaultConfigValue: false,
+    },
+  ];
 
-      expect(config.useReturnExceptionHeader).toBe(true);
-    });
+  const configParsedAsIntFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AcbsConfig;
+    environmentVariableName: string;
+    defaultConfigValue: number;
+  }[] = [
+    {
+      configPropertyName: 'maxRedirects',
+      environmentVariableName: 'ACBS_MAX_REDIRECTS',
+      defaultConfigValue: 5,
+    },
+    {
+      configPropertyName: 'timeout',
+      environmentVariableName: 'ACBS_TIMEOUT',
+      defaultConfigValue: 30000,
+    },
+  ];
 
-    it('sets useReturnExceptionHeader to false if ACBS_USE_RETURN_EXCEPTION_HEADER is false', () => {
-      replaceEnvironmentVariables({
-        ACBS_USE_RETURN_EXCEPTION_HEADER: 'false',
-      });
-
-      const config = acbsConfig();
-
-      expect(config.useReturnExceptionHeader).toBe(false);
-    });
-
-    it('sets useReturnExceptionHeader to false if ACBS_USE_RETURN_EXCEPTION_HEADER is not specified', () => {
-      replaceEnvironmentVariables({});
-
-      const config = acbsConfig();
-
-      expect(config.useReturnExceptionHeader).toBe(false);
-    });
-
-    it('sets useReturnExceptionHeader to false if ACBS_USE_RETURN_EXCEPTION_HEADER is an empty string', () => {
-      replaceEnvironmentVariables({
-        ACBS_USE_RETURN_EXCEPTION_HEADER: '',
-      });
-
-      const config = acbsConfig();
-
-      expect(config.useReturnExceptionHeader).toBe(false);
-    });
-
-    it('sets useReturnExceptionHeader to false if ACBS_USE_RETURN_EXCEPTION_HEADER is any string other than true or false', () => {
-      replaceEnvironmentVariables({
-        ACBS_USE_RETURN_EXCEPTION_HEADER: valueGenerator.string(),
-      });
-
-      const config = acbsConfig();
-
-      expect(config.useReturnExceptionHeader).toBe(false);
-    });
+  withEnvironmentVariableParsingUnitTests({
+    configDirectlyFromEnvironmentVariables,
+    configParsedBooleanFromEnvironmentVariablesWithDefault,
+    configParsedAsIntFromEnvironmentVariablesWithDefault,
+    getConfig: () => acbsConfig(),
   });
-
-  const replaceEnvironmentVariables = (newEnvVariables: Record<string, string>): void => {
-    process.env = newEnvVariables;
-  };
 });

--- a/src/config/acbs.config.ts
+++ b/src/config/acbs.config.ts
@@ -1,6 +1,7 @@
 import './load-dotenv';
 
 import { registerAs } from '@nestjs/config';
+import { getIntConfig } from '@ukef/helpers/get-int-config';
 
 export interface AcbsConfig {
   baseUrl: string;
@@ -13,8 +14,8 @@ export default registerAs(
   'acbs',
   (): AcbsConfig => ({
     baseUrl: process.env.ACBS_BASE_URL,
-    maxRedirects: parseInt(process.env.ACBS_MAX_REDIRECTS) || 5,
-    timeout: parseInt(process.env.ACBS_TIMEOUT) || 30000,
+    maxRedirects: getIntConfig(process.env.ACBS_MAX_REDIRECTS, 5),
+    timeout: getIntConfig(process.env.ACBS_TIMEOUT, 30000),
     useReturnExceptionHeader: process.env.ACBS_USE_RETURN_EXCEPTION_HEADER === 'true',
   }),
 );

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -1,6 +1,7 @@
+import { withEnvironmentVariableParsingUnitTests } from '@ukef-test/common-tests/environment-variable-parsing-unit-tests';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 
-import appConfig from './app.config';
+import appConfig, { AppConfig } from './app.config';
 import { InvalidConfigException } from './invalid-config.exception';
 
 describe('appConfig', () => {
@@ -132,4 +133,21 @@ describe('appConfig', () => {
   const replaceEnvironmentVariables = (newEnvVariables: Record<string, string>): void => {
     process.env = newEnvVariables;
   };
+
+  const configParsedAsIntFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AppConfig;
+    environmentVariableName: string;
+    defaultConfigValue: number;
+  }[] = [
+    {
+      configPropertyName: 'port',
+      environmentVariableName: 'HTTP_PORT',
+      defaultConfigValue: 3001,
+    },
+  ];
+
+  withEnvironmentVariableParsingUnitTests({
+    configParsedAsIntFromEnvironmentVariablesWithDefault,
+    getConfig: () => appConfig(),
+  });
 });

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,10 +1,26 @@
 import './load-dotenv';
 
 import { registerAs } from '@nestjs/config';
+import { getIntConfig } from '@ukef/helpers/get-int-config';
 
 import { InvalidConfigException } from './invalid-config.exception';
 
 const validLogLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'];
+
+export interface AppConfig {
+  name: string;
+  env: string;
+  versioning: {
+    enable: boolean;
+    prefix: string;
+    version: string;
+  };
+  globalPrefix: string;
+  port: number;
+  apiKey: string;
+  logLevel: string;
+  redactLogs: boolean;
+}
 
 export default registerAs('app', (): Record<string, any> => {
   const logLevel = process.env.LOG_LEVEL || 'info';
@@ -23,7 +39,7 @@ export default registerAs('app', (): Record<string, any> => {
     },
 
     globalPrefix: '/api',
-    port: process.env.HTTP_PORT ? Number.parseInt(process.env.HTTP_PORT, 10) : 3001,
+    port: getIntConfig(process.env.HTTP_PORT, 3001),
     apiKey: process.env.API_KEY,
     logLevel: process.env.LOG_LEVEL || 'info',
     redactLogs: process.env.REDACT_LOGS !== 'false',

--- a/src/config/mdm.config.ts
+++ b/src/config/mdm.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config';
+import { getIntConfig } from '@ukef/helpers/get-int-config';
 
 export const KEY = 'mdm';
 
@@ -16,7 +17,7 @@ export default registerAs(
     baseUrl: process.env.APIM_MDM_URL,
     apiKeyHeaderName: process.env.APIM_MDM_KEY,
     apiKeyHeaderValue: process.env.APIM_MDM_VALUE,
-    maxRedirects: parseInt(process.env.APIM_MDM_MAX_REDIRECTS) || 5,
-    timeout: parseInt(process.env.APIM_MDM_TIMEOUT) || 30000,
+    maxRedirects: getIntConfig(process.env.APIM_MDM_MAX_REDIRECTS, 5),
+    timeout: getIntConfig(process.env.APIM_MDM_TIMEOUT, 30000),
   }),
 );

--- a/src/helpers/get-int-config.helper.test.ts
+++ b/src/helpers/get-int-config.helper.test.ts
@@ -1,0 +1,47 @@
+import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
+
+import { getIntConfig } from './get-int-config';
+
+describe('Get integer configuration value Helper', () => {
+  describe('getIntConfig returns value', () => {
+    it.each([
+      { value: undefined, defaultValue: 60, expectedResult: 60 },
+      { value: '123', defaultValue: 60, expectedResult: 123 },
+      { value: '123', defaultValue: undefined, expectedResult: 123 },
+      { value: '-123', defaultValue: 60, expectedResult: -123 },
+      { value: '0', defaultValue: 60, expectedResult: 0 },
+      { value: `${Number.MAX_SAFE_INTEGER}`, defaultValue: 60, expectedResult: Number.MAX_SAFE_INTEGER },
+      { value: `-${Number.MAX_SAFE_INTEGER}`, defaultValue: 60, expectedResult: -Number.MAX_SAFE_INTEGER },
+    ])('if input is "$value", returns $expectedResult', ({ value, defaultValue, expectedResult }) => {
+      expect(getIntConfig(value, defaultValue)).toBe(expectedResult);
+    });
+  });
+
+  describe('getIntConfig throws invalid integer exception', () => {
+    it.each(['abc', '12.5', '20th', '0xFF', '0b101'])(`throws InvalidConfigException for "%s" because it is not valid integer`, (value) => {
+      const gettingTheConfig = () => getIntConfig(value as unknown as string);
+
+      expect(gettingTheConfig).toThrow(InvalidConfigException);
+      expect(gettingTheConfig).toThrow(`Invalid integer value "${value}" for configuration property.`);
+    });
+  });
+
+  describe('getIntConfig throws InvalidConfigException because environment variable type is not string', () => {
+    it.each([12, true, null, false, /.*/, {}, [], 0xff, 0b101])(
+      'throws InvalidConfigException for "%s" because environment variable type is not string',
+      (value) => {
+        const gettingTheConfig = () => getIntConfig(value as unknown as string);
+
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be string.`);
+      },
+    );
+  });
+
+  it('throws InvalidConfigException if environment variable and default value is missing', () => {
+    const gettingTheConfig = () => getIntConfig(undefined);
+
+    expect(gettingTheConfig).toThrow(InvalidConfigException);
+    expect(gettingTheConfig).toThrow("Environment variable is missing and doesn't have default value.");
+  });
+});

--- a/src/helpers/get-int-config.ts
+++ b/src/helpers/get-int-config.ts
@@ -1,0 +1,21 @@
+import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
+
+// This helper function is used to get integer from configuration.
+export const getIntConfig = (environmentVariable: string, defaultValue?: number): number | undefined => {
+  if (typeof environmentVariable === 'undefined') {
+    if (typeof defaultValue === 'undefined') {
+      throw new InvalidConfigException(`Environment variable is missing and doesn't have default value.`);
+    }
+    return defaultValue;
+  }
+  if (typeof environmentVariable !== 'string') {
+    throw new InvalidConfigException(`Input environment variable type for ${environmentVariable} should be string.`);
+  }
+
+  const integer = parseInt(environmentVariable, 10);
+  // Check if parseInt is number, decimal base integer and input didn't have anything non-numeric.
+  if (isNaN(integer) || integer.toString() !== environmentVariable) {
+    throw new InvalidConfigException(`Invalid integer value "${environmentVariable}" for configuration property.`);
+  }
+  return integer;
+};

--- a/test/common-tests/environment-variable-parsing-unit-tests.ts
+++ b/test/common-tests/environment-variable-parsing-unit-tests.ts
@@ -1,11 +1,17 @@
+import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 
 interface Options<ConfigUnderTest> {
-  configDirectlyFromEnvironmentVariables: {
+  configDirectlyFromEnvironmentVariables?: {
     configPropertyName: keyof ConfigUnderTest;
     environmentVariableName: string;
   }[];
-  configParsedAsIntFromEnvironmentVariablesWithDefault: {
+  configParsedBooleanFromEnvironmentVariablesWithDefault?: {
+    configPropertyName: keyof ConfigUnderTest;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
+  }[];
+  configParsedAsIntFromEnvironmentVariablesWithDefault?: {
     configPropertyName: keyof ConfigUnderTest;
     environmentVariableName: string;
     defaultConfigValue: number;
@@ -15,6 +21,7 @@ interface Options<ConfigUnderTest> {
 
 export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
   configDirectlyFromEnvironmentVariables,
+  configParsedBooleanFromEnvironmentVariablesWithDefault,
   configParsedAsIntFromEnvironmentVariablesWithDefault,
   getConfig,
 }: Options<ConfigUnderTest>): void => {
@@ -30,18 +37,79 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
     process.env = originalProcessEnv;
   });
 
-  describe.each(configDirectlyFromEnvironmentVariables)('$configPropertyName', ({ configPropertyName, environmentVariableName }) => {
-    it(`is the env variable ${environmentVariableName}`, () => {
-      const environmentVariableValue = valueGenerator.string();
-      process.env = {
-        [environmentVariableName]: environmentVariableValue,
-      };
+  if (configDirectlyFromEnvironmentVariables) {
+    describe.each(configDirectlyFromEnvironmentVariables)('$configPropertyName', ({ configPropertyName, environmentVariableName }) => {
+      it(`is the env variable ${environmentVariableName}`, () => {
+        const environmentVariableValue = valueGenerator.string();
+        process.env = {
+          [environmentVariableName]: environmentVariableValue,
+        };
 
-      const { [configPropertyName]: configPropertyValue } = getConfig();
+        const { [configPropertyName]: configPropertyValue } = getConfig();
 
-      expect(configPropertyValue).toBe(environmentVariableValue);
+        expect(configPropertyValue).toBe(environmentVariableValue);
+      });
     });
-  });
+  }
+
+  if (configParsedBooleanFromEnvironmentVariablesWithDefault) {
+    describe.each(configParsedBooleanFromEnvironmentVariablesWithDefault)(
+      '$configPropertyName',
+      ({ configPropertyName, environmentVariableName, defaultConfigValue }) => {
+        it(`is config ${environmentVariableName} set to true if environment variable ${environmentVariableName} is true`, () => {
+          const expectedConfigValue = true;
+          const environmentVariableValue = expectedConfigValue.toString();
+          process.env = {
+            [environmentVariableName]: environmentVariableValue,
+          };
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(expectedConfigValue);
+        });
+
+        it(`is config ${environmentVariableName} set to false if environment variable ${environmentVariableName} is false`, () => {
+          const expectedConfigValue = false;
+          const environmentVariableValue = expectedConfigValue.toString();
+          process.env = {
+            [environmentVariableName]: environmentVariableValue,
+          };
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(expectedConfigValue);
+        });
+
+        it(`is the default value ${defaultConfigValue} if ${environmentVariableName} is any string other than true or false`, () => {
+          process.env = {
+            [environmentVariableName]: valueGenerator.string(),
+          };
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(defaultConfigValue);
+        });
+
+        it(`is the default value ${defaultConfigValue} if ${environmentVariableName} is not specified`, () => {
+          process.env = {};
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(defaultConfigValue);
+        });
+
+        it(`is the default value ${defaultConfigValue} if ${environmentVariableName} is empty string`, () => {
+          process.env = {
+            [environmentVariableName]: '',
+          };
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(defaultConfigValue);
+        });
+      },
+    );
+  }
 
   describe.each(configParsedAsIntFromEnvironmentVariablesWithDefault)(
     '$configPropertyName',
@@ -66,15 +134,52 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
         expect(configPropertyValue).toBe(defaultConfigValue);
       });
 
-      it(`is the default value ${defaultConfigValue} if ${environmentVariableName} is not parseable as an integer`, () => {
+      it(`throws InvalidConfigException if ${environmentVariableName} is not parseable as an integer`, () => {
         const environmentVariableValue = 'abc';
         process.env = {
           [environmentVariableName]: environmentVariableValue,
         };
 
-        const { [configPropertyName]: configPropertyValue } = getConfig();
+        const gettingTheConfig = () => getConfig();
 
-        expect(configPropertyValue).toBe(defaultConfigValue);
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Invalid integer value "${environmentVariableValue}" for configuration property.`);
+      });
+
+      it(`throws InvalidConfigException if ${environmentVariableName} is float number`, () => {
+        const environmentVariableValue = valueGenerator.nonnegativeFloat().toString();
+        process.env = {
+          [environmentVariableName]: environmentVariableValue,
+        };
+
+        const gettingTheConfig = () => getConfig();
+
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Invalid integer value "${environmentVariableValue}" for configuration property.`);
+      });
+
+      it(`throws InvalidConfigException if ${environmentVariableName} is hex number`, () => {
+        const environmentVariableValue = '0xFF';
+        process.env = {
+          [environmentVariableName]: environmentVariableValue,
+        };
+
+        const gettingTheConfig = () => getConfig();
+
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Invalid integer value "${environmentVariableValue}" for configuration property.`);
+      });
+
+      it(`throws InvalidConfigException if ${environmentVariableName} is binary number`, () => {
+        const environmentVariableValue = '0b101';
+        process.env = {
+          [environmentVariableName]: environmentVariableValue,
+        };
+
+        const gettingTheConfig = () => getConfig();
+
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Invalid integer value "${environmentVariableValue}" for configuration property.`);
       });
     },
   );

--- a/test/common-tests/environment-variable-parsing-unit-tests.ts
+++ b/test/common-tests/environment-variable-parsing-unit-tests.ts
@@ -56,7 +56,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
     describe.each(configParsedBooleanFromEnvironmentVariablesWithDefault)(
       '$configPropertyName',
       ({ configPropertyName, environmentVariableName, defaultConfigValue }) => {
-        it(`is config ${environmentVariableName} set to true if environment variable ${environmentVariableName} is true`, () => {
+        it(`is true if environment variable ${environmentVariableName} is true`, () => {
           const expectedConfigValue = true;
           const environmentVariableValue = expectedConfigValue.toString();
           process.env = {
@@ -68,7 +68,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
           expect(configPropertyValue).toBe(expectedConfigValue);
         });
 
-        it(`is config ${environmentVariableName} set to false if environment variable ${environmentVariableName} is false`, () => {
+        it(`is false if environment variable ${environmentVariableName} is false`, () => {
           const expectedConfigValue = false;
           const environmentVariableValue = expectedConfigValue.toString();
           process.env = {


### PR DESCRIPTION
### Introduction
Current way to parse environment variables and set default value doesn't allow using 0. 0 can be useful for ACBS_MAX_REDIRECTS , ACBS_TIMEOUT and similar integer environment variables.

### Resolution
Created helper `getIntConfig`. It parses input string and returns integer from input or optional default value.

Helper throws exception for these edge cases:
  - input is set, but not string
  - input and default values are undefined
  - input is not integer in string format. For example it is float or has some non digital characters
  - input number is not using decimal base

### Misc
Moved boolean environment variable test to shared test `withEnvironmentVariableParsingUnitTests`
