### PR TITLE
fix(GIFT-13320): approve work package notes

### DIFF
--- a/src/modules/gift/services/gift.facility.service/index.ts
+++ b/src/modules/gift/services/gift.facility.service/index.ts
@@ -185,7 +185,7 @@ export class GiftFacilityService {
       const approvedStatusResponse = await this.giftStatusService.approved(facilityId, workPackageId);
 
       if (approvedStatusResponse.status !== HttpStatus.OK) {
-        this.logger.info('Creating a GIFT facility - approved status update failed %s', facilityId);
+        this.logger.info('Creating a GIFT facility - approved status update failed %s %o', facilityId, approvedStatusResponse);
 
         return {
           status: approvedStatusResponse.status,

--- a/src/modules/gift/services/gift.status.service.test.ts
+++ b/src/modules/gift/services/gift.status.service.test.ts
@@ -52,6 +52,7 @@ describe('GiftStatusService', () => {
 
       expect(mockHttpServicePost).toHaveBeenCalledWith({
         path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.APPROVE}`,
+        payload: { notes: '' },
       });
     });
 

--- a/src/modules/gift/services/gift.status.service.ts
+++ b/src/modules/gift/services/gift.status.service.ts
@@ -33,6 +33,7 @@ export class GiftStatusService {
 
       const response = await this.giftHttpService.post({
         path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.APPROVE}`,
+        payload: { notes: '' },
       });
 
       return response;


### PR DESCRIPTION
# Introduction :pencil2:

GIFT has been updated so that the facility work package `/approve` endpoint requires notes to be sent.

This is intended for the GIFT user journey side of things. For API integration, notes are not allowed - an empty `notes` string needs to be sent to GIFT.

## Resolution :heavy_check_mark:

- Update `GiftStatusService.approved`.
- Minor logging improvement for future debugging.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
