### PR TITLE
feat(GIFT-20089): amend a GIFT facility - replace expiry date

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,8 +36,9 @@ export class App {
     app.useGlobalPipes(
       new InputCharacterValidationPipe(),
       new ValidationPipe({
-        whitelist: true,
-        transform: true,
+        whitelist: true, // strips properties that do not have any decorators
+        forbidNonWhitelisted: true, // if non-whitelisted properties are present, validation will fail
+        transform: true, // automatically transform payloads to be objects typed according to their DTO classes
       }),
     );
 

--- a/src/constants/examples/gift.examples.constant.ts
+++ b/src/constants/examples/gift.examples.constant.ts
@@ -222,6 +222,9 @@ const FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA = {
     amount: 100,
     date: '2027-02-15',
   },
+  REPLACE_EXPIRY_DATE: {
+    expiryDate: '2030-03-20',
+  },
 };
 
 const FACILITY_AMENDMENT_REQUEST_PAYLOAD = {

--- a/src/constants/examples/gift.examples.constant.ts
+++ b/src/constants/examples/gift.examples.constant.ts
@@ -182,8 +182,6 @@ const RISK_DETAILS = {
 
 const FACILITY_OVERVIEW = {
   facilityId: FACILITY_ID,
-  streamId: '7d915bfa-0069-4aaa-92c5-013925f019a1',
-  streamVersion: 1,
   name: 'Amazing facility',
   obligorUrn: '01234567',
   currency: SUPPORTED_CURRENCIES.USD,
@@ -191,8 +189,6 @@ const FACILITY_OVERVIEW = {
   effectiveDate: '2025-01-01',
   expiryDate: '2027-02-01',
   creditType: CREDIT_TYPES.REVOLVER,
-  isDraft: true,
-  createdDatetime: '2025-01-21T09:58:21.115Z',
   productTypeCode: PRODUCT_TYPE_CODES.BIP,
 };
 
@@ -240,6 +236,10 @@ const FACILITY_RESPONSE_DATA: GiftFacilityPostResponseDto = {
   configurationEvent: {
     data: {
       ...FACILITY_OVERVIEW,
+      streamId: '7d915bfa-0069-4aaa-92c5-013925f019a1',
+      streamVersion: 1,
+      isDraft: true,
+      createdDatetime: '2025-01-21T09:58:21.115Z',
       drawnAmount: 2000000,
       availableAmount: 3000000,
     },

--- a/src/modules/gift/dto/request/facility-amendment.ts
+++ b/src/modules/gift/dto/request/facility-amendment.ts
@@ -4,6 +4,8 @@ import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { plainToInstance, Transform } from 'class-transformer';
 import { IsDateString, IsDefined, IsIn, IsNotEmptyObject, IsNumber, IsString, Length, Max, Min, ValidateNested } from 'class-validator';
 
+import { getAmendmentDataDto } from '../../helpers';
+
 const { VALIDATION } = GIFT;
 
 export class AmountDto {
@@ -30,7 +32,17 @@ export class AmountDto {
 export class DecreaseAmountDto extends AmountDto {}
 export class IncreaseAmountDto extends AmountDto {}
 
-@ApiExtraModels(DecreaseAmountDto, IncreaseAmountDto)
+export class ReplaceExpiryDateDto {
+  @IsDefined()
+  @IsDateString()
+  @ApiProperty({
+    required: true,
+    example: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE.expiryDate,
+  })
+  expiryDate: string;
+}
+
+@ApiExtraModels(DecreaseAmountDto, IncreaseAmountDto, ReplaceExpiryDateDto)
 export class CreateGiftFacilityAmendmentRequestDto {
   @IsDefined()
   @IsString()
@@ -55,17 +67,16 @@ export class CreateGiftFacilityAmendmentRequestDto {
        */
       const { amendmentType } = obj;
 
-      const Decrease = GIFT.AMEND_FACILITY_TYPES.AMEND_FACILITY_DECREASE_AMOUNT;
-      const Target = amendmentType === Decrease ? DecreaseAmountDto : IncreaseAmountDto;
+      const amendmentDataDto = getAmendmentDataDto(amendmentType);
 
-      return plainToInstance(Target, value);
+      return plainToInstance(amendmentDataDto, value);
     },
     { toClassOnly: true },
   )
   @ValidateNested()
   @ApiProperty({
     required: true,
-    oneOf: [{ $ref: getSchemaPath(DecreaseAmountDto) }, { $ref: getSchemaPath(IncreaseAmountDto) }],
+    oneOf: [{ $ref: getSchemaPath(DecreaseAmountDto) }, { $ref: getSchemaPath(IncreaseAmountDto) }, { $ref: getSchemaPath(ReplaceExpiryDateDto) }],
   })
-  amendmentData: DecreaseAmountDto | IncreaseAmountDto;
+  amendmentData: DecreaseAmountDto | IncreaseAmountDto | ReplaceExpiryDateDto;
 }

--- a/src/modules/gift/dto/request/facility-amendment.ts
+++ b/src/modules/gift/dto/request/facility-amendment.ts
@@ -69,6 +69,14 @@ export class CreateGiftFacilityAmendmentRequestDto {
 
       const amendmentDataDto = getAmendmentDataDto(amendmentType);
 
+      if (!amendmentDataDto) {
+        /**
+         * If we cannot determine a DTO for the given amendmentType (e.g. invalid type),
+         * return the original value so that amendmentType validation can handle the error.
+         */
+        return value;
+      }
+
       return plainToInstance(amendmentDataDto, value);
     },
     { toClassOnly: true },

--- a/src/modules/gift/dto/request/facility-amendment.ts
+++ b/src/modules/gift/dto/request/facility-amendment.ts
@@ -2,7 +2,7 @@ import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { AMEND_FACILITY_TYPES_ARRAY, AmendFacilityType, GIFT } from '@ukef/constants';
 import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
 import { plainToInstance, Transform } from 'class-transformer';
-import { IsDateString, IsDefined, IsIn, IsNotEmptyObject, IsNumber, IsString, Length, Max, Min, ValidateNested } from 'class-validator';
+import { IsDateString, IsDefined, IsIn, IsNumber, IsObject, IsString, Length, Max, Min, ValidateNested } from 'class-validator';
 
 import { getAmendmentDataDto } from '../../helpers';
 
@@ -54,7 +54,7 @@ export class CreateGiftFacilityAmendmentRequestDto {
   })
   amendmentType: AmendFacilityType;
 
-  @IsNotEmptyObject()
+  @IsObject()
   @IsDefined()
   @Transform(
     ({ value, obj }) => {

--- a/src/modules/gift/helpers/get-amendment-data-dto/index.test.ts
+++ b/src/modules/gift/helpers/get-amendment-data-dto/index.test.ts
@@ -1,0 +1,44 @@
+import { AmendFacilityType, GIFT } from '@ukef/constants';
+
+import { DecreaseAmountDto, IncreaseAmountDto, ReplaceExpiryDateDto } from '../../dto';
+import { getAmendmentDataDto } from '.';
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_REPLACE_EXPIRY_DATE },
+} = GIFT;
+
+describe('modules/gift/helpers/get-amendment-data-dto', () => {
+  describe(`when the provided amendmentType is ${AMEND_FACILITY_DECREASE_AMOUNT}`, () => {
+    it('should return a response with the received status and data', () => {
+      const result = getAmendmentDataDto(AMEND_FACILITY_DECREASE_AMOUNT);
+
+      expect(result).toBe(DecreaseAmountDto);
+    });
+  });
+
+  describe(`when the provided amendmentType is ${AMEND_FACILITY_INCREASE_AMOUNT}`, () => {
+    it('should return a response with the received status and data', () => {
+      const result = getAmendmentDataDto(AMEND_FACILITY_INCREASE_AMOUNT);
+
+      expect(result).toBe(IncreaseAmountDto);
+    });
+  });
+
+  describe(`when the provided amendmentType is ${AMEND_FACILITY_REPLACE_EXPIRY_DATE}`, () => {
+    it('should return a response with the received status and data', () => {
+      const result = getAmendmentDataDto(AMEND_FACILITY_REPLACE_EXPIRY_DATE);
+
+      expect(result).toBe(ReplaceExpiryDateDto);
+    });
+  });
+
+  describe('when the provided amendmentType is invalid', () => {
+    it('should return null', () => {
+      const invalidAmendmentType = 'invalid-amendment-type' as AmendFacilityType;
+
+      const result = getAmendmentDataDto(invalidAmendmentType);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/modules/gift/helpers/get-amendment-data-dto/index.ts
+++ b/src/modules/gift/helpers/get-amendment-data-dto/index.ts
@@ -11,16 +11,16 @@ type ReturnType = DecreaseAmountDto | IncreaseAmountDto | ReplaceExpiryDateDto;
 /**
  * Get an "amendmentData" DTO class constructor corresponding to the provided amendmentType
  * @param {AmendFacilityType} amendmentType: The type of amendment
- * @returns {ReturnType | null} A DTO class instance or null if the amendment type is invalid
+ * @returns {new () => ReturnType | null} A DTO class constructor or null if the amendment type is invalid
  */
-export const getAmendmentDataDto = (amendmentType: AmendFacilityType): ReturnType | null => {
+export const getAmendmentDataDto = (amendmentType: AmendFacilityType): (new () => ReturnType) | null => {
   switch (amendmentType) {
     case AMEND_FACILITY_DECREASE_AMOUNT:
-      return new DecreaseAmountDto();
+      return DecreaseAmountDto;
     case AMEND_FACILITY_INCREASE_AMOUNT:
-      return new IncreaseAmountDto();
+      return IncreaseAmountDto;
     case AMEND_FACILITY_REPLACE_EXPIRY_DATE:
-      return new ReplaceExpiryDateDto();
+      return ReplaceExpiryDateDto;
     default:
       return null;
   }

--- a/src/modules/gift/helpers/get-amendment-data-dto/index.ts
+++ b/src/modules/gift/helpers/get-amendment-data-dto/index.ts
@@ -1,0 +1,27 @@
+import { AmendFacilityType, GIFT } from '@ukef/constants';
+
+import { DecreaseAmountDto, IncreaseAmountDto, ReplaceExpiryDateDto } from '../../dto';
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_REPLACE_EXPIRY_DATE },
+} = GIFT;
+
+type ReturnType = DecreaseAmountDto | IncreaseAmountDto | ReplaceExpiryDateDto;
+
+/**
+ * Get an "amendmentData" DTO class constructor corresponding to the provided amendmentType
+ * @param {AmendFacilityType} amendmentType: The type of amendment
+ * @returns {ReturnType | null} A DTO class instance or null if the amendment type is invalid
+ */
+export const getAmendmentDataDto = (amendmentType: AmendFacilityType): ReturnType | null => {
+  switch (amendmentType) {
+    case AMEND_FACILITY_DECREASE_AMOUNT:
+      return new DecreaseAmountDto();
+    case AMEND_FACILITY_INCREASE_AMOUNT:
+      return new IncreaseAmountDto();
+    case AMEND_FACILITY_REPLACE_EXPIRY_DATE:
+      return new ReplaceExpiryDateDto();
+    default:
+      return null;
+  }
+};

--- a/src/modules/gift/helpers/index.ts
+++ b/src/modules/gift/helpers/index.ts
@@ -3,6 +3,7 @@ export * from './array-has-unique-strings';
 export * from './array-of-objects-has-value';
 export * from './async-validation';
 export * from './generate-obligation-subtype-code-errors';
+export * from './get-amendment-data-dto';
 export * from './get-counterparty-urns';
 export * from './get-repayment-profile-allocation-dates';
 export * from './get-repayment-profile-names';

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -90,7 +90,6 @@ export class GiftFacilityAmendmentService {
     } catch (error) {
       this.logger.error('Error creating amendment %s for facility %s %o', amendmentType, facilityId, error);
 
-      // TODO: update all error instances with { cause: error } / create ticket.
       throw new Error(`Error creating amendment ${amendmentType} for facility ${facilityId}`, { cause: error });
     }
   }

--- a/test/gift/assertions/amendment-type-string-validation.ts
+++ b/test/gift/assertions/amendment-type-string-validation.ts
@@ -49,6 +49,8 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
         amendmentTypeValidationMessage,
         `amendmentType must be longer than or equal to ${min} characters`,
         'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
       ];
 
       expect(body.message).toStrictEqual(expected);
@@ -79,6 +81,8 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
         amendmentTypeValidationMessage,
         `amendmentType must be longer than or equal to ${min} characters`,
         'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
       ];
 
       expect(body.message).toStrictEqual(expected);
@@ -104,7 +108,13 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be longer than or equal to ${min} characters`, 'amendmentType must be a string'];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be longer than or equal to ${min} characters`,
+        'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });
@@ -133,6 +143,8 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
         amendmentTypeValidationMessage,
         `amendmentType must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
         'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
       ];
 
       expect(body.message).toStrictEqual(expected);
@@ -158,7 +170,13 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be longer than or equal to ${min} characters`, 'amendmentType must be a string'];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be longer than or equal to ${min} characters`,
+        'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });
@@ -183,7 +201,13 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be longer than or equal to ${min} characters`, 'amendmentType must be a string'];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be longer than or equal to ${min} characters`,
+        'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });
@@ -212,6 +236,8 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
         amendmentTypeValidationMessage,
         `amendmentType must be longer than or equal to ${min} and shorter than or equal to ${max} characters`,
         'amendmentType must be a string',
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
       ];
 
       expect(body.message).toStrictEqual(expected);
@@ -237,7 +263,12 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be longer than or equal to ${min} characters`];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be longer than or equal to ${min} characters`,
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });
@@ -262,7 +293,12 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be longer than or equal to ${min} characters`];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be longer than or equal to ${min} characters`,
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });
@@ -287,7 +323,12 @@ export const amendmentTypeStringValidation = ({ initialPayload, min, max, url })
       const { body } = await api.post(url, mockPayload);
 
       // Assert
-      const expected = [amendmentTypeValidationMessage, `amendmentType must be shorter than or equal to ${max} characters`];
+      const expected = [
+        amendmentTypeValidationMessage,
+        `amendmentType must be shorter than or equal to ${max} characters`,
+        'amendmentData should not be null or undefined',
+        'amendmentData must be an object',
+      ];
 
       expect(body.message).toStrictEqual(expected);
     });

--- a/test/gift/assertions/product-type-code-string-validation.ts
+++ b/test/gift/assertions/product-type-code-string-validation.ts
@@ -41,16 +41,6 @@ export const productTypeCodeStringValidation = ({ initialPayload, parentFieldNam
   mockPayload[`${parentFieldName}`][`${fieldName}`] = UNSUPPORTED_PRODUCT_TYPE_CODE;
 
   /**
-   * Map over the payload's obligations so that each obligation has the same unsupported product type code.
-   * Otherwise, obligation validation errors will be returned.
-   * This test is specifically for the high level product type code only.
-   */
-  mockPayload.obligations = mockPayload.obligations.map((obligation) => ({
-    ...obligation,
-    productTypeCode: UNSUPPORTED_PRODUCT_TYPE_CODE,
-  }));
-
-  /**
    * Mock the obligation subtype response,
    * so that obligations with an unsupported product type code are technically valid.
    * This prevents the obligation validation errors from being returned.
@@ -59,7 +49,6 @@ export const productTypeCodeStringValidation = ({ initialPayload, parentFieldNam
   const mockObligationSubtypeResponse = {
     obligationSubtypes: [
       {
-        tonyTest: true,
         code: OBLIGATION_SUBTYPES.EXP01.code,
         name: OBLIGATION_SUBTYPES.EXP01.name,
         productTypeCode: UNSUPPORTED_PRODUCT_TYPE_CODE,

--- a/test/gift/create-facility-validation.api-test.ts
+++ b/test/gift/create-facility-validation.api-test.ts
@@ -150,7 +150,6 @@ describe('POST /gift/facility - validation', () => {
       // Arrange
       const mockPayload = {
         overview: [],
-        businessCalendarsConvention: [],
         counterparties: [],
         fixedFees: [],
         obligations: [],
@@ -191,7 +190,6 @@ describe('POST /gift/facility - validation', () => {
       // Arrange
       const mockPayload = {
         overview: null,
-        businessCalendarsConvention: null,
         counterparties: null,
         fixedFees: null,
         obligations: null,
@@ -248,7 +246,6 @@ describe('POST /gift/facility - validation', () => {
       // Arrange
       const mockPayload = {
         overview: undefined,
-        businessCalendarsConvention: undefined,
         counterparties: undefined,
         fixedFees: undefined,
         obligations: undefined,
@@ -299,7 +296,6 @@ describe('POST /gift/facility - validation', () => {
       // Arrange
       const mockPayload = {
         overview: {},
-        businessCalendarsConvention: {},
         counterparties: {},
         fixedFees: {},
         obligations: {},

--- a/test/gift/facility-amendment-validation-amendmentData.api-test.ts
+++ b/test/gift/facility-amendment-validation-amendmentData.api-test.ts
@@ -1,0 +1,280 @@
+import { HttpStatus } from '@nestjs/common';
+import { GIFT } from '@ukef/constants';
+import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
+import { Api } from '@ukef-test/support/api';
+import nock from 'nock';
+
+import { dateStringValidation, numberValidation } from './assertions';
+import { apimFacilityAmendmentUrl } from './test-helpers';
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_REPLACE_EXPIRY_DATE },
+  VALIDATION,
+} = GIFT;
+
+describe('POST /gift/facility/:facilityId/amendment - validation - amendmentData', () => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  describe.each([AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT])(`when amendmentType is %s`, (amendmentType: string) => {
+    describe('when an empty object is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType,
+          amendmentData: {},
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: [
+            'amendmentData.amount should not be null or undefined',
+            `amendmentData.amount must not be greater than ${VALIDATION.FACILITY.AMENDMENT.AMOUNT.MAX}`,
+            `amendmentData.amount must not be less than ${VALIDATION.FACILITY.AMENDMENT.AMOUNT.MIN}`,
+            'amendmentData.amount must be a number conforming to the specified constraints',
+            'amendmentData.date should not be null or undefined',
+            'amendmentData.date must be a valid ISO 8601 date string',
+          ],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an empty array is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType,
+          amendmentData: [],
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData must be an object'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when amount is provided, but date is not', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType,
+          amendmentData: {
+            amount: 100,
+          },
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData.date should not be null or undefined', 'amendmentData.date must be a valid ISO 8601 date string'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when date is provided, but amount is not', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType,
+          amendmentData: {
+            date: '2023-01-01',
+          },
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: [
+            'amendmentData.amount should not be null or undefined',
+            `amendmentData.amount must not be greater than ${VALIDATION.FACILITY.AMENDMENT.AMOUNT.MAX}`,
+            `amendmentData.amount must not be less than ${VALIDATION.FACILITY.AMENDMENT.AMOUNT.MIN}`,
+            'amendmentData.amount must be a number conforming to the specified constraints',
+          ],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an invalid field is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType,
+          amendmentData: {
+            ...GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.INCREASE_AMOUNT,
+            invalidField: true,
+          },
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData.property invalidField should not exist'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('amount', () => {
+      numberValidation({
+        fieldName: 'amount',
+        initialPayload: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD,
+        min: VALIDATION.FACILITY.AMENDMENT.AMOUNT.MIN,
+        max: VALIDATION.FACILITY.AMENDMENT.AMOUNT.MAX,
+        parentFieldName: 'amendmentData',
+        url: apimFacilityAmendmentUrl,
+      });
+    });
+
+    describe('date', () => {
+      dateStringValidation({
+        fieldName: 'date',
+        initialPayload: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD,
+        parentFieldName: 'amendmentData',
+        url: apimFacilityAmendmentUrl,
+      });
+    });
+  });
+
+  describe(`when amendmentType is ${AMEND_FACILITY_REPLACE_EXPIRY_DATE}`, () => {
+    describe('when an empty object is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: {},
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData.expiryDate should not be null or undefined', 'amendmentData.expiryDate must be a valid ISO 8601 date string'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an empty array is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: [],
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData must be an object'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an invalid field is provided', () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: {
+            ...GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
+            invalidField: true,
+          },
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = {
+          error: 'Bad Request',
+          message: ['amendmentData.property invalidField should not exist'],
+          statusCode: HttpStatus.BAD_REQUEST,
+        };
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('expiryDate', () => {
+      dateStringValidation({
+        fieldName: 'expiryDate',
+        initialPayload: {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
+        },
+        parentFieldName: 'amendmentData',
+        url: apimFacilityAmendmentUrl,
+      });
+    });
+  });
+});

--- a/test/gift/facility-amendment-validation.api-test.ts
+++ b/test/gift/facility-amendment-validation.api-test.ts
@@ -126,6 +126,13 @@ describe('POST /gift/facility/:facilityId/amendment - validation', () => {
     });
   });
 
+  // TODO
+  // TODO
+  // TODO - split up this test file
+  // TODO
+
+  // TODO - when additional field is provided.
+
   describe('amendmentData', () => {
     describe.each([AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT])(`when amendmentType is %s`, (amendmentType: string) => {
       describe('when an empty object is provided', () => {
@@ -152,6 +159,30 @@ describe('POST /gift/facility/:facilityId/amendment - validation', () => {
               'amendmentData.date should not be null or undefined',
               'amendmentData.date must be a valid ISO 8601 date string',
             ],
+            statusCode: HttpStatus.BAD_REQUEST,
+          };
+
+          expect(body).toStrictEqual(expected);
+        });
+      });
+
+      describe('when an empty array is provided', () => {
+        it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+          // Arrange
+          const mockPayload = {
+            amendmentType,
+            amendmentData: [],
+          };
+
+          // Act
+          const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+          // Assert
+          expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+          const expected = {
+            error: 'Bad Request',
+            message: ['amendmentData must be a non-empty object'],
             statusCode: HttpStatus.BAD_REQUEST,
           };
 
@@ -231,6 +262,68 @@ describe('POST /gift/facility/:facilityId/amendment - validation', () => {
         dateStringValidation({
           fieldName: 'date',
           initialPayload: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD,
+          parentFieldName: 'amendmentData',
+          url: apimFacilityAmendmentUrl,
+        });
+      });
+    });
+
+    describe(`when amendmentType is ${AMEND_FACILITY_REPLACE_EXPIRY_DATE}`, () => {
+      describe('when an empty object is provided', () => {
+        it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+          // Arrange
+          const mockPayload = {
+            amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+            amendmentData: {},
+          };
+
+          // Act
+          const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+          // Assert
+          expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+          const expected = {
+            error: 'Bad Request',
+            message: ['amendmentData.expiryDate should not be null or undefined', 'amendmentData.expiryDate must be a valid ISO 8601 date string'],
+            statusCode: HttpStatus.BAD_REQUEST,
+          };
+
+          expect(body).toStrictEqual(expected);
+        });
+      });
+
+      describe('when an empty array is provided', () => {
+        it(`should return a ${HttpStatus.BAD_REQUEST} response with validation errors`, async () => {
+          // Arrange
+          const mockPayload = {
+            amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+            amendmentData: [],
+          };
+
+          // Act
+          const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+          // Assert
+          expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+          const expected = {
+            error: 'Bad Request',
+            message: ['amendmentData must be a non-empty object'],
+            statusCode: HttpStatus.BAD_REQUEST,
+          };
+
+          expect(body).toStrictEqual(expected);
+        });
+      });
+
+      describe('expiryDate', () => {
+        dateStringValidation({
+          fieldName: 'expiryDate',
+          initialPayload: {
+            amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+            amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
+          },
           parentFieldName: 'amendmentData',
           url: apimFacilityAmendmentUrl,
         });

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -11,7 +11,7 @@ import { apimFacilityAmendmentUrl, facilityAmendmentUrl, mockResponses, workPack
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
 const {
-  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT },
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_REPLACE_EXPIRY_DATE },
 } = GIFT;
 
 describe('POST /gift/facility/:facilityId/amendment', () => {
@@ -43,6 +43,8 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
     nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
 
     nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_DECREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
+
+    nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_REPLACE_EXPIRY_DATE)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
   });
 
   describe(`${AMEND_FACILITY_INCREASE_AMOUNT}`, () => {
@@ -74,6 +76,28 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
         const mockPayload = {
           amendmentType: AMEND_FACILITY_DECREASE_AMOUNT,
           amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.DECREASE_AMOUNT,
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, mockPayload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.CREATED);
+
+        const expected = mockResponses.facilityAmendment;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe(`${AMEND_FACILITY_REPLACE_EXPIRY_DATE}`, () => {
+    describe(`when the payload is valid and a ${HttpStatus.CREATED} response is returned by all GIFT endpoints`, () => {
+      it(`should return a ${HttpStatus.CREATED} response with a facility and the created amendment`, async () => {
+        // Arrange
+        const mockPayload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
         };
 
         // Act


### PR DESCRIPTION
# Introduction :pencil2:

This PR introduces support for the "Replace expiry date" amendment in GIFT.

**URL**: POST /api/v2/gift/facility/{facilityId}/amendment

**Request payload**:

```json
{
  "amendmentType": "ReplaceExpiryDate",
  "amendmentData": {
    "expiryDate": "2030-03-20"
  }
}
```

## Resolution :heavy_check_mark:

- Create new DTO, `ReplaceExpiryDateDto`.
- Update DTO, `CreateGiftFacilityAmendmentRequestDto`.
- Create helper, `getAmendmentDataDto`.
- Add, update API tests.

## Miscellaneous :heavy_plus_sign:

- Update the app config to include `forbidNonWhitelisted`, so that validation errors appear in responses for fields that are not included in a DTO.
- Minor documentation improvements.
- Update example constants.
- Replace `amendmentData` DTO to have `IsObject` decorator instead of `IsNotEmptyObject` decorator - allows for nicer error messages.
- Simplify some API test mocks/assertions.
- Split up some amendment API tests.


## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
