### PR TITLE
chore(GIFT-20088-20412): catch error causes, amendment api tests

### DIFF
--- a/src/modules/gift/services/gift.business-calendar.service.test.ts
+++ b/src/modules/gift/services/gift.business-calendar.service.test.ts
@@ -74,9 +74,11 @@ describe('GiftBusinessCalendarService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -93,7 +95,7 @@ describe('GiftBusinessCalendarService', () => {
         });
 
         // Assert
-        const expected = new Error(`Error creating a business calendar for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating a business calendar for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.business-calendar.service.ts
+++ b/src/modules/gift/services/gift.business-calendar.service.ts
@@ -53,7 +53,7 @@ export class GiftBusinessCalendarService {
     } catch (error) {
       this.logger.error('Error creating a business calendar for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating a business calendar for facility ${facilityId}`, error);
+      throw new Error(`Error creating a business calendar for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.business-calendars-convention.service.test.ts
+++ b/src/modules/gift/services/gift.business-calendars-convention.service.test.ts
@@ -73,9 +73,11 @@ describe('GiftBusinessCalendarsConventionService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -90,7 +92,7 @@ describe('GiftBusinessCalendarsConventionService', () => {
         });
 
         // Assert
-        const expected = new Error(`Error creating business calendars convention for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating business calendars convention for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.business-calendars-convention.service.ts
+++ b/src/modules/gift/services/gift.business-calendars-convention.service.ts
@@ -50,7 +50,7 @@ export class GiftBusinessCalendarsConventionService {
     } catch (error) {
       this.logger.error('Error creating business calendars convention for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating business calendars convention for facility ${facilityId}`, error);
+      throw new Error(`Error creating business calendars convention for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.counterparty.service.test.ts
+++ b/src/modules/gift/services/gift.counterparty.service.test.ts
@@ -70,11 +70,9 @@ describe('GiftCounterpartyService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
-      const mockError = mockResponse500();
-
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
         giftHttpService.post = mockHttpServicePost;
 
         service = new GiftCounterpartyService(giftHttpService, logger);
@@ -85,9 +83,7 @@ describe('GiftCounterpartyService', () => {
         const promise = service.createOne(mockCounterparty, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a counterparty with URN ${mockCounterparty.counterpartyUrn} for facility ${mockFacilityId}`, {
-          cause: mockError,
-        });
+        const expected = new Error(`Error creating a counterparty with URN ${mockCounterparty.counterpartyUrn} for facility ${mockFacilityId}`);
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.counterparty.service.test.ts
+++ b/src/modules/gift/services/gift.counterparty.service.test.ts
@@ -70,10 +70,11 @@ describe('GiftCounterpartyService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
-
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
         service = new GiftCounterpartyService(giftHttpService, logger);
@@ -84,7 +85,9 @@ describe('GiftCounterpartyService', () => {
         const promise = service.createOne(mockCounterparty, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a counterparty with URN ${mockCounterparty.counterpartyUrn} for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating a counterparty with URN ${mockCounterparty.counterpartyUrn} for facility ${mockFacilityId}`, {
+          cause: mockError,
+        });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -140,9 +143,11 @@ describe('GiftCounterpartyService', () => {
     });
 
     describe('when service.createOne returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockCreateOne = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockCreateOne = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftCounterpartyService(giftHttpService, logger);
 
@@ -154,7 +159,7 @@ describe('GiftCounterpartyService', () => {
         const promise = service.createMany(mockCounterparties, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating counterparties for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating counterparties for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -212,9 +217,11 @@ describe('GiftCounterpartyService', () => {
     });
 
     describe('when giftHttpService.get returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.get = mockHttpServiceGet;
 
@@ -226,7 +233,7 @@ describe('GiftCounterpartyService', () => {
         const promise = service.getAllRoles();
 
         // Assert
-        const expected = new Error('Error getting all counterparty roles');
+        const expected = new Error('Error getting all counterparty roles', { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.counterparty.service.ts
+++ b/src/modules/gift/services/gift.counterparty.service.ts
@@ -43,7 +43,7 @@ export class GiftCounterpartyService {
     } catch (error) {
       this.logger.error('Error creating a counterparty with URN %s for facility %s %o', counterpartyData.counterpartyUrn, facilityId, error);
 
-      throw new Error(`Error creating a counterparty with URN ${counterpartyData.counterpartyUrn} for facility ${facilityId}`, { cause: error });
+      throw new Error(`Error creating a counterparty with URN ${counterpartyData.counterpartyUrn} for facility ${facilityId}`);
     }
   }
 

--- a/src/modules/gift/services/gift.counterparty.service.ts
+++ b/src/modules/gift/services/gift.counterparty.service.ts
@@ -43,7 +43,7 @@ export class GiftCounterpartyService {
     } catch (error) {
       this.logger.error('Error creating a counterparty with URN %s for facility %s %o', counterpartyData.counterpartyUrn, facilityId, error);
 
-      throw new Error(`Error creating a counterparty with URN ${counterpartyData.counterpartyUrn} for facility ${facilityId}`, error);
+      throw new Error(`Error creating a counterparty with URN ${counterpartyData.counterpartyUrn} for facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -77,7 +77,7 @@ export class GiftCounterpartyService {
     } catch (error) {
       this.logger.error('Error creating counterparties for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating counterparties for facility ${facilityId}`, error);
+      throw new Error(`Error creating counterparties for facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -98,7 +98,7 @@ export class GiftCounterpartyService {
     } catch (error) {
       this.logger.error('Error getting all counterparty roles %o', error);
 
-      throw new Error('Error getting all counterparty roles', error);
+      throw new Error('Error getting all counterparty roles', { cause: error });
     }
   }
 
@@ -118,7 +118,7 @@ export class GiftCounterpartyService {
     } catch (error) {
       this.logger.error('Error getting all counterparty role codes %o', error);
 
-      throw new Error('Error getting all counterparty role codes', error);
+      throw new Error('Error getting all counterparty role codes', { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.currency.service.test.ts
+++ b/src/modules/gift/services/gift.currency.service.test.ts
@@ -54,9 +54,11 @@ describe('GiftCurrencyService', () => {
     });
 
     describe('when giftHttpService.get returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.get = mockHttpServiceGet;
 
@@ -68,7 +70,7 @@ describe('GiftCurrencyService', () => {
         const promise = service.getSupportedCurrencies();
 
         // Assert
-        const expected = new Error('Error getting supported currencies');
+        const expected = new Error('Error getting supported currencies', { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.currency.service.ts
+++ b/src/modules/gift/services/gift.currency.service.ts
@@ -37,7 +37,7 @@ export class GiftCurrencyService {
     } catch (error) {
       this.logger.error('Error getting supported currencies %o', error);
 
-      throw new Error('Error getting supported currencies', error);
+      throw new Error('Error getting supported currencies', { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.facility-async-validation.service.test.ts
+++ b/src/modules/gift/services/gift.facility-async-validation.service.test.ts
@@ -28,6 +28,8 @@ const mockCounterpartyRoleCodes = [COUNTERPARTY_ROLES_RESPONSE_DATA.counterparty
 
 const mockObligationSubtypes = OBLIGATION_SUBTYPES_RESPONSE_DATA.obligationSubtypes;
 
+const mockError = mockResponse500();
+
 describe('GiftFacilityAsyncValidationService', () => {
   const logger = new PinoLogger({});
 
@@ -198,7 +200,7 @@ describe('GiftFacilityAsyncValidationService', () => {
     describe('when feeTypeService.getAllFeeTypeCodes returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockGetAllFeeTypeCodes = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetAllFeeTypeCodes = jest.fn().mockRejectedValueOnce(mockError);
 
         feeTypeService.getAllFeeTypeCodes = mockGetAllFeeTypeCodes;
 
@@ -217,7 +219,7 @@ describe('GiftFacilityAsyncValidationService', () => {
         const promise = service.creation(mockPayload, mockFacilityId);
 
         // Assert
-        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`);
+        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -226,7 +228,7 @@ describe('GiftFacilityAsyncValidationService', () => {
     describe('when currencyService.getSupportedCurrencies returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockGetSupportedCurrencies = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetSupportedCurrencies = jest.fn().mockRejectedValueOnce(mockError);
 
         currencyService.getSupportedCurrencies = mockGetSupportedCurrencies;
 
@@ -245,7 +247,7 @@ describe('GiftFacilityAsyncValidationService', () => {
         const promise = service.creation(mockPayload, mockFacilityId);
 
         // Assert
-        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`);
+        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -254,7 +256,7 @@ describe('GiftFacilityAsyncValidationService', () => {
     describe('when productTypeService.isSupported returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockProductTypeIsSupported = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockProductTypeIsSupported = jest.fn().mockRejectedValueOnce(mockError);
 
         productTypeService.isSupported = mockProductTypeIsSupported;
 
@@ -273,7 +275,7 @@ describe('GiftFacilityAsyncValidationService', () => {
         const promise = service.creation(mockPayload, mockFacilityId);
 
         // Assert
-        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`);
+        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -282,7 +284,7 @@ describe('GiftFacilityAsyncValidationService', () => {
     describe('when obligationSubtypeService.getAllByProductType returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockGetAllByProductType = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetAllByProductType = jest.fn().mockRejectedValueOnce(mockError);
 
         obligationSubtypeService.getAllByProductType = mockGetAllByProductType;
 
@@ -301,7 +303,7 @@ describe('GiftFacilityAsyncValidationService', () => {
         const promise = service.creation(mockPayload, mockFacilityId);
 
         // Assert
-        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`);
+        const expected = new Error(`Error validating a GIFT facility - async ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.facility-async-validation.service.ts
+++ b/src/modules/gift/services/gift.facility-async-validation.service.ts
@@ -118,7 +118,7 @@ export class GiftFacilityAsyncValidationService {
     } catch (error) {
       this.logger.error('Error validating a GIFT facility - async %s %o', facilityId, error);
 
-      throw new Error(`Error validating a GIFT facility - async ${facilityId}`, error);
+      throw new Error(`Error validating a GIFT facility - async ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-async-validation-errors.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-async-validation-errors.test.ts
@@ -223,9 +223,11 @@ describe('GiftFacilityService.create - async validation errors', () => {
   });
 
   describe('when asyncValidationService.creation throws an error', () => {
+    const mockError = mockAxiosError();
+
     beforeEach(() => {
       // Arrange
-      asyncValidationServiceCreationSpy = jest.fn().mockRejectedValueOnce(mockAxiosError());
+      asyncValidationServiceCreationSpy = jest.fn().mockRejectedValueOnce(mockError);
 
       asyncValidationService.creation = asyncValidationServiceCreationSpy;
 
@@ -249,7 +251,7 @@ describe('GiftFacilityService.create - async validation errors', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
@@ -44,6 +44,7 @@ const mockObligations = [OBLIGATION(), OBLIGATION(), OBLIGATION()];
 const mockRepaymentProfiles = [REPAYMENT_PROFILE(), REPAYMENT_PROFILE(), REPAYMENT_PROFILE()];
 const mockRiskDetails = RISK_DETAILS;
 
+const mockAsyncValidationServiceCreationResponse = [];
 const mockCreateBusinessCalendarResponse = mockResponse201({ data: mockBusinessCalendar });
 const mockCreateBusinessCalendarsConventionResponse = mockResponse201({ data: BUSINESS_CALENDAR });
 const mockCreateCounterpartiesResponse = mockCounterparties.map((counterparty) => mockResponse201(counterparty));
@@ -119,6 +120,7 @@ describe('GiftFacilityService.create - error handling', () => {
     riskDetailsService = new GiftRiskDetailsService(giftHttpService, logger);
     statusService = new GiftStatusService(giftHttpService, logger);
 
+    asyncValidationServiceCreationSpy = jest.fn().mockResolvedValueOnce(mockAsyncValidationServiceCreationResponse);
     createInitialFacilitySpy = jest.fn().mockResolvedValueOnce(mockResponse201(FACILITY_RESPONSE_DATA));
     createBusinessCalendarSpy = jest.fn().mockResolvedValueOnce(mockCreateBusinessCalendarResponse);
     createBusinessCalendarsConventionSpy = jest.fn().mockResolvedValueOnce(mockCreateBusinessCalendarsConventionResponse);

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
@@ -86,6 +86,8 @@ describe('GiftFacilityService.create - error handling', () => {
     validationErrors: [{ mock: true }],
   };
 
+  const mockError = mockAxiosError({ data: mockAxiosErrorData, status: HttpStatus.BAD_REQUEST });
+
   beforeEach(() => {
     // Arrange
     mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockHttpPostResponse);
@@ -161,7 +163,7 @@ describe('GiftFacilityService.create - error handling', () => {
   describe('when giftFacilityService.createInitialFacility throws an error', () => {
     beforeEach(() => {
       // Arrange
-      createInitialFacilitySpy = jest.fn().mockRejectedValueOnce(mockAxiosError({ data: mockAxiosErrorData, status: HttpStatus.BAD_REQUEST }));
+      createInitialFacilitySpy = jest.fn().mockRejectedValueOnce(mockError);
 
       service = new GiftFacilityService(
         giftHttpService,
@@ -185,7 +187,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });
@@ -194,7 +196,7 @@ describe('GiftFacilityService.create - error handling', () => {
   describe('when counterpartyService.createMany throws an error', () => {
     beforeEach(() => {
       // Arrange
-      createCounterpartiesSpy = jest.fn().mockRejectedValueOnce(mockAxiosError({ data: mockAxiosErrorData, status: HttpStatus.BAD_REQUEST }));
+      createCounterpartiesSpy = jest.fn().mockRejectedValueOnce(mockError);
 
       counterpartyService.createMany = createCounterpartiesSpy;
 
@@ -229,9 +231,9 @@ describe('GiftFacilityService.create - error handling', () => {
   describe('when fixedFeeService.createMany throws an error', () => {
     beforeEach(() => {
       // Arrange
-      createFixedFeesSpy = jest.fn().mockRejectedValueOnce(mockAxiosError({ data: mockAxiosErrorData, status: HttpStatus.BAD_REQUEST }));
+      createFixedFeesSpy = jest.fn().mockRejectedValueOnce(mockError);
 
-      counterpartyService.createMany = createFixedFeesSpy;
+      fixedFeeService.createMany = createFixedFeesSpy;
 
       service = new GiftFacilityService(
         giftHttpService,
@@ -255,7 +257,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });
@@ -290,7 +292,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });
@@ -325,7 +327,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });
@@ -360,7 +362,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });
@@ -395,7 +397,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-createFacility-error-handling.test.ts
@@ -222,7 +222,7 @@ describe('GiftFacilityService.create - error handling', () => {
       const response = service.create(mockPayload, mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(response).rejects.toThrow(expected);
     });

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-createInitialFacility.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-createInitialFacility.test.ts
@@ -118,9 +118,11 @@ describe('GiftFacilityService.createInitialFacility', () => {
   });
 
   describe('when giftHttpService.post returns an error', () => {
+    const mockError = mockResponse500();
+
     beforeEach(() => {
       // Arrange
-      mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+      mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
       giftHttpService.post = mockHttpServicePost;
 
@@ -144,7 +146,7 @@ describe('GiftFacilityService.createInitialFacility', () => {
       const promise = service.createInitialFacility(mockPayload.overview);
 
       // Assert
-      const expected = new Error(`Error creating an initial GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error creating an initial GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(promise).rejects.toThrow(expected);
     });

--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-get.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-get.test.ts
@@ -117,9 +117,11 @@ describe('GiftFacilityService.get', () => {
   });
 
   describe('when giftHttpService.get returns an error', () => {
+    const mockError = mockResponse500();
+
     beforeEach(() => {
       // Arrange
-      mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+      mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
       giftHttpService.get = mockHttpServiceGet;
 
@@ -143,7 +145,7 @@ describe('GiftFacilityService.get', () => {
       const promise = service.get(mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error getting a GIFT facility ${mockFacilityId}`);
+      const expected = new Error(`Error getting a GIFT facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(promise).rejects.toThrow(expected);
     });

--- a/src/modules/gift/services/gift.facility.service/index.ts
+++ b/src/modules/gift/services/gift.facility.service/index.ts
@@ -72,7 +72,7 @@ export class GiftFacilityService {
     } catch (error) {
       this.logger.error('Error getting a GIFT facility %s %o', facilityId, error);
 
-      throw new Error(`Error getting a GIFT facility ${facilityId}`, error);
+      throw new Error(`Error getting a GIFT facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -94,7 +94,7 @@ export class GiftFacilityService {
     } catch (error) {
       this.logger.error('Error creating an initial GIFT facility %s %o', overviewData.facilityId, error);
 
-      throw new Error(`Error creating an initial GIFT facility ${overviewData.facilityId}`, error);
+      throw new Error(`Error creating an initial GIFT facility ${overviewData.facilityId}`, { cause: error });
     }
   }
 
@@ -248,7 +248,7 @@ export class GiftFacilityService {
     } catch (error) {
       this.logger.error('Error creating a GIFT facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating a GIFT facility ${facilityId}`, error);
+      throw new Error(`Error creating a GIFT facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.fee-type.service.test.ts
+++ b/src/modules/gift/services/gift.fee-type.service.test.ts
@@ -20,6 +20,8 @@ describe('GiftFeeTypeService', () => {
   let mockHttpServiceGet: jest.Mock;
   let mockGetSupportedFeeTypes: jest.Mock;
 
+  const mockError = mockResponse500();
+
   beforeEach(() => {
     // Arrange
     mockGetResponse = mockResponse201(FEE_TYPES_RESPONSE_DATA);
@@ -61,7 +63,7 @@ describe('GiftFeeTypeService', () => {
     describe('when giftHttpService.get returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.get = mockHttpServiceGet;
 
@@ -73,7 +75,7 @@ describe('GiftFeeTypeService', () => {
         const promise = service.getSupportedFeeTypes();
 
         // Assert
-        const expected = new Error('Error getting supported fee types');
+        const expected = new Error('Error getting supported fee types', { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -114,7 +116,7 @@ describe('GiftFeeTypeService', () => {
     describe('when service.getSupportedFeeTypes returns an error', () => {
       beforeEach(() => {
         // Arrange
-        mockGetSupportedFeeTypes = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetSupportedFeeTypes = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftFeeTypeService(giftHttpService, logger);
 
@@ -126,7 +128,7 @@ describe('GiftFeeTypeService', () => {
         const promise = service.getAllFeeTypeCodes();
 
         // Assert
-        const expected = new Error('Error getting all fee type codes');
+        const expected = new Error('Error getting all fee type codes', { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.fee-type.service.ts
+++ b/src/modules/gift/services/gift.fee-type.service.ts
@@ -38,7 +38,7 @@ export class GiftFeeTypeService {
     } catch (error) {
       this.logger.error('Error getting supported fee types %o', error);
 
-      throw new Error('Error getting supported fee types', error);
+      throw new Error('Error getting supported fee types', { cause: error });
     }
   }
 
@@ -59,7 +59,7 @@ export class GiftFeeTypeService {
     } catch (error) {
       this.logger.error('Error getting all fee type codes %o', error);
 
-      throw new Error('Error getting all fee type codes', error);
+      throw new Error('Error getting all fee type codes', { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.fixed-fee.service.test.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.test.ts
@@ -66,11 +66,9 @@ describe('GiftFixedFeeService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
-      const mockError = mockResponse500();
-
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
         giftHttpService.post = mockHttpServicePost;
 
         service = new GiftFixedFeeService(giftHttpService, logger);
@@ -81,9 +79,7 @@ describe('GiftFixedFeeService', () => {
         const promise = service.createOne(mockFixedFee, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a fixed fee with feeTypeCode ${mockFixedFee.feeTypeCode} for facility ${mockFacilityId}`, {
-          cause: mockError,
-        });
+        const expected = new Error(`Error creating a fixed fee with feeTypeCode ${mockFixedFee.feeTypeCode} for facility ${mockFacilityId}`);
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.fixed-fee.service.test.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.test.ts
@@ -66,10 +66,11 @@ describe('GiftFixedFeeService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
-
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
         service = new GiftFixedFeeService(giftHttpService, logger);
@@ -80,7 +81,9 @@ describe('GiftFixedFeeService', () => {
         const promise = service.createOne(mockFixedFee, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a fixed fee with feeTypeCode ${mockFixedFee.feeTypeCode} for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating a fixed fee with feeTypeCode ${mockFixedFee.feeTypeCode} for facility ${mockFacilityId}`, {
+          cause: mockError,
+        });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -136,9 +139,11 @@ describe('GiftFixedFeeService', () => {
     });
 
     describe('when service.createOne returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockCreateOne = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockCreateOne = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftFixedFeeService(giftHttpService, logger);
 
@@ -150,7 +155,7 @@ describe('GiftFixedFeeService', () => {
         const promise = service.createMany(mockFixedFees, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating fixed fees for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating fixed fees for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.fixed-fee.service.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.ts
@@ -52,7 +52,7 @@ export class GiftFixedFeeService {
     } catch (error) {
       this.logger.error('Error creating a fixed fee with feeTypeCode %s for facility %s %o', fixedFeeData.feeTypeCode, facilityId, error);
 
-      throw new Error(`Error creating a fixed fee with feeTypeCode ${fixedFeeData.feeTypeCode} for facility ${facilityId}`, error);
+      throw new Error(`Error creating a fixed fee with feeTypeCode ${fixedFeeData.feeTypeCode} for facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -84,7 +84,7 @@ export class GiftFixedFeeService {
     } catch (error) {
       this.logger.error('Error creating fixed fees for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating fixed fees for facility ${facilityId}`, error);
+      throw new Error(`Error creating fixed fees for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.fixed-fee.service.ts
+++ b/src/modules/gift/services/gift.fixed-fee.service.ts
@@ -52,7 +52,7 @@ export class GiftFixedFeeService {
     } catch (error) {
       this.logger.error('Error creating a fixed fee with feeTypeCode %s for facility %s %o', fixedFeeData.feeTypeCode, facilityId, error);
 
-      throw new Error(`Error creating a fixed fee with feeTypeCode ${fixedFeeData.feeTypeCode} for facility ${facilityId}`, { cause: error });
+      throw new Error(`Error creating a fixed fee with feeTypeCode ${fixedFeeData.feeTypeCode} for facility ${facilityId}`);
     }
   }
 

--- a/src/modules/gift/services/gift.http.service.test.ts
+++ b/src/modules/gift/services/gift.http.service.test.ts
@@ -103,9 +103,11 @@ describe('GiftHttpService', () => {
     });
 
     describe('when the axios call fails', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockAxiosGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockAxiosGet = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftHttpService(logger);
       });
@@ -115,7 +117,9 @@ describe('GiftHttpService', () => {
         const serviceCall = service.get({ path: mockGetPath });
 
         // Assert
-        await expect(serviceCall).rejects.toThrow(`Error calling GET with path ${mockGetPath}`);
+        const expected = new Error(`Error calling GET with path ${mockGetPath}`, { cause: mockError });
+
+        await expect(serviceCall).rejects.toThrow(expected);
       });
     });
   });
@@ -153,9 +157,11 @@ describe('GiftHttpService', () => {
     });
 
     describe('when the axios call fails', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockAxiosPost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockAxiosPost = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftHttpService(logger);
       });
@@ -165,7 +171,9 @@ describe('GiftHttpService', () => {
         const serviceCall = service.post({ path: mockPostPath, payload: mockPayload });
 
         // Assert
-        await expect(serviceCall).rejects.toThrow(`Error calling POST with path ${mockPostPath}`);
+        const expected = new Error(`Error calling POST with path ${mockPostPath}`, { cause: mockError });
+
+        await expect(serviceCall).rejects.toThrow(expected);
       });
     });
   });

--- a/src/modules/gift/services/gift.http.service.ts
+++ b/src/modules/gift/services/gift.http.service.ts
@@ -66,7 +66,7 @@ export class GiftHttpService {
     } catch (error) {
       this.logger.error('Error calling GET with path %s %o', path, error);
 
-      throw new Error(`Error calling GET with path ${path}`, error);
+      throw new Error(`Error calling GET with path ${path}`, { cause: error });
     }
   }
 
@@ -84,7 +84,7 @@ export class GiftHttpService {
     } catch (error) {
       this.logger.error('Error calling POST with path %s %o', path, error);
 
-      throw new Error(`Error calling POST with path ${path}`, error);
+      throw new Error(`Error calling POST with path ${path}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.obligation-subtype.service.test.ts
+++ b/src/modules/gift/services/gift.obligation-subtype.service.test.ts
@@ -67,9 +67,11 @@ describe('GiftObligationSubtypeService', () => {
     });
 
     describe('when giftHttpService.get returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.get = mockHttpServiceGet;
 
@@ -81,7 +83,7 @@ describe('GiftObligationSubtypeService', () => {
         const promise = service.getAll();
 
         // Assert
-        const expected = new Error('Error getting obligation subtypes');
+        const expected = new Error('Error getting obligation subtypes', { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -117,9 +119,11 @@ describe('GiftObligationSubtypeService', () => {
     });
 
     describe('when service.getAll returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockGetAll = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetAll = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftObligationSubtypeService(giftHttpService, logger);
 
@@ -131,7 +135,7 @@ describe('GiftObligationSubtypeService', () => {
         const promise = service.getAllByProductType(mockProductCode);
 
         // Assert
-        const expected = new Error(`Error getting obligation subtypes by product type ${mockProductCode}`);
+        const expected = new Error(`Error getting obligation subtypes by product type ${mockProductCode}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.obligation-subtype.service.ts
+++ b/src/modules/gift/services/gift.obligation-subtype.service.ts
@@ -38,7 +38,7 @@ export class GiftObligationSubtypeService {
     } catch (error) {
       this.logger.error('Error getting obligation subtypes %o', error);
 
-      throw new Error('Error getting obligation subtypes', error);
+      throw new Error('Error getting obligation subtypes', { cause: error });
     }
   }
 
@@ -60,7 +60,7 @@ export class GiftObligationSubtypeService {
     } catch (error) {
       this.logger.error('Error getting obligation subtypes by product type %s %o', productTypeCode, error);
 
-      throw new Error(`Error getting obligation subtypes by product type ${productTypeCode}`, error);
+      throw new Error(`Error getting obligation subtypes by product type ${productTypeCode}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.obligation.service.test.ts
+++ b/src/modules/gift/services/gift.obligation.service.test.ts
@@ -66,9 +66,11 @@ describe('GiftObligationService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -80,7 +82,7 @@ describe('GiftObligationService', () => {
         const promise = service.createOne(mockObligation, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating an obligation with amount ${mockObligation.amount} for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating an obligation with amount ${mockObligation.amount} for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -134,9 +136,11 @@ describe('GiftObligationService', () => {
     });
 
     describe('when service.createOne returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockCreateOne = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockCreateOne = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftObligationService(giftHttpService, logger);
 
@@ -148,7 +152,7 @@ describe('GiftObligationService', () => {
         const promise = service.createMany(mockObligations, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating obligations for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating obligations for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.obligation.service.test.ts
+++ b/src/modules/gift/services/gift.obligation.service.test.ts
@@ -66,11 +66,9 @@ describe('GiftObligationService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
-      const mockError = mockResponse500();
-
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -82,7 +80,7 @@ describe('GiftObligationService', () => {
         const promise = service.createOne(mockObligation, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating an obligation with amount ${mockObligation.amount} for facility ${mockFacilityId}`, { cause: mockError });
+        const expected = new Error(`Error creating an obligation with amount ${mockObligation.amount} for facility ${mockFacilityId}`);
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.obligation.service.ts
+++ b/src/modules/gift/services/gift.obligation.service.ts
@@ -84,7 +84,7 @@ export class GiftObligationService {
     } catch (error) {
       this.logger.error('Error creating obligations for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating obligations for facility ${facilityId}`);
+      throw new Error(`Error creating obligations for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.obligation.service.ts
+++ b/src/modules/gift/services/gift.obligation.service.ts
@@ -52,7 +52,7 @@ export class GiftObligationService {
     } catch (error) {
       this.logger.error('Error creating an obligation with amount %s for facility %s %o', obligationData.amount, facilityId, error);
 
-      throw new Error(`Error creating an obligation with amount ${obligationData.amount} for facility ${facilityId}`, error);
+      throw new Error(`Error creating an obligation with amount ${obligationData.amount} for facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -84,7 +84,7 @@ export class GiftObligationService {
     } catch (error) {
       this.logger.error('Error creating obligations for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating obligations for facility ${facilityId}`, error);
+      throw new Error(`Error creating obligations for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.obligation.service.ts
+++ b/src/modules/gift/services/gift.obligation.service.ts
@@ -52,7 +52,7 @@ export class GiftObligationService {
     } catch (error) {
       this.logger.error('Error creating an obligation with amount %s for facility %s %o', obligationData.amount, facilityId, error);
 
-      throw new Error(`Error creating an obligation with amount ${obligationData.amount} for facility ${facilityId}`, { cause: error });
+      throw new Error(`Error creating an obligation with amount ${obligationData.amount} for facility ${facilityId}`);
     }
   }
 
@@ -84,7 +84,7 @@ export class GiftObligationService {
     } catch (error) {
       this.logger.error('Error creating obligations for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating obligations for facility ${facilityId}`, { cause: error });
+      throw new Error(`Error creating obligations for facility ${facilityId}`);
     }
   }
 }

--- a/src/modules/gift/services/gift.product-type.service.test.ts
+++ b/src/modules/gift/services/gift.product-type.service.test.ts
@@ -56,9 +56,11 @@ describe('GiftProductTypeService', () => {
     });
 
     describe('when giftHttpService.get returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServiceGet = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.get = mockHttpServiceGet;
 
@@ -70,7 +72,7 @@ describe('GiftProductTypeService', () => {
         const promise = service.getOne(PRODUCT_TYPE_CODES.EXIP);
 
         // Assert
-        const expected = new Error(`Error getting product type ${PRODUCT_TYPE_CODES.EXIP}`);
+        const expected = new Error(`Error getting product type ${PRODUCT_TYPE_CODES.EXIP}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -125,9 +127,11 @@ describe('GiftProductTypeService', () => {
     });
 
     describe('when service.getOne returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockGetOne = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockGetOne = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftProductTypeService(giftHttpService, logger);
 
@@ -139,7 +143,7 @@ describe('GiftProductTypeService', () => {
         const promise = service.isSupported(PRODUCT_TYPE_CODES.EXIP);
 
         // Assert
-        const expected = new Error(`Error checking if product type ${PRODUCT_TYPE_CODES.EXIP} is supported`);
+        const expected = new Error(`Error checking if product type ${PRODUCT_TYPE_CODES.EXIP} is supported`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.product-type.service.ts
+++ b/src/modules/gift/services/gift.product-type.service.ts
@@ -38,7 +38,7 @@ export class GiftProductTypeService {
     } catch (error) {
       this.logger.error('Error getting product type %s %o', productTypeCode, error);
 
-      throw new Error(`Error getting product type ${productTypeCode}`, error);
+      throw new Error(`Error getting product type ${productTypeCode}`, { cause: error });
     }
   }
 
@@ -62,7 +62,7 @@ export class GiftProductTypeService {
     } catch (error) {
       this.logger.error('Error checking if product type %s is supported %o', productTypeCode, error);
 
-      throw new Error(`Error checking if product type ${productTypeCode} is supported`, error);
+      throw new Error(`Error checking if product type ${productTypeCode} is supported`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.repayment-profile.service.test.ts
+++ b/src/modules/gift/services/gift.repayment-profile.service.test.ts
@@ -63,11 +63,9 @@ describe('GiftRepaymentProfileService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
-      const mockError = mockResponse500();
-
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -79,9 +77,7 @@ describe('GiftRepaymentProfileService', () => {
         const promise = service.createOne(mockRepaymentProfile, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a repayment profile with name ${mockRepaymentProfile.name} for facility ${mockFacilityId}`, {
-          cause: mockError,
-        });
+        const expected = new Error(`Error creating a repayment profile with name ${mockRepaymentProfile.name} for facility ${mockFacilityId}`);
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.repayment-profile.service.test.ts
+++ b/src/modules/gift/services/gift.repayment-profile.service.test.ts
@@ -63,9 +63,11 @@ describe('GiftRepaymentProfileService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -77,7 +79,9 @@ describe('GiftRepaymentProfileService', () => {
         const promise = service.createOne(mockRepaymentProfile, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating a repayment profile with name ${mockRepaymentProfile.name} for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating a repayment profile with name ${mockRepaymentProfile.name} for facility ${mockFacilityId}`, {
+          cause: mockError,
+        });
 
         await expect(promise).rejects.toThrow(expected);
       });
@@ -131,9 +135,11 @@ describe('GiftRepaymentProfileService', () => {
     });
 
     describe('when service.createOne returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockCreateOne = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockCreateOne = jest.fn().mockRejectedValueOnce(mockError);
 
         service = new GiftRepaymentProfileService(giftHttpService, logger);
 
@@ -145,7 +151,7 @@ describe('GiftRepaymentProfileService', () => {
         const promise = service.createMany(mockRepaymentProfiles, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating repayment profiles for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating repayment profiles for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.repayment-profile.service.ts
+++ b/src/modules/gift/services/gift.repayment-profile.service.ts
@@ -42,7 +42,7 @@ export class GiftRepaymentProfileService {
     } catch (error) {
       this.logger.error('Error creating a repayment profile with name %s for facility %s %o', repaymentProfileData.name, facilityId, error);
 
-      throw new Error(`Error creating a repayment profile with name ${repaymentProfileData.name} for facility ${facilityId}`, error);
+      throw new Error(`Error creating a repayment profile with name ${repaymentProfileData.name} for facility ${facilityId}`, { cause: error });
     }
   }
 
@@ -74,7 +74,7 @@ export class GiftRepaymentProfileService {
     } catch (error) {
       this.logger.error('Error creating repayment profiles for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating repayment profiles for facility ${facilityId}`, error);
+      throw new Error(`Error creating repayment profiles for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.repayment-profile.service.ts
+++ b/src/modules/gift/services/gift.repayment-profile.service.ts
@@ -42,7 +42,7 @@ export class GiftRepaymentProfileService {
     } catch (error) {
       this.logger.error('Error creating a repayment profile with name %s for facility %s %o', repaymentProfileData.name, facilityId, error);
 
-      throw new Error(`Error creating a repayment profile with name ${repaymentProfileData.name} for facility ${facilityId}`, { cause: error });
+      throw new Error(`Error creating a repayment profile with name ${repaymentProfileData.name} for facility ${facilityId}`);
     }
   }
 

--- a/src/modules/gift/services/gift.risk-details.service.test.ts
+++ b/src/modules/gift/services/gift.risk-details.service.test.ts
@@ -68,9 +68,11 @@ describe('GiftRiskDetailsService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -82,7 +84,7 @@ describe('GiftRiskDetailsService', () => {
         const promise = service.createOne(RISK_DETAILS, mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error creating risk details for facility ${mockFacilityId}`);
+        const expected = new Error(`Error creating risk details for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.risk-details.service.ts
+++ b/src/modules/gift/services/gift.risk-details.service.ts
@@ -46,7 +46,7 @@ export class GiftRiskDetailsService {
     } catch (error) {
       this.logger.error('Error creating risk details for facility %s %o', facilityId, error);
 
-      throw new Error(`Error creating risk details for facility ${facilityId}`, error);
+      throw new Error(`Error creating risk details for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.status.service.test.ts
+++ b/src/modules/gift/services/gift.status.service.test.ts
@@ -60,9 +60,11 @@ describe('GiftStatusService', () => {
     });
 
     describe('when giftHttpService.post returns an error', () => {
+      const mockError = mockResponse500();
+
       beforeEach(() => {
         // Arrange
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;
 
@@ -74,7 +76,7 @@ describe('GiftStatusService', () => {
         const promise = service.approved(mockFacilityId, mockWorkPackageId);
 
         // Assert
-        const expected = new Error(`Error updating facility work package status to approved for facility ${mockFacilityId}`);
+        const expected = new Error(`Error updating facility work package status to approved for facility ${mockFacilityId}`, { cause: mockError });
 
         await expect(promise).rejects.toThrow(expected);
       });

--- a/src/modules/gift/services/gift.status.service.ts
+++ b/src/modules/gift/services/gift.status.service.ts
@@ -39,7 +39,7 @@ export class GiftStatusService {
     } catch (error) {
       this.logger.error('Error updating facility work package status to approved for facility %s %o', facilityId, error);
 
-      throw new Error(`Error updating facility work package status to approved for facility ${facilityId}`, error);
+      throw new Error(`Error updating facility work package status to approved for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.work-package.service.test.ts
+++ b/src/modules/gift/services/gift.work-package.service.test.ts
@@ -62,9 +62,11 @@ describe('GiftWorkPackageService', () => {
   });
 
   describe('when giftHttpService.post returns an error', () => {
+    const mockError = mockResponse500();
+
     beforeEach(() => {
       // Arrange
-      mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockResponse500());
+      mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
 
       giftHttpService.post = mockHttpServicePost;
 
@@ -76,7 +78,7 @@ describe('GiftWorkPackageService', () => {
       const promise = service.create(mockFacilityId);
 
       // Assert
-      const expected = new Error(`Error creating work package for facility ${mockFacilityId}`, { cause: mockResponse500() });
+      const expected = new Error(`Error creating work package for facility ${mockFacilityId}`, { cause: mockError });
 
       await expect(promise).rejects.toThrow(expected);
     });

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -111,7 +111,8 @@ export const repaymentProfileUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WOR
 export const riskDetailsUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`;
 export const approveStatusUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.APPROVE}`;
 export const workPackageUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}`;
-export const facilityAmendmentUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${AMEND_FACILITY_TYPES.AMEND_FACILITY_INCREASE_AMOUNT}`;
+export const facilityAmendmentUrl = (amendmentType: string = AMEND_FACILITY_TYPES.AMEND_FACILITY_INCREASE_AMOUNT) =>
+  `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${amendmentType}`;
 
 export const businessCalendar = GIFT_EXAMPLES.BUSINESS_CALENDAR;
 export const businessCalendarsConvention = GIFT_EXAMPLES.BUSINESS_CALENDARS_CONVENTION;


### PR DESCRIPTION
# Introduction :pencil2:

- Some catch handler errors should throw with a `{ cause: error }`.
- The APIM GIFT "decrease amount amendment" functionality is working. Need to add some tests.

## Resolution :heavy_check_mark:

- Update some catch handlers.
- Add API tests for specific amendments happy paths.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
