### PR TITLE
chore(GIFT-10023): create a facility - repayment profiles - api tests

### DIFF
--- a/src/constants/gift.constant.ts
+++ b/src/constants/gift.constant.ts
@@ -51,7 +51,7 @@ export const GIFT = {
       START_DATE: DATE_STRING_VALIDATION,
     },
     REPAYMENT_PROFILE: {
-      NAME: { MIN_LENGTH: 0, MAX_LENGTH: 120 },
+      NAME: { MIN_LENGTH: 1, MAX_LENGTH: 120 },
       ALLOCATION: {
         DUE_DATE: DATE_STRING_VALIDATION,
         AMOUNT: { MIN: 0 },

--- a/src/modules/gift/dto/facility-creation.ts
+++ b/src/modules/gift/dto/facility-creation.ts
@@ -44,6 +44,7 @@ export class GiftFacilityCreationDto {
     isArray: true,
     example: [REPAYMENT_PROFILE(), REPAYMENT_PROFILE()],
     required: true,
+    type: GiftRepaymentProfileDto,
   })
   @IsArray()
   @ArrayNotEmpty()

--- a/test/gift/assertions/array-of-nested-objects-number-validation.ts
+++ b/test/gift/assertions/array-of-nested-objects-number-validation.ts
@@ -1,0 +1,187 @@
+import { Api } from '@ukef-test/support/api';
+
+import { generatePayloadArrayOfObjects } from './generate-payload';
+import { assert400Response } from './response-assertion';
+
+/**
+ * Validation tests for an nested array of nested - number field with invalid values
+ * @param {String} fieldName: The name of a field. E.g, amount
+ * @param {String} parentFieldName: The name of a parent field. E.g parentObject
+ * @param {String} grandParentFieldName: The name of a parent field. E.g grandParentObject
+ * @param {Object} initialPayload: The payload to use before adding a field value
+ * @param {Number} min: The minimum length
+ * @param {Number} max: The maximum length
+ * @param {String} url: The URL the tests will call.
+ */
+export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFieldName, parentFieldName, initialPayload, min, max, url }) => {
+  let api: Api;
+
+  const payloadParams = { initialPayload, fieldName, grandParentFieldName, parentFieldName };
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  describe(`when ${fieldName} is null`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is undefined`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a string`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is below the minimum`, () => {
+    let mockPayload;
+
+    const value = min - 1;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must not be less than ${min}`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must not be less than ${min}`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  if (max) {
+    describe(`when ${fieldName} is above the maximum`, () => {
+      let mockPayload;
+
+      const value = max + 1;
+
+      beforeAll(() => {
+        mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+      });
+
+      it('should return a 400 response', async () => {
+        const response = await api.post(url, mockPayload);
+
+        assert400Response(response);
+      });
+
+      it('should return the correct error messages', async () => {
+        const { body } = await api.post(url, mockPayload);
+
+        const expected = [
+          `${parentFieldName}.0.${fieldName} must not be greater than ${max}`,
+          `${parentFieldName}.1.${fieldName} must not be greater than ${max}`,
+        ];
+
+        expect(body.message).toStrictEqual(expected);
+      });
+    });
+  }
+};

--- a/test/gift/assertions/array-of-nested-objects-number-validation.ts
+++ b/test/gift/assertions/array-of-nested-objects-number-validation.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { Api } from '@ukef-test/support/api';
 
 import { generatePayloadArrayOfObjects } from './generate-payload';
@@ -33,7 +34,7 @@ export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -68,7 +69,7 @@ export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -103,7 +104,7 @@ export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -136,7 +137,7 @@ export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -166,7 +167,7 @@ export const arrayOfNestedObjectsNumberValidation = ({ fieldName, grandParentFie
         mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
       });
 
-      it('should return a 400 response', async () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
         const response = await api.post(url, mockPayload);
 
         assert400Response(response);

--- a/test/gift/assertions/array-of-nested-objects-string-validation.ts
+++ b/test/gift/assertions/array-of-nested-objects-string-validation.ts
@@ -13,7 +13,7 @@ import { assert400Response } from './response-assertion';
  * @param {Number} max: The maximum length
  * @param {String} url: The URL the tests will call.
  */
-export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFieldName = '', parentFieldName, initialPayload, min, max, url }) => {
+export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFieldName, parentFieldName, initialPayload, min, max, url }) => {
   let api: Api;
 
   const payloadParams = { initialPayload, fieldName, grandParentFieldName, parentFieldName };

--- a/test/gift/assertions/array-of-nested-objects-string-validation.ts
+++ b/test/gift/assertions/array-of-nested-objects-string-validation.ts
@@ -1,0 +1,245 @@
+import { Api } from '@ukef-test/support/api';
+
+import { generatePayloadArrayOfObjects } from './generate-payload';
+import { assert400Response } from './response-assertion';
+
+/**
+ * Validation tests for a nested array of objects - string field with invalid values
+ * @param {String} fieldName: The name of a field. E.g, email
+ * @param {String} parentFieldName: The name of a parent field. E.g parentObject
+ * @param {String} grandParentFieldName: The name of a parent field. E.g grandParentObject
+ * @param {Object} initialPayload: The payload to use before adding a field value
+ * @param {Number} min: The minimum length
+ * @param {Number} max: The maximum length
+ * @param {String} url: The URL the tests will call.
+ */
+export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFieldName = '', parentFieldName, initialPayload, min, max, url }) => {
+  let api: Api;
+
+  const payloadParams = { initialPayload, fieldName, grandParentFieldName, parentFieldName };
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  describe(`when ${fieldName} is null`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is undefined`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} should not be null or undefined`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is an empty array`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: [] });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${max} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${max} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a number, 1`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 1 });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be a string`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be a string`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is an empty string`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is below the minimum`, () => {
+    let mockPayload;
+
+    const value = 'a'.repeat(min - 1);
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be longer than or equal to ${min} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be longer than or equal to ${min} characters`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is above the maximum`, () => {
+    let mockPayload;
+
+    const value = 'a'.repeat(max + 1);
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
+
+    it('should return a 400 response', async () => {
+      const response = await api.post(url, mockPayload);
+
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      const { body } = await api.post(url, mockPayload);
+
+      const expected = [
+        `${grandParentFieldName}.0.${parentFieldName}.0.${fieldName} must be shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.0.${parentFieldName}.1.${fieldName} must be shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.0.${fieldName} must be shorter than or equal to ${max} characters`,
+        `${grandParentFieldName}.1.${parentFieldName}.1.${fieldName} must be shorter than or equal to ${max} characters`,
+      ];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+};

--- a/test/gift/assertions/array-of-nested-objects-string-validation.ts
+++ b/test/gift/assertions/array-of-nested-objects-string-validation.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { Api } from '@ukef-test/support/api';
 
 import { generatePayloadArrayOfObjects } from './generate-payload';
@@ -33,7 +34,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -68,7 +69,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -103,7 +104,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: [] });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -134,7 +135,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 1 });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -165,7 +166,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -194,7 +195,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);
@@ -223,7 +224,7 @@ export const arrayOfNestedObjectsStringValidation = ({ fieldName, grandParentFie
       mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
     });
 
-    it('should return a 400 response', async () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       const response = await api.post(url, mockPayload);
 
       assert400Response(response);

--- a/test/gift/assertions/array-of-objects-number-validation.ts
+++ b/test/gift/assertions/array-of-objects-number-validation.ts
@@ -6,14 +6,17 @@ import { assert400Response } from './response-assertion';
 /**
  * Validation tests for an array of objects - number field with invalid values
  * @param {String} fieldName: The name of a field. E.g, amount
+ * @param {String} parentFieldName: The name of a parent field. E.g parentObject
+ * @param {String} grandParentFieldName: The name of a parent field. E.g grandParentObject
  * @param {Object} initialPayload: The payload to use before adding a field value
  * @param {Number} min: The minimum length
  * @param {Number} max: The maximum length
- * @param {String} parentFieldName: The name of a parent field. E.g parentObject
  * @param {String} url: The URL the tests will call.
  */
-export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min, max, parentFieldName, url }) => {
+export const arrayOfObjectsNumberValidation = ({ fieldName, grandParentFieldName = '', parentFieldName, initialPayload, min, max, url }) => {
   let api: Api;
+
+  const payloadParams = { initialPayload, fieldName, grandParentFieldName, parentFieldName };
 
   beforeAll(async () => {
     api = await Api.create();
@@ -24,7 +27,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is null`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: null });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -51,7 +58,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is undefined`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: undefined });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -78,7 +89,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is an empty array`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: [] });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: [] });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -103,7 +118,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a boolean, true`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: true });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: true });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -128,7 +147,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a boolean, false`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: false });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: false });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -153,7 +176,11 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a string`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: '' });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -178,9 +205,13 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is below the minimum`, () => {
+    let mockPayload;
+
     const value = min - 1;
 
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value });
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -198,9 +229,13 @@ export const arrayOfObjectsNumberValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is above the maximum`, () => {
+    let mockPayload;
+
     const value = max + 1;
 
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value });
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);

--- a/test/gift/assertions/array-of-objects-number-validation.ts
+++ b/test/gift/assertions/array-of-objects-number-validation.ts
@@ -7,16 +7,15 @@ import { assert400Response } from './response-assertion';
  * Validation tests for an array of objects - number field with invalid values
  * @param {String} fieldName: The name of a field. E.g, amount
  * @param {String} parentFieldName: The name of a parent field. E.g parentObject
- * @param {String} grandParentFieldName: The name of a parent field. E.g grandParentObject
  * @param {Object} initialPayload: The payload to use before adding a field value
  * @param {Number} min: The minimum length
  * @param {Number} max: The maximum length
  * @param {String} url: The URL the tests will call.
  */
-export const arrayOfObjectsNumberValidation = ({ fieldName, grandParentFieldName = '', parentFieldName, initialPayload, min, max, url }) => {
+export const arrayOfObjectsNumberValidation = ({ fieldName, parentFieldName, initialPayload, min, max, url }) => {
   let api: Api;
 
-  const payloadParams = { initialPayload, fieldName, grandParentFieldName, parentFieldName };
+  const payloadParams = { initialPayload, fieldName, parentFieldName };
 
   beforeAll(async () => {
     api = await Api.create();

--- a/test/gift/assertions/array-of-objects-string-validation.ts
+++ b/test/gift/assertions/array-of-objects-string-validation.ts
@@ -15,6 +15,8 @@ import { assert400Response } from './response-assertion';
 export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min, max, parentFieldName, url }) => {
   let api: Api;
 
+  const payloadParams = { initialPayload, fieldName, parentFieldName };
+
   beforeAll(async () => {
     api = await Api.create();
   });
@@ -24,7 +26,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is null`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: null });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: null });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -49,7 +55,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is undefined`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: undefined });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: undefined });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -74,7 +84,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is an empty array`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: [] });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: [] });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -97,7 +111,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a boolean, true`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: true });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: true });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -120,7 +138,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a boolean, false`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: false });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: false });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -143,7 +165,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a number, 0`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: 0 });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 0 });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -166,7 +192,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is a number, 1`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: 1 });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 1 });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -189,7 +219,11 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is an empty string`, () => {
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value: '' });
+    let mockPayload;
+
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: '' });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -210,9 +244,13 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is below the minimum`, () => {
+    let mockPayload;
+
     const value = 'a'.repeat(min - 1);
 
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value });
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);
@@ -233,9 +271,13 @@ export const arrayOfObjectsStringValidation = ({ fieldName, initialPayload, min,
   });
 
   describe(`when ${fieldName} is above the maximum`, () => {
+    let mockPayload;
+
     const value = 'a'.repeat(max + 1);
 
-    const mockPayload = generatePayloadArrayOfObjects({ initialPayload, fieldName, parentFieldName, value });
+    beforeAll(() => {
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value });
+    });
 
     it('should return a 400 response', async () => {
       const response = await api.post(url, mockPayload);

--- a/test/gift/assertions/generate-payload.ts
+++ b/test/gift/assertions/generate-payload.ts
@@ -29,18 +29,41 @@ export const generatePayload = ({ initialPayload, fieldName, parentFieldName = '
 
 /**
  * Generate a payload for an array of objects, for field validation assertion in each object.
+ * This supports one/two level nested arrays, for example:
+ * 1) { payments: [{}, {}] }
+ * 2) { payments: [ { contacts: [] }, { contacts: [] }] }
  * This function generates a payload object with an array of objects,
  * with a value being assigned to the provided field name, for each object in the array.
  * @param {Object} initialPayload: The payload to use before adding a field value
  * @param {String} fieldName: The name of a field. E.g, email
  * @param {String} parentFieldName: The name of a parent field. E.g parentObject
+ * @param {String} grandParentFieldName: The name of a parent field. E.g grandParentObject
  * @param {any} value: The value to assign to fieldName.
  * @returns {Object} payload for testing purposes
  */
-export const generatePayloadArrayOfObjects = ({ initialPayload, fieldName, parentFieldName = '', value }) => ({
-  ...initialPayload,
-  [`${parentFieldName}`]: initialPayload[`${parentFieldName}`].map((item: object) => ({
-    ...item,
-    [`${fieldName}`]: value,
-  })),
-});
+export const generatePayloadArrayOfObjects = ({ initialPayload, fieldName, parentFieldName = '', grandParentFieldName = '', value }) => {
+  if (grandParentFieldName) {
+    const payload = {
+      ...initialPayload,
+      [`${grandParentFieldName}`]: initialPayload[`${grandParentFieldName}`].map((parentItem: object) => ({
+        ...parentItem,
+        [`${parentFieldName}`]: parentItem[`${parentFieldName}`].map((item: object) => {
+          return {
+            ...item,
+            [`${fieldName}`]: value,
+          };
+        }),
+      })),
+    };
+
+    return payload;
+  }
+
+  return {
+    ...initialPayload,
+    [`${parentFieldName}`]: initialPayload[`${parentFieldName}`].map((item: object) => ({
+      ...item,
+      [`${fieldName}`]: value,
+    })),
+  };
+};

--- a/test/gift/assertions/index.ts
+++ b/test/gift/assertions/index.ts
@@ -1,3 +1,5 @@
+export * from './array-of-nested-objects-number-validation';
+export * from './array-of-nested-objects-string-validation';
 export * from './array-of-objects-number-validation';
 export * from './array-of-objects-string-validation';
 export * from './boolean-validation';

--- a/test/gift/assertions/response-assertion.ts
+++ b/test/gift/assertions/response-assertion.ts
@@ -1,3 +1,5 @@
+import { HttpStatus } from '@nestjs/common';
+
 /**
  * Check that a response is a 400 response.
  * @param {Object} response: The API response
@@ -5,8 +7,9 @@
 export const assert400Response = (response) => {
   const { status, body } = response;
 
-  expect(status).toBe(400);
+  expect(status).toBe(HttpStatus.BAD_REQUEST);
 
   expect(body.error).toBe('Bad Request');
-  expect(body.statusCode).toBe(400);
+
+  expect(body.statusCode).toBe(HttpStatus.BAD_REQUEST);
 };

--- a/test/gift/create-facility-validation-repayment-profiles.api-test.ts
+++ b/test/gift/create-facility-validation-repayment-profiles.api-test.ts
@@ -1,0 +1,161 @@
+import { HttpStatus } from '@nestjs/common';
+import AppConfig from '@ukef/config/app.config';
+import { EXAMPLES, GIFT } from '@ukef/constants';
+import { Api } from '@ukef-test/support/api';
+import nock from 'nock';
+
+import { arrayOfNestedObjectsNumberValidation, arrayOfNestedObjectsStringValidation, arrayOfObjectsStringValidation } from './assertions';
+
+const {
+  giftVersioning: { prefixAndVersion },
+} = AppConfig();
+
+const {
+  PATH: { FACILITY },
+  VALIDATION: { REPAYMENT_PROFILE: REPAYMENT_PROFILE_VALIDATION },
+} = GIFT;
+
+describe('POST /gift/facility - validation - repayment profiles', () => {
+  const url = `/api/${prefixAndVersion}/gift${FACILITY}`;
+
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  const baseParams = {
+    initialPayload: EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD,
+    url,
+  };
+
+  describe('when an empty repayment profile object is provided', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = {
+        ...EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD,
+        repaymentProfiles: [{}],
+      };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: [
+          'repaymentProfiles.0.name should not be null or undefined',
+          `repaymentProfiles.0.name must be longer than or equal to ${REPAYMENT_PROFILE_VALIDATION.NAME.MIN_LENGTH} characters`,
+          'repaymentProfiles.0.name must be a string',
+          'repaymentProfiles.0.allocations should not be null or undefined',
+          'repaymentProfiles.0.allocations should not be empty',
+          'repaymentProfiles.0.allocations must be an array',
+        ],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('name', () => {
+    arrayOfObjectsStringValidation({
+      ...baseParams,
+      parentFieldName: 'repaymentProfiles',
+      fieldName: 'name',
+      min: REPAYMENT_PROFILE_VALIDATION.NAME.MIN_LENGTH,
+      max: REPAYMENT_PROFILE_VALIDATION.NAME.MAX_LENGTH,
+    });
+  });
+
+  describe('when a repayment has allocations as an empty array', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = {
+        ...EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD,
+        repaymentProfiles: [
+          {
+            ...EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD.repaymentProfiles[0],
+            allocations: [],
+          },
+        ],
+      };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: ['repaymentProfiles.0.allocations should not be empty'],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('when a repayment has allocations as sn empty object', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = {
+        ...EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD,
+        repaymentProfiles: [
+          {
+            ...EXAMPLES.GIFT.FACILITY_CREATION_PAYLOAD.repaymentProfiles[0],
+            allocations: [{}],
+          },
+        ],
+      };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: [
+          'repaymentProfiles.0.allocations.0.amount should not be null or undefined',
+          `repaymentProfiles.0.allocations.0.amount must not be less than ${REPAYMENT_PROFILE_VALIDATION.ALLOCATION.AMOUNT.MIN}`,
+          'repaymentProfiles.0.allocations.0.amount must be a number conforming to the specified constraints',
+          'repaymentProfiles.0.allocations.0.dueDate should not be null or undefined',
+          `repaymentProfiles.0.allocations.0.dueDate must be longer than or equal to ${REPAYMENT_PROFILE_VALIDATION.ALLOCATION.DUE_DATE.MIN_LENGTH} characters`,
+          'repaymentProfiles.0.allocations.0.dueDate must be a string',
+        ],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('allocation.amount', () => {
+    arrayOfNestedObjectsNumberValidation({
+      ...baseParams,
+      grandParentFieldName: 'repaymentProfiles',
+      parentFieldName: 'allocations',
+      fieldName: 'amount',
+      min: REPAYMENT_PROFILE_VALIDATION.ALLOCATION.AMOUNT.MIN,
+      max: null,
+    });
+  });
+
+  describe('allocation.dueDate', () => {
+    arrayOfNestedObjectsStringValidation({
+      ...baseParams,
+      grandParentFieldName: 'repaymentProfiles',
+      parentFieldName: 'allocations',
+      fieldName: 'dueDate',
+      min: REPAYMENT_PROFILE_VALIDATION.ALLOCATION.DUE_DATE.MIN_LENGTH,
+      max: REPAYMENT_PROFILE_VALIDATION.ALLOCATION.DUE_DATE.MAX_LENGTH,
+    });
+  });
+});

--- a/test/gift/create-facility-validation.api-test.ts
+++ b/test/gift/create-facility-validation.api-test.ts
@@ -12,9 +12,7 @@ const {
 
 const {
   PATH: { FACILITY },
-  VALIDATION: {
-    FACILITY: { OVERVIEW: OVERVIEW_VALIDATION },
-  },
+  VALIDATION,
 } = GIFT;
 
 describe('POST /gift/facility - validation', () => {
@@ -35,7 +33,7 @@ describe('POST /gift/facility - validation', () => {
     nock.cleanAll();
   });
 
-  describe('when an empty object provided', () => {
+  describe('when an empty object is provided', () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with a validation error`, async () => {
       const mockPayload = {};
 
@@ -62,9 +60,111 @@ describe('POST /gift/facility - validation', () => {
     });
   });
 
-  describe('when an unpopulated object is provided', () => {
+  describe('when an empty array is provided', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with a validation error`, async () => {
+      const mockPayload = [];
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: [
+          'overview should not be null or undefined',
+          'overview must be a non-empty object',
+          'counterparties should not be null or undefined',
+          'counterparties should not be empty',
+          'counterparties must be an array',
+          'repaymentProfiles should not be null or undefined',
+          'repaymentProfiles should not be empty',
+          'repaymentProfiles must be an array',
+        ],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('when empty entity arrays are provided', () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
-      const mockPayload = { overview: {}, counterparties: [], repaymentProfiles: [] };
+      const mockPayload = { overview: [], counterparties: [], repaymentProfiles: [] };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: ['overview must be a non-empty object', 'counterparties should not be empty', 'repaymentProfiles should not be empty'],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('when null entities are provided', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = { overview: null, counterparties: null, repaymentProfiles: null };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: [
+          'overview should not be null or undefined',
+          'overview must be a non-empty object',
+          'nested property overview must be either object or array',
+          'counterparties should not be null or undefined',
+          'counterparties should not be empty',
+          'counterparties must be an array',
+          'nested property counterparties must be either object or array',
+          'repaymentProfiles should not be null or undefined',
+          'repaymentProfiles should not be empty',
+          'repaymentProfiles must be an array',
+          'nested property repaymentProfiles must be either object or array',
+        ],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('when undefined entities are provided', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = { overview: undefined, counterparties: undefined, repaymentProfiles: undefined };
+
+      const { status, body } = await api.post(url, mockPayload);
+
+      expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+      const expected = {
+        error: 'Bad Request',
+        message: [
+          'overview should not be null or undefined',
+          'overview must be a non-empty object',
+          'counterparties should not be null or undefined',
+          'counterparties should not be empty',
+          'counterparties must be an array',
+          'repaymentProfiles should not be null or undefined',
+          'repaymentProfiles should not be empty',
+          'repaymentProfiles must be an array',
+        ],
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
+  describe('when empty entity objects are provided', () => {
+    it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors for all required fields`, async () => {
+      const mockPayload = { overview: {}, counterparties: {}, repaymentProfiles: {} };
 
       const { status, body } = await api.post(url, mockPayload);
 
@@ -74,39 +174,59 @@ describe('POST /gift/facility - validation', () => {
         error: 'Bad Request',
         message: [
           'overview.currency should not be null or undefined',
-          `overview.currency must be longer than or equal to ${OVERVIEW_VALIDATION.CURRENCY.MIN_LENGTH} characters`,
+          `overview.currency must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.CURRENCY.MIN_LENGTH} characters`,
           'overview.currency must be a string',
           'overview.dealId must be a string',
-          `overview.dealId must be longer than or equal to ${OVERVIEW_VALIDATION.DEAL_ID.MIN_LENGTH} characters`,
+          `overview.dealId must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.DEAL_ID.MIN_LENGTH} characters`,
           'overview.dealId must match /^00\\d{8}$/ regular expression',
           'overview.effectiveDate should not be null or undefined',
-          `overview.effectiveDate must be longer than or equal to ${OVERVIEW_VALIDATION.EFFECTIVE_DATE.MIN_LENGTH} characters`,
+          `overview.effectiveDate must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.EFFECTIVE_DATE.MIN_LENGTH} characters`,
           'overview.effectiveDate must be a string',
           'overview.endOfCoverDate should not be null or undefined',
-          `overview.endOfCoverDate must be longer than or equal to ${OVERVIEW_VALIDATION.END_OF_COVER_DATE.MIN_LENGTH} characters`,
+          `overview.endOfCoverDate must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.END_OF_COVER_DATE.MIN_LENGTH} characters`,
           'overview.endOfCoverDate must be a string',
           'overview.expiryDate should not be null or undefined',
-          `overview.expiryDate must be longer than or equal to ${OVERVIEW_VALIDATION.EXPIRY_DATE.MIN_LENGTH} characters`,
+          `overview.expiryDate must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.EXPIRY_DATE.MIN_LENGTH} characters`,
           'overview.expiryDate must be a string',
           'overview.facilityAmount should not be null or undefined',
-          `overview.facilityAmount must not be less than ${OVERVIEW_VALIDATION.FACILITY_AMOUNT.MIN}`,
+          `overview.facilityAmount must not be less than ${VALIDATION.FACILITY.OVERVIEW.FACILITY_AMOUNT.MIN}`,
           'overview.facilityAmount must be a number conforming to the specified constraints',
           'overview.facilityId must be a string',
-          `overview.facilityId must be longer than or equal to ${OVERVIEW_VALIDATION.FACILITY_ID.MIN_LENGTH} characters`,
+          `overview.facilityId must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.FACILITY_ID.MIN_LENGTH} characters`,
           'overview.facilityId must match /^00\\d{8}$/ regular expression',
           'overview.isRevolving should not be null or undefined',
           'overview.isRevolving must be a boolean value',
           'overview.name should not be null or undefined',
-          `overview.name must be longer than or equal to ${OVERVIEW_VALIDATION.FACILITY_NAME.MIN_LENGTH} characters`,
+          `overview.name must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.FACILITY_NAME.MIN_LENGTH} characters`,
           'overview.name must be a string',
           'overview.obligorUrn should not be null or undefined',
-          `overview.obligorUrn must be longer than or equal to ${OVERVIEW_VALIDATION.OBLIGOR_URN.MIN_LENGTH} characters`,
+          `overview.obligorUrn must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.OBLIGOR_URN.MIN_LENGTH} characters`,
           'overview.obligorUrn must be a number string',
           'overview.productType should not be null or undefined',
-          `overview.productType must be longer than or equal to ${OVERVIEW_VALIDATION.PRODUCT_TYPE.MIN_LENGTH} characters`,
+          `overview.productType must be longer than or equal to ${VALIDATION.FACILITY.OVERVIEW.PRODUCT_TYPE.MIN_LENGTH} characters`,
           'overview.productType must be a string',
-          'counterparties should not be empty',
-          'repaymentProfiles should not be empty',
+          `counterparties.counterpartyUrn should not be null or undefined`,
+          `counterparties.counterpartyUrn must be longer than or equal to ${VALIDATION.COUNTERPARTY.COUNTERPARTY_URN.MIN_LENGTH} characters`,
+          `counterparties.counterpartyUrn must be a string`,
+          `counterparties.exitDate should not be null or undefined`,
+          `counterparties.exitDate must be longer than or equal to ${VALIDATION.COUNTERPARTY.EXIT_DATE.MIN_LENGTH} characters`,
+          `counterparties.exitDate must be a string`,
+          `counterparties.roleId should not be null or undefined`,
+          `counterparties.roleId must be longer than or equal to ${VALIDATION.COUNTERPARTY.ROLE_ID.MIN_LENGTH} characters`,
+          `counterparties.roleId must be a string`,
+          `counterparties.sharePercentage should not be null or undefined`,
+          `counterparties.sharePercentage must not be greater than ${VALIDATION.COUNTERPARTY.SHARE_PERCENTAGE.MAX}`,
+          `counterparties.sharePercentage must not be less than ${VALIDATION.COUNTERPARTY.SHARE_PERCENTAGE.MIN}`,
+          `counterparties.sharePercentage must be a number conforming to the specified constraints`,
+          `counterparties.startDate should not be null or undefined`,
+          `counterparties.startDate must be longer than or equal to ${VALIDATION.COUNTERPARTY.START_DATE.MIN_LENGTH} characters`,
+          `counterparties.startDate must be a string`,
+          'repaymentProfiles.name should not be null or undefined',
+          `repaymentProfiles.name must be longer than or equal to ${VALIDATION.REPAYMENT_PROFILE.NAME.MIN_LENGTH} characters`,
+          'repaymentProfiles.name must be a string',
+          'repaymentProfiles.allocations should not be null or undefined',
+          'repaymentProfiles.allocations should not be empty',
+          'repaymentProfiles.allocations must be an array',
         ],
         statusCode: HttpStatus.BAD_REQUEST,
       };
@@ -125,8 +245,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'currency',
-      min: OVERVIEW_VALIDATION.CURRENCY.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.CURRENCY.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.CURRENCY.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.CURRENCY.MAX_LENGTH,
     });
   });
 
@@ -134,8 +254,8 @@ describe('POST /gift/facility - validation', () => {
     ukefIdValidation({
       ...baseParams,
       fieldName: 'dealId',
-      min: OVERVIEW_VALIDATION.DEAL_ID.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.DEAL_ID.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.DEAL_ID.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.DEAL_ID.MAX_LENGTH,
     });
   });
 
@@ -143,8 +263,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'effectiveDate',
-      min: OVERVIEW_VALIDATION.EFFECTIVE_DATE.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.EFFECTIVE_DATE.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.EFFECTIVE_DATE.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.EFFECTIVE_DATE.MAX_LENGTH,
     });
   });
 
@@ -152,8 +272,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'endOfCoverDate',
-      min: OVERVIEW_VALIDATION.END_OF_COVER_DATE.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.END_OF_COVER_DATE.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.END_OF_COVER_DATE.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.END_OF_COVER_DATE.MAX_LENGTH,
     });
   });
 
@@ -161,8 +281,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'expiryDate',
-      min: OVERVIEW_VALIDATION.EXPIRY_DATE.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.EXPIRY_DATE.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.EXPIRY_DATE.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.EXPIRY_DATE.MAX_LENGTH,
     });
   });
 
@@ -170,7 +290,7 @@ describe('POST /gift/facility - validation', () => {
     numberValidation({
       ...baseParams,
       fieldName: 'facilityAmount',
-      min: OVERVIEW_VALIDATION.FACILITY_AMOUNT.MIN,
+      min: VALIDATION.FACILITY.OVERVIEW.FACILITY_AMOUNT.MIN,
     });
   });
 
@@ -178,8 +298,8 @@ describe('POST /gift/facility - validation', () => {
     ukefIdValidation({
       ...baseParams,
       fieldName: 'facilityId',
-      min: OVERVIEW_VALIDATION.FACILITY_ID.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.FACILITY_ID.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.FACILITY_ID.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.FACILITY_ID.MAX_LENGTH,
     });
   });
 
@@ -191,8 +311,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'name',
-      min: OVERVIEW_VALIDATION.FACILITY_NAME.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.FACILITY_NAME.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.FACILITY_NAME.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.FACILITY_NAME.MAX_LENGTH,
     });
   });
 
@@ -200,8 +320,8 @@ describe('POST /gift/facility - validation', () => {
     numberStringValidation({
       ...baseParams,
       fieldName: 'obligorUrn',
-      min: OVERVIEW_VALIDATION.OBLIGOR_URN.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.OBLIGOR_URN.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.OBLIGOR_URN.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.OBLIGOR_URN.MAX_LENGTH,
     });
   });
 
@@ -209,8 +329,8 @@ describe('POST /gift/facility - validation', () => {
     stringValidation({
       ...baseParams,
       fieldName: 'productType',
-      min: OVERVIEW_VALIDATION.PRODUCT_TYPE.MIN_LENGTH,
-      max: OVERVIEW_VALIDATION.PRODUCT_TYPE.MAX_LENGTH,
+      min: VALIDATION.FACILITY.OVERVIEW.PRODUCT_TYPE.MIN_LENGTH,
+      max: VALIDATION.FACILITY.OVERVIEW.PRODUCT_TYPE.MAX_LENGTH,
     });
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:

This PR improves API test coverage for the repayment profiles aspect of the "create facility" endpoint.

## Resolution :heavy_check_mark:

- Update `REPAYMENT_PROFILE.NAME` to have a minimum length of 1, instead of 0.
- Create new DRY test assertions:
  - `arrayOfNestedObjectsNumberValidation`
  - `arrayOfNestedObjectsStringValidation`
- Update `generatePayloadArrayOfObjects` to consume a `grandParentFieldName` param and return a nested array of objects with a provided field/value.
- Add API tests for repayment profiles.

## Miscellaneous :heavy_plus_sign:

- Add a missing `type` property.
- Improve `arrayOfObjectsNumberValidation` and `arrayOfObjectsStringValidation`  payload constructions.
- Update `assert400Response` to use `HttpStatus`.
- API test coverage improvements
