### PR TITLE
chore(APIM-618): only run commit hooks on staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "unit-test": "jest --selectProjects=Unit",
     "unit-test-dev": "jest --verbose --config=jest.config.ts",
     "validate:all": "npm run lint:fix && npm run prettier:fix && npm run type-check && npm run validate:yml && npm run validate:md",
-    "validate:md": "npx markdownlint-cli --config .markdownlint.json '**/*.md'",
+    "validate:md": "npx markdownlint-cli --config .markdownlint.json \"**/*.md\"",
     "validate:yml": "npx yaml-lint **/*.yml --ignore=**/node_modules"
   },
   "lint-staged": {
@@ -35,10 +35,10 @@
     ],
     "**/*.md": [
       "prettier --write",
-      "npm run validate:md"
+      "npx markdownlint-cli --config .markdownlint.json"
     ],
     "**/*.yml": [
-      "npm run validate:yml"
+      "npx yaml-lint --ignore=**/node_modules"
     ],
     "**/*": [
       "cspell lint --gitignore --no-must-find-files --unique --no-progress --show-suggestions --color"


### PR DESCRIPTION
# Introduction :pencil2:

`.md` and `.yml` validation was running in commit hooks even if no such files were staged.

## Resolution :heavy_check_mark:

- Update `package.json`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
