### PR TITLE
feat(GIFT-20432): amend a GIFT facility - delete work package if amendment fails

### DIFF
--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import { EXAMPLES, GIFT } from '@ukef/constants';
 import { mockWorkPackageId } from '@ukef-test/gift/test-helpers';
-import { mockResponse201 } from '@ukef-test/http-response';
+import { mockResponse201, mockResponse204 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
 import { GiftWorkPackageService } from '../gift.work-package.service';
@@ -20,6 +20,7 @@ describe('GiftFacilityAmendmentService', () => {
   const logger = new PinoLogger({});
 
   let mockHttpServicePost: jest.Mock;
+  let mockHttpServiceDelete: jest.Mock;
   let workPackageService: GiftWorkPackageService;
   let mockWorkPackageServiceCreate: jest.Mock;
 
@@ -33,11 +34,13 @@ describe('GiftFacilityAmendmentService', () => {
 
     mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
     mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockHttpPostResponse);
+    mockHttpServiceDelete = jest.fn().mockResolvedValueOnce(mockResponse204());
 
     workPackageService.create = mockWorkPackageServiceCreate;
 
     giftHttpService = {
       post: mockHttpServicePost,
+      delete: mockHttpServiceDelete,
     };
 
     service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService);
@@ -68,6 +71,14 @@ describe('GiftFacilityAmendmentService', () => {
       path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${mockPayload.amendmentType}`,
       payload: mockPayload.amendmentData,
     });
+  });
+
+  it('should NOT call giftHttpService.delete', async () => {
+    // Act
+    await service.create(mockFacilityId, mockPayload);
+
+    // Assert
+    expect(mockHttpServiceDelete).not.toHaveBeenCalled();
   });
 
   describe('when all calls are successful', () => {

--- a/src/modules/gift/services/gift.http.service.ts
+++ b/src/modules/gift/services/gift.http.service.ts
@@ -21,6 +21,11 @@ export const GIFT_API_ACCEPTABLE_STATUSES = [
   HttpStatus.NOT_FOUND,
 ];
 
+/**
+ * Array of acceptable statuses to consume from a GIFT API DELETE response
+ * NOTE: For DELETE requests, we currently only expect a 204 No content response.
+ * @returns {Array<HttpStatus>}
+ */
 export const GIFT_API_ACCEPTABLE_DELETE_STATUSES = [HttpStatus.NO_CONTENT];
 
 /**

--- a/src/modules/gift/services/gift.http.service.ts
+++ b/src/modules/gift/services/gift.http.service.ts
@@ -21,6 +21,8 @@ export const GIFT_API_ACCEPTABLE_STATUSES = [
   HttpStatus.NOT_FOUND,
 ];
 
+export const GIFT_API_ACCEPTABLE_DELETE_STATUSES = [HttpStatus.NO_CONTENT];
+
 /**
  * GIFT HTTP service.
  * This is responsible for all CRUD calls made to the external GIFT API.
@@ -38,16 +40,21 @@ export class GiftHttpService {
 
   /**
    * Create a new Axios instance
+   * @param {number[]} acceptableStatuses - Array of acceptable statuses to consume from a GIFT API response
+   * NOTE: We need to consume and surface certain error scenarios,
+   * such as Bad request (validation errors), Not found etc.
+   * By default, this is set to GIFT_API_ACCEPTABLE_STATUSES, but can be overridden if needed (e.g. for DELETE requests)
+   * @see GIFT_API_ACCEPTABLE_STATUSES
    * @returns {AxiosInstance}
    */
-  createAxiosInstance(): AxiosInstance {
+  createAxiosInstance(acceptableStatuses: number[] = GIFT_API_ACCEPTABLE_STATUSES): AxiosInstance {
     const instance = axios.create({
       baseURL: this.config.baseUrl,
       headers: {
         [this.config.apiKeyHeaderName]: this.config.apiKeyHeaderValue,
         [CONTENT_TYPE.KEY]: [CONTENT_TYPE.VALUES.JSON],
       },
-      validateStatus: (status) => GIFT_API_ACCEPTABLE_STATUSES.includes(status),
+      validateStatus: (status) => acceptableStatuses.includes(status),
     });
 
     return instance;
@@ -85,6 +92,25 @@ export class GiftHttpService {
       this.logger.error('Error calling POST with path %s %o', path, error);
 
       throw new Error(`Error calling POST with path ${path}`, { cause: error });
+    }
+  }
+
+  /**
+   * Execute a DELETE axios/HTTP request
+   * @param {string} path
+   * @returns {Promise<AxiosResponse<T>>}
+   */
+  async delete<T>({ path }: { path: string }): Promise<AxiosResponse<T>> {
+    try {
+      const axiosInstance = this.createAxiosInstance(GIFT_API_ACCEPTABLE_DELETE_STATUSES);
+
+      const response = await axiosInstance.delete(path);
+
+      return response;
+    } catch (error) {
+      this.logger.error('Error calling DELETE with path %s %o', path, error);
+
+      throw new Error(`Error calling DELETE with path ${path}`, { cause: error });
     }
   }
 }

--- a/test/gift/facility-amendment-error-handling.api-test.ts
+++ b/test/gift/facility-amendment-error-handling.api-test.ts
@@ -1,0 +1,210 @@
+import { HttpStatus } from '@nestjs/common';
+import { GIFT } from '@ukef/constants';
+import { GIFT_EXAMPLES } from '@ukef/constants/examples/gift.examples.constant';
+import { Api } from '@ukef-test/support/api';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import nock from 'nock';
+
+import { apimFacilityAmendmentUrl, facilityAmendmentUrl, facilityWorkPackageUrl, mockResponses, workPackageUrl } from './test-helpers';
+
+const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT },
+} = GIFT;
+
+describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    // Arrange
+    nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
+  });
+
+  describe('GIFT "create work package - congifuration event" endpoint', () => {
+    describe(`when a ${HttpStatus.BAD_REQUEST} response is returned`, () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+
+        const expected = mockResponses.badRequest;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned`, () => {
+      it(`should return a ${HttpStatus.UNAUTHORIZED} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.UNAUTHORIZED);
+
+        const expected = mockResponses.unauthorized;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.FORBIDDEN} response is returned`, () => {
+      it(`should return a ${HttpStatus.FORBIDDEN} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.FORBIDDEN);
+
+        const expected = mockResponses.forbidden;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} response is returned`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.internalServerError);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an unacceptable response is returned', () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.iAmATeapot);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('GIFT "delete work package" endpoint', () => {
+    describe(`when a ${HttpStatus.BAD_REQUEST} response is returned`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.UNAUTHORIZED} response is returned`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.UNAUTHORIZED, mockResponses.unauthorized);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.FORBIDDEN} response is returned`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.FORBIDDEN, mockResponses.forbidden);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} response is returned`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.internalServerError);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+
+    describe('when an unacceptable response is returned', () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
+        // Arrange
+        nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.INTERNAL_SERVER_ERROR, mockResponses.iAmATeapot);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        const expected = mockResponses.internalServerError;
+
+        expect(body).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -6,7 +6,7 @@ import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
 import nock from 'nock';
 
-import { apimFacilityAmendmentUrl, facilityAmendmentUrl, mockResponses, workPackageUrl } from './test-helpers';
+import { apimFacilityAmendmentUrl, facilityAmendmentUrl, facilityWorkPackageUrl, mockResponses } from './test-helpers';
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
@@ -38,7 +38,7 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
   beforeEach(() => {
     // Arrange
-    nock(GIFT_API_URL).persist().post(workPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+    nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
 
     nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
 

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -110,9 +110,10 @@ export const obligationUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACK
 export const repaymentProfileUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_REPAYMENT_PROFILE}`;
 export const riskDetailsUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`;
 export const approveStatusUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.APPROVE}`;
-export const workPackageUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}`;
+export const facilityWorkPackageUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}`;
 export const facilityAmendmentUrl = (amendmentType: string = AMEND_FACILITY_TYPES.AMEND_FACILITY_INCREASE_AMOUNT) =>
   `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${amendmentType}`;
+export const workPackageUrl = `${PATH.WORK_PACKAGE}/${mockWorkPackageId}`;
 
 export const businessCalendar = GIFT_EXAMPLES.BUSINESS_CALENDAR;
 export const businessCalendarsConvention = GIFT_EXAMPLES.BUSINESS_CALENDARS_CONVENTION;

--- a/test/http-response/index.ts
+++ b/test/http-response/index.ts
@@ -22,6 +22,14 @@ export const mockResponse201 = (data: object | Array<any> = {}) => ({
 });
 
 /**
+ * Mock 204 response
+ * @returns {object}
+ */
+export const mockResponse204 = () => ({
+  status: HttpStatus.NO_CONTENT,
+});
+
+/**
  * Mock 400 response
  * @returns {object}
  */


### PR DESCRIPTION
# Introduction :pencil2:

When amending a GIFT facility, the current API flow is:

1) Create facility work package
2) Add amendment to the work package

However, if no.2 fails - the facility would have an empty work package with no amendments.

This PR updates the amendment services so that if no.2 fails, the facility work package is deleted.

## Resolution :heavy_check_mark:

- Update unit tests.
- Update `GiftFacilityAmendmentService.
- Add/update documentation.
- Add `delete` method to `GiftHttpService.create` method.
- Add API tests.
- Add `workPackageUrl` test helper const, rename `workPackageUrl` to `facilityWorkPackageUrl`.


## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
