### PR TITLE
chore(GIFT-21508): update MDM endpoints to specify MDM version

### DIFF
--- a/src/modules/http/http.client.get.test.ts
+++ b/src/modules/http/http.client.get.test.ts
@@ -32,6 +32,7 @@ describe('HttpClient', () => {
     };
 
     const expectedHttpServiceGetArgs: [string, object] = [path, { headers, params: queryParams }];
+    const expectedHttpServiceGetArgsWithoutHeaders: [string, object] = [path, { params: queryParams }];
 
     const response: AxiosResponse = {
       data: {
@@ -79,6 +80,34 @@ describe('HttpClient', () => {
         });
 
         expect(onError).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when headers are not provided', () => {
+      beforeEach(() => {
+        when(httpServiceGet)
+          .calledWith(...expectedHttpServiceGetArgsWithoutHeaders)
+          .mockReturnValueOnce(of(response));
+      });
+
+      it('calls HttpService.get without headers in config', async () => {
+        await client.get({
+          path,
+          queryParams,
+          onError,
+        });
+
+        expect(httpServiceGet).toHaveBeenCalledWith(...expectedHttpServiceGetArgsWithoutHeaders);
+      });
+
+      it('resolves with the same response', async () => {
+        const result = await client.get({
+          path,
+          queryParams,
+          onError,
+        });
+
+        expect(result).toBe(response);
       });
     });
 

--- a/src/modules/http/http.client.get.test.ts
+++ b/src/modules/http/http.client.get.test.ts
@@ -60,7 +60,7 @@ describe('HttpClient', () => {
           .mockReturnValueOnce(of(response));
       });
 
-      it('resolves with the same response', async () => {
+      it('should return the same response', async () => {
         const result = await client.get({
           path,
           queryParams,
@@ -71,7 +71,7 @@ describe('HttpClient', () => {
         expect(result).toBe(response);
       });
 
-      it('does not call onError', async () => {
+      it('should NOT call onError', async () => {
         await client.get({
           path,
           queryParams,
@@ -90,7 +90,7 @@ describe('HttpClient', () => {
           .mockReturnValueOnce(of(response));
       });
 
-      it('calls HttpService.get without headers in config', async () => {
+      it('should call HttpService.get without headers in config', async () => {
         await client.get({
           path,
           queryParams,
@@ -100,7 +100,7 @@ describe('HttpClient', () => {
         expect(httpServiceGet).toHaveBeenCalledWith(...expectedHttpServiceGetArgsWithoutHeaders);
       });
 
-      it('resolves with the same response', async () => {
+      it('should return the same response', async () => {
         const result = await client.get({
           path,
           queryParams,
@@ -124,7 +124,7 @@ describe('HttpClient', () => {
           .mockImplementationOnce(() => throwError(() => errorThatOnErrorThrows));
       });
 
-      it('calls onError with the error that HttpService errored with', async () => {
+      it('should call onError with the error that HttpService errored with', async () => {
         await client
           .get({
             path,
@@ -140,15 +140,15 @@ describe('HttpClient', () => {
         expect(onError).toHaveBeenCalledTimes(1);
       });
 
-      it('rejects with the error that onError throws', async () => {
-        const clientPostPromise = client.get({
+      it('should reject with the error that onError throws', async () => {
+        const clientGetPromise = client.get({
           path,
           queryParams,
           headers,
           onError,
         });
 
-        await expect(clientPostPromise).rejects.toBe(errorThatOnErrorThrows);
+        await expect(clientGetPromise).rejects.toBe(errorThatOnErrorThrows);
       });
     });
   });

--- a/src/modules/http/http.client.post.test.ts
+++ b/src/modules/http/http.client.post.test.ts
@@ -60,7 +60,7 @@ describe('HttpClient', () => {
           .mockReturnValueOnce(of(response));
       });
 
-      it('resolves with the same response', async () => {
+      it('should return the same response', async () => {
         const result = await client.post({
           path,
           requestBody,
@@ -71,7 +71,7 @@ describe('HttpClient', () => {
         expect(result).toBe(response);
       });
 
-      it('does not call onError', async () => {
+      it('should NOT call onError', async () => {
         await client.post({
           path,
           requestBody,
@@ -90,7 +90,7 @@ describe('HttpClient', () => {
           .mockReturnValueOnce(of(response));
       });
 
-      it('calls HttpService.post with an empty config object', async () => {
+      it('should call HttpService.post with an empty config object', async () => {
         await client.post({
           path,
           requestBody,
@@ -100,7 +100,7 @@ describe('HttpClient', () => {
         expect(httpServicePost).toHaveBeenCalledWith(...expectedHttpServicePostArgsWithoutHeaders);
       });
 
-      it('resolves with the same response', async () => {
+      it('should return the same response', async () => {
         const result = await client.post({
           path,
           requestBody,
@@ -124,7 +124,7 @@ describe('HttpClient', () => {
           .mockImplementationOnce(() => throwError(() => errorThatOnErrorThrows));
       });
 
-      it('calls onError with the error that HttpService errored with', async () => {
+      it('should call onError with the error that HttpService errored with', async () => {
         await client
           .post({
             path,
@@ -140,7 +140,7 @@ describe('HttpClient', () => {
         expect(onError).toHaveBeenCalledTimes(1);
       });
 
-      it('rejects with the error that onError throws', async () => {
+      it('should reject with the error that onError throws', async () => {
         const clientPostPromise = client.post({
           path,
           requestBody,

--- a/src/modules/http/http.client.post.test.ts
+++ b/src/modules/http/http.client.post.test.ts
@@ -32,6 +32,7 @@ describe('HttpClient', () => {
     };
 
     const expectedHttpServicePostArgs: [string, object, object] = [path, requestBody, { headers }];
+    const expectedHttpServicePostArgsWithoutHeaders: [string, object, object] = [path, requestBody, {}];
 
     const response: AxiosResponse = {
       data: {
@@ -79,6 +80,34 @@ describe('HttpClient', () => {
         });
 
         expect(onError).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when headers are not provided', () => {
+      beforeEach(() => {
+        when(httpServicePost)
+          .calledWith(...expectedHttpServicePostArgsWithoutHeaders)
+          .mockReturnValueOnce(of(response));
+      });
+
+      it('calls HttpService.post with an empty config object', async () => {
+        await client.post({
+          path,
+          requestBody,
+          onError,
+        });
+
+        expect(httpServicePost).toHaveBeenCalledWith(...expectedHttpServicePostArgsWithoutHeaders);
+      });
+
+      it('resolves with the same response', async () => {
+        const result = await client.post({
+          path,
+          requestBody,
+          onError,
+        });
+
+        expect(result).toBe(response);
       });
     });
 

--- a/src/modules/http/http.client.ts
+++ b/src/modules/http/http.client.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { AxiosResponse } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { catchError, lastValueFrom, Observable, ObservableInput } from 'rxjs';
 
 import { RequestHeaders } from './type/headers.type';
@@ -16,10 +16,16 @@ export class HttpClient {
   }: {
     path: string;
     requestBody: RequestBody;
-    headers: RequestHeaders;
+    headers?: RequestHeaders;
     onError: (error: Error) => ObservableInput<never>;
   }): Promise<AxiosResponse<ResponseBody, RequestBody>> {
-    return this.responseFrom({ request: this.httpService.post<ResponseBody>(path, requestBody, { headers }), onError });
+    const config: AxiosRequestConfig<RequestBody> = {};
+
+    if (headers) {
+      config.headers = headers;
+    }
+
+    return this.responseFrom({ request: this.httpService.post<ResponseBody>(path, requestBody, config), onError });
   }
 
   get<QueryParams, ResponseBody>({
@@ -30,10 +36,16 @@ export class HttpClient {
   }: {
     path: string;
     queryParams: QueryParams;
-    headers: RequestHeaders;
+    headers?: RequestHeaders;
     onError: (error: Error) => ObservableInput<never>;
   }): Promise<AxiosResponse<ResponseBody>> {
-    return this.responseFrom({ request: this.httpService.get<ResponseBody>(path, { headers, params: queryParams }), onError });
+    const config: AxiosRequestConfig = { params: queryParams };
+
+    if (headers) {
+      config.headers = headers;
+    }
+
+    return this.responseFrom({ request: this.httpService.get<ResponseBody>(path, config), onError });
   }
 
   private async responseFrom<RequestBody, ResponseBody>({

--- a/src/modules/mdm/mdm.service.test.ts
+++ b/src/modules/mdm/mdm.service.test.ts
@@ -40,7 +40,6 @@ describe('MdmService', () => {
 
     const expectedHttpServiceGetArgs: [string, object] = ['/v1/customers', { headers: {}, params: { partyUrn: partyUrnToSearch } }];
 
-    // TODO: clean up.
     it('returns the search results from sending a GET request to the MDM /v1/customers?partyUrn={partyUrn} endpoint', async () => {
       when(httpServiceGet)
         .calledWith(...expectedHttpServiceGetArgs)

--- a/src/modules/mdm/mdm.service.test.ts
+++ b/src/modules/mdm/mdm.service.test.ts
@@ -21,7 +21,7 @@ describe('MdmService', () => {
     httpServiceGet = jest.fn();
     httpService.get = httpServiceGet;
 
-    service = new MdmService(httpService, null);
+    service = new MdmService(httpService);
   });
 
   describe('findCustomersByPartyUrn', () => {
@@ -38,7 +38,7 @@ describe('MdmService', () => {
       },
     ];
 
-    const expectedHttpServiceGetArgs: [string, object] = ['/v1/customers', { headers: {}, params: { partyUrn: partyUrnToSearch } }];
+    const expectedHttpServiceGetArgs: [string, object] = ['/v1/customers', { params: { partyUrn: partyUrnToSearch } }];
 
     it('returns the search results from sending a GET request to the MDM /v1/customers?partyUrn={partyUrn} endpoint', async () => {
       when(httpServiceGet)

--- a/src/modules/mdm/mdm.service.test.ts
+++ b/src/modules/mdm/mdm.service.test.ts
@@ -17,10 +17,11 @@ describe('MdmService', () => {
 
   beforeEach(() => {
     const httpService = new HttpService();
+
     httpServiceGet = jest.fn();
     httpService.get = httpServiceGet;
 
-    service = new MdmService(httpService);
+    service = new MdmService(httpService, null);
   });
 
   describe('findCustomersByPartyUrn', () => {
@@ -37,9 +38,10 @@ describe('MdmService', () => {
       },
     ];
 
-    const expectedHttpServiceGetArgs: [string, object] = ['/customers', { headers: {}, params: { partyUrn: partyUrnToSearch } }];
+    const expectedHttpServiceGetArgs: [string, object] = ['/v1/customers', { headers: {}, params: { partyUrn: partyUrnToSearch } }];
 
-    it('returns the search results from sending a GET request to the MDM /customers?partyUrn={partyUrn} endpoint', async () => {
+    // TODO: clean up.
+    it('returns the search results from sending a GET request to the MDM /v1/customers?partyUrn={partyUrn} endpoint', async () => {
       when(httpServiceGet)
         .calledWith(...expectedHttpServiceGetArgs)
         .mockReturnValueOnce(
@@ -57,7 +59,7 @@ describe('MdmService', () => {
       expect(foundCustomers).toBe(customerSearchResults);
     });
 
-    it('throws an MdmResourceNotFoundException if the request to MDM fails with a 404 response', async () => {
+    it('throws an MdmResourceNotFoundException if the request in APIM MDM fails with a 404 response', async () => {
       const axios404Error = new AxiosError();
       axios404Error.response = { data: valueGenerator.string(), status: 404, statusText: 'Not Found', headers: undefined, config: undefined };
       when(httpServiceGet)
@@ -68,12 +70,12 @@ describe('MdmService', () => {
 
       await expect(findCustomersPromise).rejects.toBeInstanceOf(MdmResourceNotFoundException);
       await expect(findCustomersPromise).rejects.toThrow(
-        `Failed to find customers with partyUrn ${partyUrnToSearch} in MDM. The response status was 404 Not Found.`,
+        `Failed to find customers with partyUrn ${partyUrnToSearch} in APIM MDM. The response status was 404 Not Found.`,
       );
       await expect(findCustomersPromise).rejects.toHaveProperty('innerError', axios404Error);
     });
 
-    it('throws an MdmException that is not an MdmResourceNotFoundException if the request to MDM fails with a 500 response', async () => {
+    it('throws an MdmException that is not an MdmResourceNotFoundException if the request to APIM MDM fails with a 500 response', async () => {
       const axios500Error = new AxiosError();
       axios500Error.response = { data: valueGenerator.string(), status: 500, statusText: 'Internal Server Error', headers: undefined, config: undefined };
       when(httpServiceGet)
@@ -84,11 +86,11 @@ describe('MdmService', () => {
 
       await expect(findCustomersPromise).rejects.not.toBeInstanceOf(MdmResourceNotFoundException);
       await expect(findCustomersPromise).rejects.toBeInstanceOf(MdmException);
-      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in MDM.`);
+      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in APIM MDM.`);
       await expect(findCustomersPromise).rejects.toHaveProperty('innerError', axios500Error);
     });
 
-    it('throws an MdmException that is not an MdmResourceNotFoundException if the request to MDM fails with an AxiosError without a response', async () => {
+    it('throws an MdmException that is not an MdmResourceNotFoundException if the request in APIM MDM fails with an AxiosError without a response', async () => {
       const axiosErrorWithoutResponse = new AxiosError();
       when(httpServiceGet)
         .calledWith(...expectedHttpServiceGetArgs)
@@ -98,11 +100,11 @@ describe('MdmService', () => {
 
       await expect(findCustomersPromise).rejects.not.toBeInstanceOf(MdmResourceNotFoundException);
       await expect(findCustomersPromise).rejects.toBeInstanceOf(MdmException);
-      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in MDM.`);
+      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in APIM MDM.`);
       await expect(findCustomersPromise).rejects.toHaveProperty('innerError', axiosErrorWithoutResponse);
     });
 
-    it('throws an MdmException that is not an MdmResourceNotFoundException if the request to MDM fails with a generic error', async () => {
+    it('throws an MdmException that is not an MdmResourceNotFoundException if the request in APIM MDM fails with a generic error', async () => {
       const error = new Error();
       when(httpServiceGet)
         .calledWith(...expectedHttpServiceGetArgs)
@@ -112,7 +114,7 @@ describe('MdmService', () => {
 
       await expect(findCustomersPromise).rejects.not.toBeInstanceOf(MdmResourceNotFoundException);
       await expect(findCustomersPromise).rejects.toBeInstanceOf(MdmException);
-      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in MDM.`);
+      await expect(findCustomersPromise).rejects.toThrow(`Failed to find customers with partyUrn ${partyUrnToSearch} in APIM MDM.`);
       await expect(findCustomersPromise).rejects.toHaveProperty('innerError', error);
     });
   });

--- a/src/modules/mdm/mdm.service.ts
+++ b/src/modules/mdm/mdm.service.ts
@@ -2,7 +2,6 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { HttpClient } from '@ukef/modules/http/http.client';
 import { AxiosError } from 'axios';
-import { PinoLogger } from 'nestjs-pino';
 import { throwError } from 'rxjs';
 
 import { MdmCustomersParams } from './dto/mdm-customers-params.dto';
@@ -13,11 +12,9 @@ import { MdmResourceNotFoundException } from './exception/mdm-resource-not-found
 @Injectable()
 export class MdmService {
   private readonly httpClient: HttpClient;
-  private readonly logger: PinoLogger;
 
-  constructor(httpService: HttpService, logger: PinoLogger) {
+  constructor(httpService: HttpService) {
     this.httpClient = new HttpClient(httpService);
-    this.logger = logger;
   }
 
   /**

--- a/src/modules/mdm/mdm.service.ts
+++ b/src/modules/mdm/mdm.service.ts
@@ -2,6 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { HttpClient } from '@ukef/modules/http/http.client';
 import { AxiosError } from 'axios';
+import { PinoLogger } from 'nestjs-pino';
 import { throwError } from 'rxjs';
 
 import { MdmCustomersParams } from './dto/mdm-customers-params.dto';
@@ -12,25 +13,34 @@ import { MdmResourceNotFoundException } from './exception/mdm-resource-not-found
 @Injectable()
 export class MdmService {
   private readonly httpClient: HttpClient;
+  private readonly logger: PinoLogger;
 
-  constructor(httpService: HttpService) {
+  constructor(httpService: HttpService, logger: PinoLogger) {
     this.httpClient = new HttpClient(httpService);
+    this.logger = logger;
   }
 
+  /**
+   * Finds a customer in APIM MDM by their party URN.
+   * @param {string} partyUrnToSearch: The party URN to search for.
+   * @returns {Promise<MdmCustomersResponse>}
+   */
   async findCustomersByPartyUrn(partyUrnToSearch: string): Promise<MdmCustomersResponse> {
     const { data: customerSearchResults } = await this.httpClient.get<MdmCustomersParams, MdmCustomersResponse>({
-      path: '/customers',
+      path: '/v1/customers',
       queryParams: { partyUrn: partyUrnToSearch },
-      headers: {},
       onError: (error: Error) =>
         throwError(() => {
-          const baseErrorMessage = `Failed to find customers with partyUrn ${partyUrnToSearch} in MDM.`;
+          const baseErrorMessage = `Failed to find customers with partyUrn ${partyUrnToSearch} in APIM MDM.`;
+
           if (error instanceof AxiosError && error.response?.status === 404) {
             return new MdmResourceNotFoundException(`${baseErrorMessage} The response status was 404 Not Found.`, error);
           }
+
           return new MdmException(baseErrorMessage, error);
         }),
     });
+
     return customerSearchResults;
   }
 }

--- a/src/modules/party/party-customer-type.service.test.ts
+++ b/src/modules/party/party-customer-type.service.test.ts
@@ -4,6 +4,7 @@ import { AxiosError } from 'axios';
 import { when } from 'jest-when';
 import { PinoLogger } from 'nestjs-pino';
 
+import { HttpService } from '../http/http.module';
 import { MdmException } from '../mdm/exception/mdm.exception';
 import { MdmResourceNotFoundException } from '../mdm/exception/mdm-resource-not-found.exception';
 import { PartyCustomerTypeService } from './party-customer-type.service';
@@ -20,7 +21,9 @@ describe('PartyCustomerTypeService', () => {
   let service: PartyCustomerTypeService;
 
   beforeEach(() => {
-    const mdmService = new MdmService(null);
+    const httpService = new HttpService();
+
+    const mdmService = new MdmService(httpService, null);
     findCustomersByPartyUrn = jest.fn();
     mdmService.findCustomersByPartyUrn = findCustomersByPartyUrn;
 

--- a/src/modules/party/party-customer-type.service.test.ts
+++ b/src/modules/party/party-customer-type.service.test.ts
@@ -23,7 +23,7 @@ describe('PartyCustomerTypeService', () => {
   beforeEach(() => {
     const httpService = new HttpService();
 
-    const mdmService = new MdmService(httpService, null);
+    const mdmService = new MdmService(httpService);
     findCustomersByPartyUrn = jest.fn();
     mdmService.findCustomersByPartyUrn = findCustomersByPartyUrn;
 


### PR DESCRIPTION
# Introduction :pencil2:

For DTFS => APIM integration, APIM TFS needs to call a new APIM MDM endpoint.

Currently, MDM endpoints in TFS, do not specify the MDM endpoint version and so it is defaulted.

This PR updates the MDM integration so that the existing MDM endpoint specifies a version.

## Resolution :heavy_check_mark:

- Update `HttpClient` to optionally include headers.
- Update `MdmService.findCustomersByPartyUrn` to specific `v1` in the path.
- Update tests.

## Miscellaneous :heavy_plus_sign:

- Minor readability, logging, documentation improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
