### PR TITLE
chore(GIFT-13373): update gift event names

### DIFF
--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -24,8 +24,8 @@ export const GIFT = {
     ADD_COUNTERPARTY: 'AddFacilityCounterparty',
     ADD_MANUAL_REPAYMENT_PROFILE: 'AddManualRepaymentProfile',
     CREATE_FACILITY: 'CreateFacility',
-    CREATE_FIXED_FEE: 'CreateFixedFee',
-    CREATE_OBLIGATION: 'CreateObligation',
+    ADD_FIXED_FEE: 'AddFixedFee',
+    ADD_OBLIGATION: 'AddObligation',
   },
   FEE_TYPE_CODES: {
     BEX: 'BEX',

--- a/src/modules/gift/services/gift.fixed-fee.service.test.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.test.ts
@@ -53,7 +53,7 @@ describe('GiftFixedFeeService', () => {
       expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
 
       expect(mockHttpServicePost).toHaveBeenCalledWith({
-        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_FIXED_FEE}`,
+        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_FIXED_FEE}`,
         payload: mockFixedFee,
       });
     });

--- a/src/modules/gift/services/gift.fixed-fee.service.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.ts
@@ -34,7 +34,7 @@ export class GiftFixedFeeService {
       this.logger.info('Creating a fixed fee with description %s for facility %s', fixedFeeData.description, facilityId);
 
       const response = await this.giftHttpService.post<GiftFixedFeeRequestDto>({
-        path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_FIXED_FEE}`,
+        path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_FIXED_FEE}`,
         payload: fixedFeeData,
       });
 

--- a/src/modules/gift/services/gift.obligation.service.test.ts
+++ b/src/modules/gift/services/gift.obligation.service.test.ts
@@ -53,7 +53,7 @@ describe('GiftObligationService', () => {
       expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
 
       expect(mockHttpServicePost).toHaveBeenCalledWith({
-        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_OBLIGATION}`,
+        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_OBLIGATION}`,
         payload: mockObligation,
       });
     });

--- a/src/modules/gift/services/gift.obligation.service.ts
+++ b/src/modules/gift/services/gift.obligation.service.ts
@@ -34,7 +34,7 @@ export class GiftObligationService {
       this.logger.info('Creating an obligation with amount %s for facility %s', obligationData.amount, facilityId);
 
       const response = await this.giftHttpService.post<GiftObligationRequestDto>({
-        path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_OBLIGATION}`,
+        path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_OBLIGATION}`,
         payload: obligationData,
       });
 

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -88,8 +88,8 @@ export const feeTypeUrl = PATH.FEE_TYPE;
 export const obligationSubtypeUrl = PATH.OBLIGATION_SUBTYPE;
 export const productTypeUrl = `${PATH.PRODUCT_TYPE}/${PRODUCT_TYPE_CODES.EXIP}`;
 export const counterpartyUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_COUNTERPARTY}`;
-export const fixedFeeUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_FIXED_FEE}`;
-export const obligationUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.CREATE_OBLIGATION}`;
+export const fixedFeeUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_FIXED_FEE}`;
+export const obligationUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_OBLIGATION}`;
 export const repaymentProfileUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_MANUAL_REPAYMENT_PROFILE}`;
 export const approveStatusUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.APPROVE}`;
 


### PR DESCRIPTION
# Introduction :pencil2:

GIFT has renamed some events to be "add" instead of "create".

Therefore, this change needs to be reflected in APIM TFS.

## Resolution :heavy_check_mark:

- Update "add" events to be "create".

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
