### PR TITLE
fix(GIFT-20434): risk details - default facility category code

### DIFF
--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -38,6 +38,7 @@ export const GIFT = {
     OVERRIDE_RISK_RATING: null,
     OVERRIDE_LOSS_GIVEN_DEFAULT: null,
     RISK_REASSESSMENT_DATE: null,
+    FACILITY_CATEGORY_CODE: null,
   },
   ENTITY_NAMES: {
     BUSINESS_CALENDAR: 'Business calendar',

--- a/src/modules/gift/services/gift.risk-details.service.test.ts
+++ b/src/modules/gift/services/gift.risk-details.service.test.ts
@@ -39,21 +39,50 @@ describe('GiftRiskDetailsService', () => {
   });
 
   describe('createOne', () => {
-    it('should call giftHttpService.post', async () => {
-      // Act
-      await service.createOne(RISK_DETAILS, mockFacilityId, mockWorkPackageId);
+    describe('when facilityCategoryCode is NOT provided', () => {
+      it('should call giftHttpService.post with facilityCategoryCode as null', async () => {
+        // Act
+        await service.createOne(RISK_DETAILS, mockFacilityId, mockWorkPackageId);
 
-      // Assert
-      expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
 
-      expect(mockHttpServicePost).toHaveBeenCalledWith({
-        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`,
-        payload: {
+        expect(mockHttpServicePost).toHaveBeenCalledWith({
+          path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`,
+          payload: {
+            ...RISK_DETAILS,
+            overrideRiskRating: INTEGRATION_DEFAULTS.OVERRIDE_RISK_RATING,
+            overrideLossGivenDefault: INTEGRATION_DEFAULTS.OVERRIDE_LOSS_GIVEN_DEFAULT,
+            riskReassessmentDate: INTEGRATION_DEFAULTS.RISK_REASSESSMENT_DATE,
+            facilityCategoryCode: null,
+          },
+        });
+      });
+    });
+
+    describe('when facilityCategoryCode is provided', () => {
+      it('should call giftHttpService.post with the provided facilityCategoryCode', async () => {
+        // Arrange
+        const mockPayload = {
           ...RISK_DETAILS,
-          overrideRiskRating: INTEGRATION_DEFAULTS.OVERRIDE_RISK_RATING,
-          overrideLossGivenDefault: INTEGRATION_DEFAULTS.OVERRIDE_LOSS_GIVEN_DEFAULT,
-          riskReassessmentDate: INTEGRATION_DEFAULTS.RISK_REASSESSMENT_DATE,
-        },
+          facilityCategoryCode: 'Mock facility category code',
+        };
+
+        // Act
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        expect(mockHttpServicePost).toHaveBeenCalledWith({
+          path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`,
+          payload: {
+            ...mockPayload,
+            overrideRiskRating: INTEGRATION_DEFAULTS.OVERRIDE_RISK_RATING,
+            overrideLossGivenDefault: INTEGRATION_DEFAULTS.OVERRIDE_LOSS_GIVEN_DEFAULT,
+            riskReassessmentDate: INTEGRATION_DEFAULTS.RISK_REASSESSMENT_DATE,
+          },
+        });
       });
     });
 

--- a/src/modules/gift/services/gift.risk-details.service.ts
+++ b/src/modules/gift/services/gift.risk-details.service.ts
@@ -32,14 +32,17 @@ export class GiftRiskDetailsService {
     try {
       this.logger.info('Creating risk details for facility %s', facilityId);
 
+      const payload = {
+        ...riskDetailsData,
+        overrideRiskRating: INTEGRATION_DEFAULTS.OVERRIDE_RISK_RATING,
+        overrideLossGivenDefault: INTEGRATION_DEFAULTS.OVERRIDE_LOSS_GIVEN_DEFAULT,
+        riskReassessmentDate: INTEGRATION_DEFAULTS.RISK_REASSESSMENT_DATE,
+        facilityCategoryCode: riskDetailsData.facilityCategoryCode || INTEGRATION_DEFAULTS.FACILITY_CATEGORY_CODE,
+      };
+
       const response = await this.giftHttpService.post<GiftBusinessCalendarsConventionResponseDto>({
         path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`,
-        payload: {
-          ...riskDetailsData,
-          overrideRiskRating: INTEGRATION_DEFAULTS.OVERRIDE_RISK_RATING,
-          overrideLossGivenDefault: INTEGRATION_DEFAULTS.OVERRIDE_LOSS_GIVEN_DEFAULT,
-          riskReassessmentDate: INTEGRATION_DEFAULTS.RISK_REASSESSMENT_DATE,
-        },
+        payload,
       });
 
       return response;


### PR DESCRIPTION
# Introduction :pencil2:

GIFT facility - risk details has a `facilityCategoryCode` - if a product does not require a facility category code, it should be sent to GIFT as null.

## Resolution :heavy_check_mark:

- Update `GiftRiskDetailsService.createOne` to default `facilityCategoryCode`, if not provided.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
