### PR TITLE
fix(GIFT-24034): get multiple facilities - 404 if none found

### DIFF
--- a/src/modules/gift/services/gift.facility.service/gift.facility.service-getMany.test.ts
+++ b/src/modules/gift/services/gift.facility.service/gift.facility.service-getMany.test.ts
@@ -1,3 +1,4 @@
+import { HttpStatus, NotFoundException } from '@nestjs/common';
 import { EXAMPLES } from '@ukef/constants';
 import { mockGiftFacilityCreationErrorService } from '@ukef-test/gift/mock-services';
 import { mockResponse200 } from '@ukef-test/http-response';
@@ -126,6 +127,48 @@ describe('GiftFacilityService.getMany', () => {
       const expected = [mockResponseGet1.data, mockResponseGet2.data, mockResponseGet3.data];
 
       expect(response).toEqual(expected);
+    });
+
+    describe(`when all facilities return ${HttpStatus.NOT_FOUND}`, () => {
+      beforeEach(() => {
+        mockGet = jest
+          .fn()
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.NOT_FOUND }))
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.NOT_FOUND }))
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.NOT_FOUND }));
+
+        service.get = mockGet;
+      });
+
+      it('should throw a NotFoundException with the facility IDs', async () => {
+        // Act
+        const promise = service.getMany(mockFacilityIds);
+
+        // Assert
+        await expect(promise).rejects.toThrow(NotFoundException);
+
+        await expect(promise).rejects.toThrow(`No GIFT facilities found for IDs ${mockFacilityIds}`);
+      });
+    });
+
+    describe(`when at least one facility does not return ${HttpStatus.NOT_FOUND}`, () => {
+      beforeEach(() => {
+        mockGet = jest
+          .fn()
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.NOT_FOUND }))
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.OK }))
+          .mockResolvedValueOnce(mockResponse200({ statusCode: HttpStatus.NOT_FOUND }));
+
+        service.get = mockGet;
+      });
+
+      it('should return mapped responses', async () => {
+        // Act
+        const response = await service.getMany(mockFacilityIds);
+
+        // Assert
+        expect(response).toEqual([{ statusCode: HttpStatus.NOT_FOUND }, { statusCode: HttpStatus.OK }, { statusCode: HttpStatus.NOT_FOUND }]);
+      });
     });
   });
 

--- a/src/modules/gift/services/gift.facility.service/index.ts
+++ b/src/modules/gift/services/gift.facility.service/index.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { GIFT } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers';
 import { AxiosResponse } from 'axios';
@@ -103,8 +103,22 @@ export class GiftFacilityService {
         responses.push(response);
       }
 
-      return responses.map(({ data }) => data);
+      const mappedResponses = responses.map((response) => response.data);
+
+      const noFacilitiesFound = mappedResponses.every((response) => response.statusCode === HttpStatus.NOT_FOUND);
+
+      if (noFacilitiesFound) {
+        this.logger.info('No GIFT facilities found for IDs %o', facilityIds);
+
+        throw new NotFoundException(`No GIFT facilities found for IDs ${facilityIds}`);
+      }
+
+      return mappedResponses;
     } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+
       this.logger.error('Error getting multiple GIFT facilities %o %o', facilityIds, error);
 
       throw new Error(`Error getting multiple GIFT facilities ${facilityIds}`, { cause: error });

--- a/test/gift/get-facilities-by-id.api-test.ts
+++ b/test/gift/get-facilities-by-id.api-test.ts
@@ -122,6 +122,53 @@ describe('GET /gift/facilities?ids={ids}', () => {
     });
   });
 
+  describe(`when ${HttpStatus.NOT_FOUND} responses are returned by GIFT for all facilities`, () => {
+    it(`should return a ${HttpStatus.NOT_FOUND} response`, async () => {
+      // Arrange
+      const notFoundResponse = {
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'not found',
+      };
+
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[0]}`).reply(HttpStatus.NOT_FOUND, notFoundResponse);
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[1]}`).reply(HttpStatus.NOT_FOUND, notFoundResponse);
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[2]}`).reply(HttpStatus.NOT_FOUND, notFoundResponse);
+
+      // Act
+      const { status, body } = await api.get(url);
+
+      // Assert
+      expect(status).toEqual(HttpStatus.NOT_FOUND);
+      expect(body.statusCode).toEqual(HttpStatus.NOT_FOUND);
+      expect(body.message).toBe(`No GIFT facilities found for IDs ${mockFacilityIdsPathParam}`);
+    });
+  });
+
+  describe(`when a ${HttpStatus.NOT_FOUND} response is returned by GIFT for one facility`, () => {
+    it(`should return a ${HttpStatus.OK} response containing the mixed facility responses`, async () => {
+      // Arrange
+      const mockNotFoundResponse = {
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'not found',
+      };
+
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[0]}`).reply(HttpStatus.OK, { facilityId: mockFacilityIds[0], aMockFacility: true });
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[1]}`).reply(HttpStatus.NOT_FOUND, mockNotFoundResponse);
+      nock(GIFT_API_URL).get(`${FACILITY}/${mockFacilityIds[2]}`).reply(HttpStatus.OK, { facilityId: mockFacilityIds[2], aMockFacility: true });
+
+      // Act
+      const { status, body } = await api.get(url);
+
+      // Assert
+      expect(status).toEqual(HttpStatus.OK);
+      expect(body).toHaveLength(mockFacilityIds.length);
+
+      expect(body[0]).toStrictEqual({ facilityId: mockFacilityIds[0], aMockFacility: true });
+      expect(body[1]).toStrictEqual(mockNotFoundResponse);
+      expect(body[2]).toStrictEqual({ facilityId: mockFacilityIds[2], aMockFacility: true });
+    });
+  });
+
   describe(`when a ${HttpStatus.INTERNAL_SERVER_ERROR} response is returned by GIFT`, () => {
     it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
       // Arrange


### PR DESCRIPTION
# Introduction :pencil2:

This PR updates the "get multiple GIFT facilities" endpoint so that if no facilities are found, a 404 is returned, instead of 200.

## Resolution :heavy_check_mark:

- Update `GiftFacilityService.getMany`.
- Add/update tests.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
