### PR TITLE
chore(github-actions): actions/checkout@v5

### DIFF
--- a/.github/actions/acr/action.yml
+++ b/.github/actions/acr/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Step 2: Log in to Azure.
     - name: Azure 🔐

--- a/.github/actions/notify/action.yml
+++ b/.github/actions/notify/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Step 2: Dispatch notification
     - name: Notification 🔔

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: [self-hosted, APIM, deployment]
     steps:
       - name: Repository 🗃️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure 🔐
         uses: azure/login@v1

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -44,7 +44,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -99,7 +99,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -127,7 +127,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -155,7 +155,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create
         uses: googleapis/release-please-action@v4

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Subscription 🛠️
         run: |

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Codacy
         uses: codacy/codacy-analysis-cli-action@master
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         working-directory: ./
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fossa
         uses: fossas/fossa-action@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -85,7 +85,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -114,7 +114,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Introduction :pencil2:

Update GitHub actions checkout plugin to latest version.

## Resolution :heavy_check_mark:

* Updated to `actions/checkout@v5`.