### PR TITLE
fix(GIFT-13101): counterparty sharePercentage validation

### DIFF
--- a/src/modules/gift/dto/request/counterparty.ts
+++ b/src/modules/gift/dto/request/counterparty.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EXAMPLES, GIFT } from '@ukef/constants';
-import { IsDateString, IsDefined, IsString, Length } from 'class-validator';
+import { IsDateString, IsDefined, IsNumber, IsOptional, IsString, Length } from 'class-validator';
 
 const {
   GIFT: { COUNTERPARTY },
@@ -43,6 +43,8 @@ export class GiftFacilityCounterpartyRequestDto {
   })
   roleCode: string;
 
+  @IsOptional()
+  @IsNumber()
   @ApiProperty({
     example: EXAMPLE.sharePercentage,
     description: "Required if a counterparty's role's hasSharePercentage field is true",

--- a/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.test.ts
+++ b/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.test.ts
@@ -30,13 +30,13 @@ const mockCounterpartyRoles: GiftFacilityCounterpartyRoleResponseDto[] = [
 ];
 
 describe('modules/gift/helpers/generate-counterparty-share-percentage-errors', () => {
-  describe('when all provided roles require a sharePercentage, but is not provided', () => {
+  describe('when all provided roles require a sharePercentage, but are not provided', () => {
     it('should return an array with validation errors', () => {
       // Arrange
       const mockProvidedRoles = [
-        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: null },
-        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: null },
-        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: null },
+        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2' },
+        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2' },
+        { ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2' },
       ];
 
       // Act

--- a/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.test.ts
+++ b/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.test.ts
@@ -56,6 +56,58 @@ describe('modules/gift/helpers/generate-counterparty-share-percentage-errors', (
     });
   });
 
+  describe(`when a provided role requires a sharePercentage, is provided and below ${MIN}`, () => {
+    it('should return an array with validation errors', () => {
+      // Arrange
+      const mockProvidedRoles = [{ ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: MIN - 1 }];
+
+      // Act
+      const result = generateCounterpartySharePercentageErrors({
+        counterpartyRoles: mockCounterpartyRoles,
+        providedCounterparties: mockProvidedRoles,
+      });
+
+      // Assert
+      const expected = [`counterparties.0.sharePercentage must be a provided as a number, at least ${MIN} and not greater than ${MAX}`];
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when a provided role requires a sharePercentage, is provided and above ${MAX}`, () => {
+    it('should return an array with validation errors', () => {
+      // Arrange
+      const mockProvidedRoles = [{ ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: MAX + 1 }];
+
+      // Act
+      const result = generateCounterpartySharePercentageErrors({
+        counterpartyRoles: mockCounterpartyRoles,
+        providedCounterparties: mockProvidedRoles,
+      });
+
+      // Assert
+      const expected = [`counterparties.0.sharePercentage must be a provided as a number, at least ${MIN} and not greater than ${MAX}`];
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when a provided role requires a sharePercentage, is provided and between ${MIN} and ${MAX}`, () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const mockProvidedRoles = [{ ...EXAMPLES.GIFT.COUNTERPARTY(), roleCode: '2', sharePercentage: MAX - 1 }];
+
+      // Act
+      const result = generateCounterpartySharePercentageErrors({
+        counterpartyRoles: mockCounterpartyRoles,
+        providedCounterparties: mockProvidedRoles,
+      });
+
+      // Assert
+      expect(result).toStrictEqual([]);
+    });
+  });
+
   describe('when one provided role requires a sharePercentage, but is not provided', () => {
     it('should return an array with validation errors', () => {
       // Arrange

--- a/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.ts
+++ b/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.ts
@@ -50,9 +50,14 @@ export const generateCounterpartySharePercentageErrors = ({
      * If the GIFT role hasSharePercentage flag is true,
      * and no sharePercentage is provided,
      * or if a provided sharePercentage is not within the MIN/MAX range,
-     * return an error.
+     * return a validation error.
      */
-    if (giftRole?.hasSharePercentage && (!sharePercentage || (sharePercentage && (sharePercentage < MIN || sharePercentage > MAX)))) {
+    const sharePercentageRequired = giftRole?.hasSharePercentage;
+    const sharePercentageLessThanMin = sharePercentage < MIN;
+    const sharePercentageGreaterThanMax = sharePercentage > MAX;
+    const invalidSharePercentage = !sharePercentage || sharePercentageLessThanMin || sharePercentageGreaterThanMax;
+
+    if (sharePercentageRequired && invalidSharePercentage) {
       validationErrors.push(`counterparties.${index}.sharePercentage must be a provided as a number, at least ${MIN} and not greater than ${MAX}`);
     }
   });

--- a/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.ts
+++ b/src/modules/gift/helpers/generate-counterparty-share-percentage-errors/index.ts
@@ -42,11 +42,17 @@ export const generateCounterpartySharePercentageErrors = ({
   const validationErrors = [];
 
   providedCounterparties.forEach((role: GiftFacilityCounterpartyRequestDto, index: number) => {
-    const { roleCode: providedRoleCode, sharePercentage: providedSharePercentage } = role;
+    const { roleCode: providedRoleCode, sharePercentage } = role;
 
     const giftRole = counterpartyRoles.find((giftRole: GiftFacilityCounterpartyRoleResponseDto) => giftRole.code === providedRoleCode);
 
-    if (giftRole?.hasSharePercentage && !providedSharePercentage) {
+    /**
+     * If the GIFT role hasSharePercentage flag is true,
+     * and no sharePercentage is provided,
+     * or if a provided sharePercentage is not within the MIN/MAX range,
+     * return an error.
+     */
+    if (giftRole?.hasSharePercentage && (!sharePercentage || (sharePercentage && (sharePercentage < MIN || sharePercentage > MAX)))) {
       validationErrors.push(`counterparties.${index}.sharePercentage must be a provided as a number, at least ${MIN} and not greater than ${MAX}`);
     }
   });

--- a/test/gift/assertions/array-of-objects-share-percentage-validation.ts
+++ b/test/gift/assertions/array-of-objects-share-percentage-validation.ts
@@ -126,27 +126,17 @@ export const arrayOfObjectsSharePercentageValidation = ({ parentFieldName, initi
       assert400Response(response);
     });
 
-    it('should return the correct body.message', async () => {
-      // Act
-      const { body } = await api.post(url, mockPayload);
-
-      // Assert
-      const expected = API_RESPONSE_MESSAGES.ASYNC_FACILITY_VALIDATION_ERRORS;
-
-      expect(body.message).toStrictEqual(expected);
-    });
-
-    it('should return the correct body.validationErrors', async () => {
+    it('should return the correct error messages', async () => {
       // Act
       const { body } = await api.post(url, mockPayload);
 
       // Assert
       const expected = [
-        `${parentFieldName}.0.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
-        `${parentFieldName}.1.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
+        `${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
       ];
 
-      expect(body.validationErrors).toStrictEqual(expected);
+      expect(body.message).toStrictEqual(expected);
     });
   });
 
@@ -166,27 +156,17 @@ export const arrayOfObjectsSharePercentageValidation = ({ parentFieldName, initi
       assert400Response(response);
     });
 
-    it('should return the correct body.message', async () => {
-      // Act
-      const { body } = await api.post(url, mockPayload);
-
-      // Assert
-      const expected = API_RESPONSE_MESSAGES.ASYNC_FACILITY_VALIDATION_ERRORS;
-
-      expect(body.message).toStrictEqual(expected);
-    });
-
-    it('should return the correct body.validationErrors', async () => {
+    it('should return the correct error messages', async () => {
       // Act
       const { body } = await api.post(url, mockPayload);
 
       // Assert
       const expected = [
-        `${parentFieldName}.0.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
-        `${parentFieldName}.1.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
+        `${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
       ];
 
-      expect(body.validationErrors).toStrictEqual(expected);
+      expect(body.message).toStrictEqual(expected);
     });
   });
 
@@ -206,27 +186,17 @@ export const arrayOfObjectsSharePercentageValidation = ({ parentFieldName, initi
       assert400Response(response);
     });
 
-    it('should return the correct body.message', async () => {
-      // Act
-      const { body } = await api.post(url, mockPayload);
-
-      // Assert
-      const expected = API_RESPONSE_MESSAGES.ASYNC_FACILITY_VALIDATION_ERRORS;
-
-      expect(body.message).toStrictEqual(expected);
-    });
-
-    it('should return the correct body.validationErrors', async () => {
+    it('should return the correct error messages', async () => {
       // Act
       const { body } = await api.post(url, mockPayload);
 
       // Assert
       const expected = [
-        `${parentFieldName}.0.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
-        `${parentFieldName}.1.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
+        `${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
       ];
 
-      expect(body.validationErrors).toStrictEqual(expected);
+      expect(body.message).toStrictEqual(expected);
     });
   });
 
@@ -246,27 +216,17 @@ export const arrayOfObjectsSharePercentageValidation = ({ parentFieldName, initi
       assert400Response(response);
     });
 
-    it('should return the correct body.message', async () => {
-      // Act
-      const { body } = await api.post(url, mockPayload);
-
-      // Assert
-      const expected = API_RESPONSE_MESSAGES.ASYNC_FACILITY_VALIDATION_ERRORS;
-
-      expect(body.message).toStrictEqual(expected);
-    });
-
-    it('should return the correct body.validationErrors', async () => {
+    it('should return the correct error messages', async () => {
       // Act
       const { body } = await api.post(url, mockPayload);
 
       // Assert
       const expected = [
-        `${parentFieldName}.0.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
-        `${parentFieldName}.1.${fieldName} must be a provided as a number, at least ${min} and not greater than ${max}`,
+        `${parentFieldName}.0.${fieldName} must be a number conforming to the specified constraints`,
+        `${parentFieldName}.1.${fieldName} must be a number conforming to the specified constraints`,
       ];
 
-      expect(body.validationErrors).toStrictEqual(expected);
+      expect(body.message).toStrictEqual(expected);
     });
   });
 

--- a/test/gift/create-facility-validation-counterparties-share-percentage.api-test.ts
+++ b/test/gift/create-facility-validation-counterparties-share-percentage.api-test.ts
@@ -59,7 +59,7 @@ describe('POST /gift/facility - validation - counterparties - share percentage',
     url,
   };
 
-  describe('when a counterparty role requires a sharePercentage and a sharePercentage is NOT provided', () => {
+  describe('when a counterparty role requires a sharePercentage', () => {
     arrayOfObjectsSharePercentageValidation(baseParams);
   });
 });


### PR DESCRIPTION
# Introduction :pencil2:

Counterparty `sharePercentage` validation has been recently updated and no longer handled some validation scenarios correctly.

## Resolution :heavy_check_mark:

- Update counterparty request DTO.
- Update `generateCounterpartySharePercentageErrors` to check for MIN/MAX.
- Update API tests.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
