### PR TITLE
chore(APIM-625): improve import deployment step

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -173,13 +173,6 @@ jobs:
             echo "✅ FQDN resolved: https://$FQDN"
 
             echo "📄 Downloading OpenAPI specification..."
-            # curl -fsSL "https://$FQDN/openapi/json" -o openapi.json
-            # if [ $? -ne 0 ]; then
-            #   echo "❌ Failed to download OpenAPI spec from Container App"
-            #   exit 1
-            # fi
-            # echo "✅ OpenAPI spec downloaded"
-
 
             http_status=$(curl -fsSL \
               --connect-timeout 10 \
@@ -216,7 +209,7 @@ jobs:
                 --api-id "${{ env.API_ID }}" \
                 --path "${{ env.NAME }}" \
                 --specification-format OpenApi \
-                --specification-file openapi.json \
+                --specification-path openapi.json \
                 --api-type http \
                 --service-url "https://$FQDN" \
                 --protocols https \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -173,12 +173,35 @@ jobs:
             echo "✅ FQDN resolved: https://$FQDN"
 
             echo "📄 Downloading OpenAPI specification..."
-            curl -fsSL "https://$FQDN/openapi/json" -o openapi.json
-            if [ $? -ne 0 ]; then
-              echo "❌ Failed to download OpenAPI spec from Container App"
+            # curl -fsSL "https://$FQDN/openapi/json" -o openapi.json
+            # if [ $? -ne 0 ]; then
+            #   echo "❌ Failed to download OpenAPI spec from Container App"
+            #   exit 1
+            # fi
+            # echo "✅ OpenAPI spec downloaded"
+
+
+            http_status=$(curl -fsSL \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --retry 5 \
+              --retry-all-errors \
+              -w "%{http_code}" \
+              "https://$FQDN/openapi/json" \
+              -o openapi.json)
+            curl_exit=$?
+
+            if [ $curl_exit -ne 0 ]; then
+              echo "❌ Failed to download OpenAPI spec from Container App (curl exit code: $curl_exit, HTTP status: $http_status)"
               exit 1
             fi
-            echo "✅ OpenAPI spec downloaded"
+
+            if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+              echo "❌ Failed to download OpenAPI spec from Container App (unexpected HTTP status: $http_status)"
+              exit 1
+            fi
+
+            echo "✅ OpenAPI spec downloaded (HTTP status: $http_status)"
 
             echo "📡 Importing API into APIM (with retry logic)..."
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -155,20 +155,60 @@ jobs:
               "GIFT_API_TIMEOUT=${{ secrets.GIFT_API_TIMEOUT }}" \
               "GIFT_HTTP_VERSION=${{ vars.GIFT_HTTP_VERSION }}"
 
-      - name: Import ⬇️
-        if: ${{ '' != env.API_ID }}
+      - name: Import
+        if: ${{ env.API_ID != '' }}
         uses: Azure/cli@v2.2.0
         with:
           inlineScript: |
-            # API specification import
+            echo "🔍 Fetching Container App FQDN..."
+            FQDN=$(az containerapp show \
+              --name "${{ env.CA_NAME }}" \
+              --query properties.latestRevisionFqdn -o tsv)
 
-            az apim api import \
-            --path '${{ env.NAME }}' \
-            --service-name ${{ env.APIM }} \
-            --specification-format OpenApi \
-            --api-id ${{ env.API_ID }} \
-            --api-type http \
-            --service-url https://$(az containerapp show --name ${{ env.CA_NAME }} --query properties.latestRevisionFqdn -o tsv) \
-            --protocols https \
-            --specification-url https://$(az containerapp show --name ${{ env.CA_NAME }} --query properties.latestRevisionFqdn -o tsv)/openapi/json \
-            --subscription-required true
+            if [ -z "$FQDN" ]; then
+              echo "❌ Failed to retrieve Container App FQDN"
+              exit 1
+            fi
+
+            echo "✅ FQDN resolved: https://$FQDN"
+
+            echo "📄 Downloading OpenAPI specification..."
+            curl -fsSL "https://$FQDN/openapi/json" -o openapi.json
+            if [ $? -ne 0 ]; then
+              echo "❌ Failed to download OpenAPI spec from Container App"
+              exit 1
+            fi
+            echo "✅ OpenAPI spec downloaded"
+
+            echo "📡 Importing API into APIM (with retry logic)..."
+
+            max_retries=5
+            delay=15
+
+            for attempt in $(seq 1 $max_retries); do
+              echo "➡️ Attempt $attempt of $max_retries"
+
+              az apim api import \
+                --service-name "${{ env.APIM }}" \
+                --api-id "${{ env.API_ID }}" \
+                --path "${{ env.NAME }}" \
+                --specification-format OpenApi \
+                --specification-file openapi.json \
+                --api-type http \
+                --service-url "https://$FQDN" \
+                --protocols https \
+                --subscription-required true
+
+              if [ $? -eq 0 ]; then
+                echo "✅ API import succeeded"
+                break
+              fi
+
+              if [ $attempt -eq $max_retries ]; then
+                echo "❌ API import failed after $max_retries attempts"
+                exit 1
+              fi
+
+              echo "⚠️ Import failed. Retrying in $delay seconds..."
+              sleep $delay
+            done


### PR DESCRIPTION
# Introduction :pencil2:

APIM TFS deplyoment is being flaky: https://github.com/UK-Export-Finance/tfs-api/actions/runs/23431814320/job/68162588291

If this improves the deployment `Import` step, we can roll this out to APIM MDM and APIM Estore.

## Resolution :heavy_check_mark:

- Update `Import` deployment step to:
  - Only call `az containerapp show ...` once.
  - Avoid APIM dev tier timeout when fetching the API spec by downloading the spec with curl instead of APIM => ContainerAPp roundtrips and latency.
  - Introduce retry logic (solved developer SKU flakiness)

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
