### PR TITLE
chore: remove redundant TODOs from APIM-492

### DIFF
--- a/src/modules/acbs/dto/acbs-base-facility-request.dto.ts
+++ b/src/modules/acbs/dto/acbs-base-facility-request.dto.ts
@@ -129,7 +129,6 @@ export interface AcbsBaseFacilityRequest {
   AccountStructure: {
     AccountStructureCode: string;
   };
-  // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
   LenderType: {
     LenderTypeCode: string;
   };

--- a/src/modules/facility/facility.service.ts
+++ b/src/modules/facility/facility.service.ts
@@ -130,7 +130,6 @@ export class FacilityService {
     // causes issue with old facilities which were manually created using old adminstrative profile.
     delete existingAcbsFacilityData.AdministrativeUserIdentifier;
 
-    // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
     delete existingAcbsFacilityData.FacilityOverallStatus;
 
     const acbsMergedUpdateFacilityRequest: AcbsUpdateFacilityRequest = {
@@ -300,7 +299,6 @@ export class FacilityService {
       AccountStructure: {
         AccountStructureCode: defaultValues.accountStructureCode,
       },
-      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultValues.lenderTypeCode,
       },

--- a/test/support/generator/create-facility-generator.ts
+++ b/test/support/generator/create-facility-generator.ts
@@ -186,7 +186,6 @@ export class CreateFacilityGenerator extends AbstractGenerator<FacilityValues, G
       AccountStructure: {
         AccountStructureCode: defaultValues.accountStructureCode,
       },
-      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultValues.lenderTypeCode,
       },

--- a/test/support/generator/update-facility-generator.ts
+++ b/test/support/generator/update-facility-generator.ts
@@ -198,7 +198,6 @@ export class UpdateFacilityGenerator extends AbstractGenerator<FacilityValues, G
       AccountStructure: {
         AccountStructureCode: defaultFacilityValues.accountStructureCode,
       },
-      // TODO: APIM-492 we might need to put FacilityOverallStatus field back here for Production release.
       LenderType: {
         LenderTypeCode: defaultFacilityValues.lenderTypeCode,
       },


### PR DESCRIPTION
## Introduction

We implemented APIM-492 to resolve an issue in the ACBS test environment. That issue was that we were unable to create facilities because ACBS's validation on the FacilityOverallStatus field was incorrect. We were able to resolve this by removing the field from our facility creation request as it is not used anyway.

We were aware that the FacilityOverallStatus field had been included in facility creation requests from Mulesoft because the Mulesoft dev team had found that it was required by ACBS. It was no longer required in the ACBS test environment, but at the time of implementing APIM-492 we were unsure if it was required or not in the ACBS production environment (which was 1 patch behind the ACBS test environment).

We now know that the FacilityOverallStatus field is not required in the ACBS production environment (it was confirmed by FIS), so the TODOs we left from APIM-492 (that our change might need to be reverted) are redundant and can be removed.

## Resolution
I have removed the redundant TODOs.