### PR TITLE
feat(GIFT-10828): create a facility - obligorUrn validation

### DIFF
--- a/src/constants/examples/gift.examples.constant.ts
+++ b/src/constants/examples/gift.examples.constant.ts
@@ -20,7 +20,7 @@ const FACILITY = {
   FACILITY_NAME: 'Amazing facility',
   IS_REVOLVING: true,
   IS_DRAFT: false,
-  OBLIGOR_URN: '01234567',
+  OBLIGOR_URN: '12345678',
   STREAM_ID: '7d915bfa-0069-4aaa-92c5-013925f019a1',
   STREAM_VERSION: 1,
 };

--- a/src/constants/gift.constant.ts
+++ b/src/constants/gift.constant.ts
@@ -21,6 +21,7 @@ export const GIFT = {
     FACILITY_AMOUNT: { MIN: 1 },
     FACILITY_ID: UKEFID.VALIDATION,
     FACILITY_NAME: { MIN: 1, MAX: 35 },
+    OBLIGOR_URN: { MIN: 8, MAX: 8 },
     PRODUCT_TYPE: { MIN: 3, MAX: 30 },
   },
 };

--- a/src/modules/gift/dto/facility.ts
+++ b/src/modules/gift/dto/facility.ts
@@ -92,6 +92,7 @@ export class GiftFacilityDto {
 
   @IsDefined()
   @IsNumberString()
+  @Length(VALIDATION.OBLIGOR_URN.MIN, VALIDATION.OBLIGOR_URN.MAX)
   @ApiProperty({
     example: EXAMPLE.OBLIGOR_URN,
   })

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -3278,7 +3278,7 @@ components:
           example: Amazing facility
         obligorUrn:
           type: string
-          example: '01234567'
+          example: '12345678'
         productType:
           type: string
           example: Export Insurance Policy (EXIP)
@@ -3303,7 +3303,7 @@ components:
             streamId: 7d915bfa-0069-4aaa-92c5-013925f019a1
             streamVersion: 1
             name: Amazing facility
-            obligorUrn: '01234567'
+            obligorUrn: '12345678'
             currency: USD
             facilityAmount: 1000000
             effectiveDate: '2025-01-01'

--- a/test/gift/assertions/index.ts
+++ b/test/gift/assertions/index.ts
@@ -1,4 +1,5 @@
 export * from './boolean-validation';
+export * from './number-string-validation';
 export * from './number-validation';
 export * from './string-validation';
 export * from './ukef-id-validation';

--- a/test/gift/assertions/number-string-validation.ts
+++ b/test/gift/assertions/number-string-validation.ts
@@ -1,0 +1,243 @@
+import { Api } from '@ukef-test/support/api';
+
+import { generatePayload } from './generate-payload';
+import { assert400Response } from './response-assertion';
+
+/**
+ * Validation tests for a number string field with invalid values
+ * @param {String} fieldName: The name of a field. E.g, email
+ * @param {Object} initialPayload: The payload to use before adding a field value
+ * @param {Number} min: The minimum length
+ * @param {Number} max: The maximum length
+ * @param {String} parentFieldName: The name of a parent field. E.g parentObject
+ * @param {String} url: The URL the tests will call.
+ */
+export const numberStringValidation = ({ fieldName, initialPayload, min, max, parentFieldName, url }) => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  const fieldPath = `${parentFieldName}.${fieldName}`;
+
+  const mockPayload = generatePayload({ initialPayload, fieldName, parentFieldName });
+
+  describe(`when ${fieldName} is null`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = null;
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${fieldPath} should not be null or undefined`,
+        `${fieldPath} must be longer than or equal to ${min} characters`,
+        `${fieldPath} must be a number string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is undefined`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = undefined;
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${fieldPath} should not be null or undefined`,
+        `${fieldPath} must be longer than or equal to ${min} characters`,
+        `${fieldPath} must be a number string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is an empty array`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = [];
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be longer than or equal to ${min} characters`, `${fieldPath} must be a number string`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a boolean, true`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = true;
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${fieldPath} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${fieldPath} must be a number string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a boolean, false`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = false;
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be longer than or equal to ${min} characters`, `${fieldPath} must be a number string`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a number`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = 1;
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${fieldPath} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${fieldPath} must be a number string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is an empty string`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = '';
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be longer than or equal to ${min} characters`, `${fieldPath} must be a number string`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a string, but not a number`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = 'not a number';
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be shorter than or equal to ${max} characters`, `${fieldPath} must be a number string`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is below the minimum`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = '1'.repeat(min - 1);
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be longer than or equal to ${min} characters`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is above the maximum`, () => {
+    beforeAll(() => {
+      mockPayload[`${parentFieldName}`][`${fieldName}`] = '1'.repeat(max + 1);
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [`${fieldPath} must be shorter than or equal to ${max} characters`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+};

--- a/test/gift/create-facility-validation.api-test.ts
+++ b/test/gift/create-facility-validation.api-test.ts
@@ -3,7 +3,7 @@ import { EXAMPLES, GIFT } from '@ukef/constants';
 import { Api } from '@ukef-test/support/api';
 import nock from 'nock';
 
-import { booleanValidation, numberValidation, stringValidation, ukefIdValidation } from './assertions';
+import { booleanValidation, numberStringValidation, numberValidation, stringValidation, ukefIdValidation } from './assertions';
 
 const {
   giftVersioning: { prefixAndVersion },
@@ -88,6 +88,7 @@ describe('POST /gift/facility - validation', () => {
           `overview.name must be longer than or equal to ${VALIDATION.FACILITY_NAME.MIN} characters`,
           'overview.name must be a string',
           'overview.obligorUrn should not be null or undefined',
+          `overview.obligorUrn must be longer than or equal to ${VALIDATION.OBLIGOR_URN.MIN} characters`,
           'overview.obligorUrn must be a number string',
           'overview.productType should not be null or undefined',
           `overview.productType must be longer than or equal to ${VALIDATION.PRODUCT_TYPE.MIN} characters`,
@@ -178,6 +179,15 @@ describe('POST /gift/facility - validation', () => {
       fieldName: 'name',
       min: VALIDATION.FACILITY_NAME.MIN,
       max: VALIDATION.FACILITY_NAME.MAX,
+    });
+  });
+
+  describe('overview.obligorUrn', () => {
+    numberStringValidation({
+      ...baseParams,
+      fieldName: 'obligorUrn',
+      min: VALIDATION.OBLIGOR_URN.MIN,
+      max: VALIDATION.OBLIGOR_URN.MAX,
     });
   });
 


### PR DESCRIPTION
## Introduction :pencil2:

This PR updates the facility creation (overview) validation to enforce the length of the `obligorUrn` field.

## Resolution :heavy_check_mark:

- Update `VALIDATION` constants.
- Update `GiftFacilityDto`.
- Add DRY test assertion function, `numberStringValidation`.
- Update API tests.