### PR TITLE
chore(GIFT-12306): handle forbidden statuses, dry mock responses

### DIFF
--- a/src/modules/gift/gift.http.service.test.ts
+++ b/src/modules/gift/gift.http.service.test.ts
@@ -44,7 +44,7 @@ describe('GiftHttpService', () => {
   describe('GIFT_API_ACCEPTABLE_STATUSES', () => {
     it('should return an array of statuses', () => {
       // Act & Assert
-      const expected = [HttpStatus.OK, HttpStatus.CREATED, HttpStatus.BAD_REQUEST, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_FOUND];
+      const expected = [HttpStatus.OK, HttpStatus.CREATED, HttpStatus.BAD_REQUEST, HttpStatus.FORBIDDEN, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_FOUND];
 
       expect(GIFT_API_ACCEPTABLE_STATUSES).toEqual(expected);
     });

--- a/src/modules/gift/gift.http.service.ts
+++ b/src/modules/gift/gift.http.service.ts
@@ -10,7 +10,14 @@ const { CONTENT_TYPE } = HEADERS;
  * Array of acceptable statuses to consume from a GIFT API response
  * @returns {Array<HttpStatus>}
  */
-export const GIFT_API_ACCEPTABLE_STATUSES = [HttpStatus.OK, HttpStatus.CREATED, HttpStatus.BAD_REQUEST, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_FOUND];
+export const GIFT_API_ACCEPTABLE_STATUSES = [
+  HttpStatus.OK,
+  HttpStatus.CREATED,
+  HttpStatus.BAD_REQUEST,
+  HttpStatus.FORBIDDEN,
+  HttpStatus.UNAUTHORIZED,
+  HttpStatus.NOT_FOUND,
+];
 
 /**
  * GIFT HTTP service.

--- a/test/gift/create-facility-approve-status-error-handling.api-test.ts
+++ b/test/gift/create-facility-approve-status-error-handling.api-test.ts
@@ -3,6 +3,7 @@ import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import {
@@ -20,6 +21,28 @@ import {
 const { API_RESPONSE_MESSAGES, PATH } = GIFT;
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
+
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock "approve status" response
+ */
+const setupMocks = (approveStatusResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
+
+  nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+  nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+  nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+  nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.badRequest);
+
+  nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(approveStatusResponse.statusCode, approveStatusResponse);
+};
 
 describe('POST /gift/facility - approve status error handling', () => {
   let api: Api;
@@ -40,21 +63,7 @@ describe('POST /gift/facility - approve status error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.approveStatus);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -74,21 +83,7 @@ describe('POST /gift/facility - approve status error handling', () => {
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.approveStatus);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -108,21 +103,7 @@ describe('POST /gift/facility - approve status error handling', () => {
   describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.FORBIDDEN, mockResponses.approveStatus);
+      setupMocks(mockResponses.forbidden);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -142,17 +123,7 @@ describe('POST /gift/facility - approve status error handling', () => {
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.approveStatus);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -167,17 +138,7 @@ describe('POST /gift/facility - approve status error handling', () => {
   describe(`when an unacceptable response is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.I_AM_A_TEAPOT, mockResponses.approveStatus);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/create-facility-approve-status-error-handling.api-test.ts
+++ b/test/gift/create-facility-approve-status-error-handling.api-test.ts
@@ -105,6 +105,40 @@ describe('POST /gift/facility - approve status error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT approve status endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(PATH.CREATE_FACILITY).reply(HttpStatus.CREATED, mockResponses.facility);
+
+      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
+
+      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.FORBIDDEN, mockResponses.approveStatus);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        statusCode: HttpStatus.FORBIDDEN,
+        message: API_RESPONSE_MESSAGES.APPROVED_STATUS_ERROR_MESSAGE,
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT approve status endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-counterparty-error-handling.api-test.ts
+++ b/test/gift/create-facility-counterparty-error-handling.api-test.ts
@@ -3,6 +3,7 @@ import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import {
@@ -24,6 +25,28 @@ const { API_RESPONSE_MESSAGES, ENTITY_NAMES } = GIFT;
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock counterparty response
+ */
+const setupMocks = (counterpartyResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+  nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(counterpartyResponse.statusCode, counterpartyResponse);
+
+  nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+  nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+  nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+  nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+};
+
 describe('POST /gift/facility - counterparty error handling', () => {
   let api: Api;
 
@@ -43,21 +66,7 @@ describe('POST /gift/facility - counterparty error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT counterparty endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with a mapped body/validation errors`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -75,58 +84,10 @@ describe('POST /gift/facility - counterparty error handling', () => {
     });
   });
 
-  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT counterparty endpoint`, () => {
-    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
-      // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
-
-      // Act
-      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
-
-      // Assert
-      expect(status).toBe(HttpStatus.FORBIDDEN);
-
-      const expected = {
-        ...mockResponses.forbidden,
-        validationErrors: getExpectedValidationErrors(payloadCounterparties, mockResponses.forbidden, ENTITY_NAMES.COUNTERPARTY),
-      };
-
-      expect(body).toStrictEqual(expected);
-    });
-  });
-
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT counterparty endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -143,24 +104,30 @@ describe('POST /gift/facility - counterparty error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT counterparty endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      setupMocks(mockResponses.forbidden);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        ...mockResponses.forbidden,
+        validationErrors: getExpectedValidationErrors(payloadCounterparties, mockResponses.forbidden, ENTITY_NAMES.COUNTERPARTY),
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT counterparty endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -175,21 +142,7 @@ describe('POST /gift/facility - counterparty error handling', () => {
   describe('when an unacceptable response is returned by the GIFT counterparty endpoint', () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.I_AM_A_TEAPOT);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/create-facility-counterparty-error-handling.api-test.ts
+++ b/test/gift/create-facility-counterparty-error-handling.api-test.ts
@@ -75,6 +75,40 @@ describe('POST /gift/facility - counterparty error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT counterparty endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        ...mockResponses.forbidden,
+        validationErrors: getExpectedValidationErrors(payloadCounterparties, mockResponses.forbidden, ENTITY_NAMES.COUNTERPARTY),
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT counterparty endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-creation-error-handling.api-test.ts
+++ b/test/gift/create-facility-creation-error-handling.api-test.ts
@@ -2,11 +2,24 @@ import { HttpStatus } from '@nestjs/common';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import { apimFacilityUrl, currencyUrl, facilityCreationUrl, feeTypeUrl, mockResponses } from './test-helpers';
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
+
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock "facility createion" response
+ */
+const setupMocks = (facilityCreationResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(facilityCreationUrl).reply(facilityCreationResponse.statusCode, facilityCreationResponse);
+};
 
 describe('POST /gift/facility - facility creation error handling', () => {
   let api: Api;
@@ -27,11 +40,7 @@ describe('POST /gift/facility - facility creation error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT facility endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -48,11 +57,7 @@ describe('POST /gift/facility - facility creation error handling', () => {
   describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT facility endpoint`, () => {
     it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+      setupMocks(mockResponses.forbidden);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -67,11 +72,7 @@ describe('POST /gift/facility - facility creation error handling', () => {
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT facility endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -86,11 +87,7 @@ describe('POST /gift/facility - facility creation error handling', () => {
   describe('when an unacceptable status is returned by the GIFT facility endpoint', () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.I_AM_A_TEAPOT);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -105,11 +102,7 @@ describe('POST /gift/facility - facility creation error handling', () => {
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT facility endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/create-facility-creation-error-handling.api-test.ts
+++ b/test/gift/create-facility-creation-error-handling.api-test.ts
@@ -45,6 +45,25 @@ describe('POST /gift/facility - facility creation error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT facility endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      expect(body).toStrictEqual(mockResponses.forbidden);
+    });
+  });
+
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT facility endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-fixed-fee-error-handling.api-test.ts
+++ b/test/gift/create-facility-fixed-fee-error-handling.api-test.ts
@@ -109,6 +109,40 @@ describe('POST /gift/facility - fixed fee error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT fixed fee endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
+
+      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        ...mockResponses.forbidden,
+        validationErrors: getExpectedValidationErrors(payloadFixedFees, mockResponses.forbidden, ENTITY_NAMES.FIXED_FEE),
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT fixed fee endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-fixed-fee-error-handling.api-test.ts
+++ b/test/gift/create-facility-fixed-fee-error-handling.api-test.ts
@@ -3,6 +3,7 @@ import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import {
@@ -24,6 +25,28 @@ const { API_RESPONSE_MESSAGES, ENTITY_NAMES } = GIFT;
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock "fixed fee" response
+ */
+const setupMocks = (fixedFeeResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+  nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+  nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(fixedFeeResponse.statusCode, fixedFeeResponse);
+
+  nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+  nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+  nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+};
+
 describe('POST /gift/facility - fixed fee error handling', () => {
   let api: Api;
 
@@ -43,21 +66,7 @@ describe('POST /gift/facility - fixed fee error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT fixed fee endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with a mapped body/validation errors`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -78,21 +87,7 @@ describe('POST /gift/facility - fixed fee error handling', () => {
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT fixed fee endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -112,21 +107,7 @@ describe('POST /gift/facility - fixed fee error handling', () => {
   describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT fixed fee endpoint`, () => {
     it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.forbidden);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -146,21 +127,7 @@ describe('POST /gift/facility - fixed fee error handling', () => {
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT fixed fee endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -175,21 +142,7 @@ describe('POST /gift/facility - fixed fee error handling', () => {
   describe('when an unacceptable response is returned by the GIFT fixed fee endpoint', () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.I_AM_A_TEAPOT);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/create-facility-obligation-error-handling.api-test.ts
+++ b/test/gift/create-facility-obligation-error-handling.api-test.ts
@@ -3,6 +3,7 @@ import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import {
@@ -24,6 +25,28 @@ const { API_RESPONSE_MESSAGES, ENTITY_NAMES } = GIFT;
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock obligation response
+ */
+const setupMocks = (obligationResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+  nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+  nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+  nock(GIFT_API_URL).persist().post(obligationUrl).reply(obligationResponse.statusCode, obligationResponse);
+
+  nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+  nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+};
+
 describe('POST /gift/facility - obligation error handling', () => {
   let api: Api;
 
@@ -43,21 +66,7 @@ describe('POST /gift/facility - obligation error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT obligation endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with a mapped body/validation errors`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -78,21 +87,7 @@ describe('POST /gift/facility - obligation error handling', () => {
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT obligation endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -112,21 +107,7 @@ describe('POST /gift/facility - obligation error handling', () => {
   describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT obligation endpoint`, () => {
     it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.forbidden);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -146,21 +127,7 @@ describe('POST /gift/facility - obligation error handling', () => {
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT obligation endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -175,21 +142,7 @@ describe('POST /gift/facility - obligation error handling', () => {
   describe('when an unacceptable response is returned by the GIFT obligation endpoint', () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.I_AM_A_TEAPOT);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/create-facility-obligation-error-handling.api-test.ts
+++ b/test/gift/create-facility-obligation-error-handling.api-test.ts
@@ -109,6 +109,40 @@ describe('POST /gift/facility - obligation error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT obligation endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.CREATED, mockResponses.repaymentProfile);
+
+      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        ...mockResponses.forbidden,
+        validationErrors: getExpectedValidationErrors(payloadObligations, mockResponses.forbidden, ENTITY_NAMES.OBLIGATION),
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT obligation endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-repayment-profile-error-handling.api-test.ts
+++ b/test/gift/create-facility-repayment-profile-error-handling.api-test.ts
@@ -109,6 +109,40 @@ describe('POST /gift/facility - repayment profile error handling', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT repayment profile endpoint`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+      // Act
+      const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+
+      const expected = {
+        ...mockResponses.forbidden,
+        validationErrors: getExpectedValidationErrors(payloadRepaymentProfiles, mockResponses.forbidden, ENTITY_NAMES.REPAYMENT_PROFILE),
+      };
+
+      expect(body).toStrictEqual(expected);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/create-facility-repayment-profile-error-handling.api-test.ts
+++ b/test/gift/create-facility-repayment-profile-error-handling.api-test.ts
@@ -3,6 +3,7 @@ import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 import nock from 'nock';
 
 import {
@@ -24,6 +25,28 @@ const { API_RESPONSE_MESSAGES, ENTITY_NAMES } = GIFT;
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
+/**
+ * Setup mocks for all endpoints.
+ * @param {MockGiftResponse} Mock "repayment profile" response
+ */
+const setupMocks = (repaymentProfileResponse: MockGiftResponse) => {
+  nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
+
+  nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
+
+  nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
+
+  nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
+
+  nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
+
+  nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
+
+  nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(repaymentProfileResponse.statusCode, repaymentProfileResponse);
+
+  nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+};
+
 describe('POST /gift/facility - repayment profile error handling', () => {
   let api: Api;
 
@@ -43,21 +66,7 @@ describe('POST /gift/facility - repayment profile error handling', () => {
   describe(`when a ${HttpStatus.BAD_REQUEST} response is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.BAD_REQUEST} response with a mapped body/validation errors`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.badRequest);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -78,21 +87,7 @@ describe('POST /gift/facility - repayment profile error handling', () => {
   describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.unauthorized);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -112,21 +107,7 @@ describe('POST /gift/facility - repayment profile error handling', () => {
   describe(`when a ${HttpStatus.FORBIDDEN} response is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.counterparty);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.forbidden);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -146,21 +127,7 @@ describe('POST /gift/facility - repayment profile error handling', () => {
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} status is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.badRequest);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.internalServerError);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
@@ -175,21 +142,7 @@ describe('POST /gift/facility - repayment profile error handling', () => {
   describe(`when an unacceptable response is returned by the GIFT repayment profile endpoint`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange
-      nock(GIFT_API_URL).persist().get(currencyUrl).reply(HttpStatus.OK, mockResponses.currencies);
-
-      nock(GIFT_API_URL).persist().get(feeTypeUrl).reply(HttpStatus.OK, mockResponses.feeTypes);
-
-      nock(GIFT_API_URL).post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
-
-      nock(GIFT_API_URL).persist().post(counterpartyUrl).reply(HttpStatus.CREATED);
-
-      nock(GIFT_API_URL).persist().post(fixedFeeUrl).reply(HttpStatus.CREATED, mockResponses.fixedFee);
-
-      nock(GIFT_API_URL).persist().post(obligationUrl).reply(HttpStatus.CREATED, mockResponses.obligation);
-
-      nock(GIFT_API_URL).persist().post(repaymentProfileUrl).reply(HttpStatus.I_AM_A_TEAPOT);
-
-      nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+      setupMocks(mockResponses.iAmATeapot);
 
       // Act
       const { status, body } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);

--- a/test/gift/get-currency-supported.api-test.ts
+++ b/test/gift/get-currency-supported.api-test.ts
@@ -90,6 +90,19 @@ describe('GET /gift/currency/supported', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by GIFT`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).get(CURRENCY).reply(HttpStatus.FORBIDDEN);
+
+      // Act
+      const { status } = await api.get(url);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} response is returned by GIFT`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/get-fee-type-supported.api-test.ts
+++ b/test/gift/get-fee-type-supported.api-test.ts
@@ -90,6 +90,19 @@ describe('GET /gift/fee-type/supported', () => {
     });
   });
 
+  describe(`when a ${HttpStatus.FORBIDDEN} response is returned by GIFT`, () => {
+    it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+      // Arrange
+      nock(GIFT_API_URL).get(FEE_TYPE).reply(HttpStatus.FORBIDDEN);
+
+      // Act
+      const { status } = await api.get(url);
+
+      // Assert
+      expect(status).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} response is returned by GIFT`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -2,6 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 import AppConfig from '@ukef/config/app.config';
 import { GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
+import { MockGiftResponse } from '@ukef-test/support/interfaces/mock-gift-response.interface';
 
 const {
   giftVersioning: { prefixAndVersion },
@@ -12,17 +13,39 @@ const { EVENT_TYPES, PATH, API_RESPONSE_TYPES } = GIFT;
 export const mockFacilityId = GIFT_EXAMPLES.FACILITY_ID;
 export const mockWorkPackageId = GIFT_EXAMPLES.WORK_PACKAGE_ID;
 
+const badRequest: MockGiftResponse = {
+  statusCode: HttpStatus.BAD_REQUEST,
+  message: 'Validation error',
+  validationErrors: [
+    {
+      path: ['fieldX'],
+      message: 'Invalid fieldX',
+    },
+  ],
+};
+
+const internalServerError: MockGiftResponse = {
+  statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+  message: 'Internal server error',
+};
+
+const forbidden: MockGiftResponse = {
+  statusCode: HttpStatus.FORBIDDEN,
+  message: 'Forbidden',
+};
+
+const unauthorized: MockGiftResponse = {
+  statusCode: HttpStatus.UNAUTHORIZED,
+  message: 'Unauthorized',
+};
+
+const iAmATeapot: MockGiftResponse = {
+  statusCode: HttpStatus.I_AM_A_TEAPOT,
+  message: 'Teapot',
+};
+
 export const mockResponses = {
-  badRequest: {
-    statusCode: HttpStatus.BAD_REQUEST,
-    message: 'Validation error',
-    validationErrors: [
-      {
-        path: ['fieldX'],
-        message: 'Invalid fieldX',
-      },
-    ],
-  },
+  badRequest,
   counterparty: { data: { aCounterparty: true } },
   currencies: GIFT_EXAMPLES.CURRENCIES,
   feeTypes: GIFT_EXAMPLES.FEE_TYPES_RESPONSE_DATA,
@@ -39,18 +62,10 @@ export const mockResponses = {
     },
   },
   approveStatus: { data: { aStatusUpdate: true } },
-  internalServerError: {
-    statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-    message: 'Internal server error',
-  },
-  forbidden: {
-    statusCode: HttpStatus.FORBIDDEN,
-    message: 'Forbidden',
-  },
-  unauthorized: {
-    statusCode: HttpStatus.UNAUTHORIZED,
-    message: 'Unauthorized',
-  },
+  internalServerError,
+  forbidden,
+  unauthorized,
+  iAmATeapot,
 };
 
 export const apimFacilityUrl = `/api/${prefixAndVersion}/gift${PATH.FACILITY}`;

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -43,6 +43,10 @@ export const mockResponses = {
     statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
     message: 'Internal server error',
   },
+  forbidden: {
+    statusCode: HttpStatus.FORBIDDEN,
+    message: 'Forbidden',
+  },
   unauthorized: {
     statusCode: HttpStatus.UNAUTHORIZED,
     message: 'Unauthorized',

--- a/test/support/interfaces/mock-gift-response.interface.ts
+++ b/test/support/interfaces/mock-gift-response.interface.ts
@@ -1,0 +1,5 @@
+export interface MockGiftResponse {
+  statusCode: number;
+  message: string;
+  validationErrors?: object[];
+}


### PR DESCRIPTION
## Introduction :pencil2:

This PR updates the GIFT integration to handle 403/Forbidden responses from GIFT.

As part of this PR, have also updated the API tests to have DRY mock endpoint responses,

## Resolution :heavy_check_mark:

- Update `GIFT_API_ACCEPTABLE_STATUSES` to include `HttpStatus.FORBIDDEN`.
- Update all API tests to include 403/Forbidden assertions.

## Miscellaneous :heavy_plus_sign:

- Update appropriate API tests to have a DRY `setupMocks` function.
- Update test helpers to create mock responses with a new `MockGiftResponse` interface.