### PR TITLE
chore(GIFT-12084): remove invalid open api field

### DIFF
--- a/src/modules/gift/gift.currency.controller.ts
+++ b/src/modules/gift/gift.currency.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get, Res } from '@nestjs/common';
 import { ApiInternalServerErrorResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import AppConfig from '@ukef/config/app.config';
 import { GIFT } from '@ukef/constants';
-import { SUPPORTED_CURRENCIES } from '@ukef/constants/currencies.constant';
 import { Response } from 'express';
 
 import { GiftCurrencyService } from './gift.currency.service';
@@ -22,7 +21,6 @@ export class GiftCurrencyController {
   @ApiOperation({ summary: 'Get all supported GIFT currencies' })
   @ApiOkResponse({
     description: 'The supported currencies',
-    example: [SUPPORTED_CURRENCIES.EUR, SUPPORTED_CURRENCIES.GBP],
     isArray: true,
     type: String,
   })


### PR DESCRIPTION
## Introduction :pencil2:

The GIFT currency controller has an invalid Open API property. This causes deployment to fail.

## Resolution :heavy_check_mark:

- Remove invalid Open API property.