### PR TITLE
feat(GIFT-24460): amend a gift facility - amount handling

### DIFF
--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -13,6 +13,9 @@ export type AmendFacilityType = (typeof AMEND_FACILITY_TYPES)[keyof typeof AMEND
 
 export const GIFT = {
   AMEND_FACILITY_TYPES,
+  AMEND_OBLIGATION_AMOUNT: {
+    PERCENTAGE_OF_FACILITY_AMOUNT: 85,
+  },
   API_RESPONSE_MESSAGES: {
     ASYNC_FACILITY_VALIDATION_ERRORS: 'Async validation errors with facility entity(s)',
     GIFT_FACILITY_VALIDATION_ERRORS: 'GIFT validation errors with facility entity(s)',

--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -15,10 +15,34 @@ export const AMEND_FACILITY_TYPES_ARRAY = Object.values(AMEND_FACILITY_TYPES);
 
 export type AmendFacilityType = (typeof AMEND_FACILITY_TYPES)[keyof typeof AMEND_FACILITY_TYPES];
 
+const FACILITY_CATEGORY_CODES = {
+  CONTINGENT: 'FCT006',
+  CASH: 'FCT007',
+} as const;
+
+export type FacilityCategoryCode = (typeof FACILITY_CATEGORY_CODES)[keyof typeof FACILITY_CATEGORY_CODES];
+
+const PRODUCT_TYPE_CODES = {
+  BIP: 'PRT001',
+  EXIP: 'PRT002',
+  BSS: 'PRT003',
+  GEF: 'PRT004',
+} as const;
+
+const PRODUCT_TYPE_NAMES = {
+  BIP: 'Bond Insurance Policy (BIP)',
+  EXIP: 'Export Insurance Policy (EXIP)',
+  BSS: 'Bond Support Scheme (BSS)',
+  GEF: 'General Export Facility (GEF)',
+} as const;
+
 export const GIFT = {
   AMEND_FACILITY_TYPES,
   AMEND_OBLIGATION_AMOUNT: {
-    PERCENTAGE_OF_FACILITY_AMOUNT: 85,
+    PERCENTAGE_OF_FACILITY_AMOUNT: {
+      [FACILITY_CATEGORY_CODES.CONTINGENT]: 70,
+      [FACILITY_CATEGORY_CODES.CASH]: 85,
+    },
   },
   API_RESPONSE_MESSAGES: {
     ASYNC_FACILITY_VALIDATION_ERRORS: 'Async validation errors with facility entity(s)',
@@ -75,6 +99,7 @@ export const GIFT = {
     BOND_SUPPLEMENTAL_TO_CASH: 'BOND: SUPPLEMENTAL TO CASH',
     BOND_SUPPLEMENTAL_TO_CREDIT: 'BOND: SUPPLEMENTAL TO CREDIT',
   },
+  FACILITY_CATEGORY_CODES,
   FEE_TYPE_CODES: {
     BEX: 'BEX',
     CMF: 'CMF',
@@ -129,18 +154,8 @@ export const GIFT = {
     SUPPORTED: '/supported',
     WORK_PACKAGE: '/work-package',
   },
-  PRODUCT_TYPE_CODES: {
-    BIP: 'PRT001',
-    EXIP: 'PRT002',
-    BSS: 'PRT003',
-    GEF: 'PRT004',
-  },
-  PRODUCT_TYPE_NAMES: {
-    BIP: 'Bond Insurance Policy (BIP)',
-    EXIP: 'Export Insurance Policy (EXIP)',
-    BSS: 'Bond Support Scheme (BSS)',
-    GEF: 'General Export Facility (GEF)',
-  },
+  PRODUCT_TYPE_CODES,
+  PRODUCT_TYPE_NAMES,
   REPAYMENT_TYPE: {
     BULLET: 'Bullet',
     SCHEDULED: 'Scheduled',

--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -1,6 +1,10 @@
 import { CONSUMER } from './consumer.constant';
 import { VALIDATION } from './validation.constant';
 
+export const AMEND_FACILITY_PREFIX_TYPES = {
+  AMEND_OBLIGATION: 'AmendObligation_',
+};
+
 export const AMEND_FACILITY_TYPES = {
   AMEND_FACILITY_INCREASE_AMOUNT: 'IncreaseAmount',
   AMEND_FACILITY_DECREASE_AMOUNT: 'DecreaseAmount',

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -116,14 +116,7 @@ describe('GiftFacilityController', () => {
       creationErrorService,
     );
 
-    giftFacilityAmendmentService = new GiftFacilityAmendmentService(
-      giftHttpService,
-      logger,
-      giftWorkPackageService,
-      giftFacilityService,
-      amountAmendmentService,
-      statusService,
-    );
+    giftFacilityAmendmentService = new GiftFacilityAmendmentService(logger, giftWorkPackageService, giftFacilityService, amountAmendmentService, statusService);
 
     mockResSend = jest.fn();
 

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -6,6 +6,7 @@ import { PinoLogger } from 'nestjs-pino';
 
 import {
   GiftAccrualScheduleService,
+  GiftAmountAmendmentService,
   GiftBusinessCalendarsConventionService,
   GiftBusinessCalendarService,
   GiftCounterpartyService,
@@ -55,6 +56,7 @@ describe('GiftFacilityController', () => {
   let giftWorkPackageService: GiftWorkPackageService;
   let creationErrorService: GiftFacilityCreationErrorService;
   let giftQueueService: GiftQueueService;
+  let amountAmendmentService: GiftAmountAmendmentService;
   let controller: GiftFacilityController;
 
   let mockRes;
@@ -96,7 +98,7 @@ describe('GiftFacilityController', () => {
     riskDetailsService = new GiftRiskDetailsService(giftHttpService, logger);
     statusService = new GiftStatusService(giftHttpService, logger);
     creationErrorService = new GiftFacilityCreationErrorService(giftWorkPackageService, logger);
-    giftFacilityAmendmentService = new GiftFacilityAmendmentService(giftHttpService, logger, giftWorkPackageService, statusService);
+    amountAmendmentService = new GiftAmountAmendmentService(giftHttpService, logger);
 
     giftFacilityService = new GiftFacilityService(
       giftHttpService,
@@ -112,6 +114,15 @@ describe('GiftFacilityController', () => {
       riskDetailsService,
       statusService,
       creationErrorService,
+    );
+
+    giftFacilityAmendmentService = new GiftFacilityAmendmentService(
+      giftHttpService,
+      logger,
+      giftWorkPackageService,
+      giftFacilityService,
+      amountAmendmentService,
+      statusService,
     );
 
     mockResSend = jest.fn();
@@ -241,7 +252,7 @@ describe('GiftFacilityController', () => {
       // Assert
       expect(mockResSend).toHaveBeenCalledTimes(1);
 
-      expect(mockResSend).toHaveBeenCalledWith(mockResponseAmendmentPost.data);
+      expect(mockResSend).toHaveBeenCalledWith();
     });
   });
 

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -245,7 +245,7 @@ describe('GiftFacilityController', () => {
       // Assert
       expect(mockResSend).toHaveBeenCalledTimes(1);
 
-      expect(mockResSend).toHaveBeenCalledWith(mockAmendmentServiceCreate);
+      expect(mockResSend).toHaveBeenCalledWith(mockResponseAmendmentPost.data);
     });
   });
 

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -245,7 +245,7 @@ describe('GiftFacilityController', () => {
       // Assert
       expect(mockResSend).toHaveBeenCalledTimes(1);
 
-      expect(mockResSend).toHaveBeenCalledWith();
+      expect(mockResSend).toHaveBeenCalledWith(mockAmendmentServiceCreate);
     });
   });
 

--- a/src/modules/gift/controllers/gift.facility.controller.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.ts
@@ -205,8 +205,12 @@ export class GiftFacilityController {
     @Body(new ValidationPipe({ transform: true })) amendmentData: CreateGiftFacilityAmendmentRequestDto,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const { status, data } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
+    // const { status, data } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
 
-    res.status(status).send(data);
+    // res.status(status).send(data);
+
+    const { status } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
+
+    res.status(status).send();
   }
 }

--- a/src/modules/gift/controllers/gift.facility.controller.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.ts
@@ -205,12 +205,8 @@ export class GiftFacilityController {
     @Body(new ValidationPipe({ transform: true })) amendmentData: CreateGiftFacilityAmendmentRequestDto,
     @Res({ passthrough: true }) res: Response,
   ) {
-    // const { status, data } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
+    const { status, data } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
 
-    // res.status(status).send(data);
-
-    const { status } = await this.giftFacilityAmendmentService.create(facilityId, amendmentData);
-
-    res.status(status).send();
+    res.status(status).send(data);
   }
 }

--- a/src/modules/gift/gift.module.ts
+++ b/src/modules/gift/gift.module.ts
@@ -4,6 +4,7 @@ import { MdmModule } from '@ukef/modules/mdm/mdm.module';
 import { GiftCurrencyController, GiftFacilitiesController, GiftFacilityController, GiftFeeTypeController } from './controllers';
 import {
   GiftAccrualScheduleService,
+  GiftAmountAmendmentService,
   GiftBusinessCalendarsConventionService,
   GiftBusinessCalendarService,
   GiftCounterpartyService,
@@ -32,6 +33,7 @@ import {
     GiftBusinessCalendarsConventionService,
     GiftCounterpartyService,
     GiftCurrencyService,
+    GiftAmountAmendmentService,
     GiftFacilityAsyncValidationService,
     GiftFacilityCreationErrorService,
     GiftFacilityService,

--- a/src/modules/gift/helpers/calculate-percentage-amount/index.test.ts
+++ b/src/modules/gift/helpers/calculate-percentage-amount/index.test.ts
@@ -1,0 +1,55 @@
+import { calculatePercentageAmount } from '.';
+
+describe('modules/gift/helpers/calculate-percentage-amount', () => {
+  describe('rounding behaviour', () => {
+    describe('when rounding is exactly half or close to half', () => {
+      it('should round half up to the nearest integer', () => {
+        // Act
+        const resultOne = calculatePercentageAmount(150, 85);
+        const resultTwo = calculatePercentageAmount(151, 85);
+        const resultThree = calculatePercentageAmount(152, 85);
+
+        // Assert
+        expect(resultOne).toBe(128);
+        expect(resultTwo).toBe(128);
+        expect(resultThree).toBe(129);
+      });
+    });
+
+    describe('when amount is very large', () => {
+      it('should calculate large values without floating-point precision drift', () => {
+        // Act
+        const result = calculatePercentageAmount(Number.MAX_SAFE_INTEGER, 85);
+
+        // Assert
+        const expected = 7656119366529842;
+
+        expect(result).toBe(expected);
+      });
+    });
+  });
+
+  describe('when amount is not a safe integer', () => {
+    it('should throw an error', () => {
+      // Act
+      const result = () => calculatePercentageAmount(100.5, 85);
+
+      // Assert
+      const expected = 'calculatePercentageAmount - amount must be a safe integer. Received: 100.5';
+
+      expect(result).toThrow(expected);
+    });
+  });
+
+  describe('when percentage is not a safe integer', () => {
+    it('should throw an error', () => {
+      // Act
+      const result = () => calculatePercentageAmount(100, 85.5);
+
+      // Assert
+      const expected = 'calculatePercentageAmount - percentage must be a safe integer. Received: 85.5';
+
+      expect(result).toThrow(expected);
+    });
+  });
+});

--- a/src/modules/gift/helpers/calculate-percentage-amount/index.ts
+++ b/src/modules/gift/helpers/calculate-percentage-amount/index.ts
@@ -1,0 +1,41 @@
+const PERCENT_DENOMINATOR = 100n;
+
+/**
+ * Calculates an integer percentage amount using BigInt arithmetic to avoid floating-point precision drift.
+ * Rounding policy: round half up to the nearest integer.
+ *
+ * @param {number} amount - The base amount to calculate from. Must be a safe integer.
+ * @param {number} percentage - The percentage value to apply. Must be a safe integer.
+ * @returns {number} The rounded percentage amount as an integer.
+ *
+ * @example
+ * calculatePercentageAmount(150, 85);
+ * // 128
+ *
+ * @example
+ * calculatePercentageAmount(151, 85);
+ * // 128
+ *
+ * @example
+ * calculatePercentageAmount(152, 85);
+ * // 129
+ */
+export const calculatePercentageAmount = (amount: number, percentage: number): number => {
+  if (!Number.isSafeInteger(amount)) {
+    throw new Error(`calculatePercentageAmount - amount must be a safe integer. Received: ${amount}`);
+  }
+
+  if (!Number.isSafeInteger(percentage)) {
+    throw new Error(`calculatePercentageAmount - percentage must be a safe integer. Received: ${percentage}`);
+  }
+
+  const numerator = BigInt(amount) * BigInt(percentage);
+
+  const quotient = numerator / PERCENT_DENOMINATOR;
+  const remainder = numerator % PERCENT_DENOMINATOR;
+
+  const shouldRoundUp = remainder * 2n >= PERCENT_DENOMINATOR;
+  const rounded = shouldRoundUp ? quotient + 1n : quotient;
+
+  return Number(rounded);
+};

--- a/src/modules/gift/helpers/index.ts
+++ b/src/modules/gift/helpers/index.ts
@@ -8,6 +8,8 @@ export * from './get-obligation-ids';
 export * from './get-repayment-profile-allocation-dates';
 export * from './get-repayment-profile-names';
 export * from './has-valid-obligation-subtype-code-formats';
+export * from './is-decrease-amount-amendment';
+export * from './is-increase-amount-amendment';
 export * from './is-supported-consumer';
 export * from './is-valid-counterparty-role-id-format';
 export * from './is-valid-product-type-code-format';

--- a/src/modules/gift/helpers/index.ts
+++ b/src/modules/gift/helpers/index.ts
@@ -2,6 +2,7 @@ export * from './array-contains-string';
 export * from './array-has-unique-strings';
 export * from './array-of-objects-has-value';
 export * from './async-validation';
+export * from './calculate-percentage-amount';
 export * from './generate-obligation-subtype-code-errors';
 export * from './get-amendment-data-dto';
 export * from './get-obligation-ids';

--- a/src/modules/gift/helpers/is-decrease-amount-amendment/index.test.ts
+++ b/src/modules/gift/helpers/is-decrease-amount-amendment/index.test.ts
@@ -1,0 +1,39 @@
+import { EXAMPLES, GIFT } from '@ukef/constants';
+
+import { isDecreaseAmountAmendment } from '.';
+
+const {
+  GIFT: { FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload },
+} = EXAMPLES;
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT },
+} = GIFT;
+
+describe('modules/gift/helpers/is-decrease-amount-amendment', () => {
+  describe(`when amendmentType is ${AMEND_FACILITY_DECREASE_AMOUNT}`, () => {
+    it('should return true', () => {
+      const payload = {
+        ...mockPayload,
+        amendmentType: AMEND_FACILITY_DECREASE_AMOUNT,
+      };
+
+      const result = isDecreaseAmountAmendment(payload);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe(`when amendmentType is ${AMEND_FACILITY_INCREASE_AMOUNT}`, () => {
+    it('should return false', () => {
+      const payload = {
+        ...mockPayload,
+        amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+      };
+
+      const result = isDecreaseAmountAmendment(payload);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/modules/gift/helpers/is-decrease-amount-amendment/index.ts
+++ b/src/modules/gift/helpers/is-decrease-amount-amendment/index.ts
@@ -1,0 +1,20 @@
+import { GIFT } from '@ukef/constants';
+
+import { CreateGiftFacilityAmendmentRequestDto, DecreaseAmountDto } from '../../dto';
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT },
+} = GIFT;
+
+export type DecreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
+  amendmentType: typeof AMEND_FACILITY_DECREASE_AMOUNT;
+  amendmentData: DecreaseAmountDto;
+};
+
+/**
+ * Type guard for decrease amount facility amendments.
+ * @param {CreateGiftFacilityAmendmentRequestDto} amendment: Facility amendment request.
+ * @returns {boolean} True when amendmentType is DecreaseAmount.
+ */
+export const isDecreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is DecreaseAmountAmendmentRequest =>
+  amendment.amendmentType === AMEND_FACILITY_DECREASE_AMOUNT;

--- a/src/modules/gift/helpers/is-increase-amount-amendment/index.test.ts
+++ b/src/modules/gift/helpers/is-increase-amount-amendment/index.test.ts
@@ -1,0 +1,39 @@
+import { EXAMPLES, GIFT } from '@ukef/constants';
+
+import { isIncreaseAmountAmendment } from '.';
+
+const {
+  GIFT: { FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload },
+} = EXAMPLES;
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT },
+} = GIFT;
+
+describe('modules/gift/helpers/is-increase-amount-amendment', () => {
+  describe(`when amendmentType is ${AMEND_FACILITY_INCREASE_AMOUNT}`, () => {
+    it('should return true', () => {
+      const payload = {
+        ...mockPayload,
+        amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+      };
+
+      const result = isIncreaseAmountAmendment(payload);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe(`when amendmentType is ${AMEND_FACILITY_DECREASE_AMOUNT}`, () => {
+    it('should return false', () => {
+      const payload = {
+        ...mockPayload,
+        amendmentType: AMEND_FACILITY_DECREASE_AMOUNT,
+      };
+
+      const result = isIncreaseAmountAmendment(payload);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/modules/gift/helpers/is-increase-amount-amendment/index.ts
+++ b/src/modules/gift/helpers/is-increase-amount-amendment/index.ts
@@ -1,0 +1,20 @@
+import { GIFT } from '@ukef/constants';
+
+import { CreateGiftFacilityAmendmentRequestDto, IncreaseAmountDto } from '../../dto';
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT },
+} = GIFT;
+
+export type IncreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
+  amendmentType: typeof AMEND_FACILITY_INCREASE_AMOUNT;
+  amendmentData: IncreaseAmountDto;
+};
+
+/**
+ * Type guard for increase amount facility amendments.
+ * @param {CreateGiftFacilityAmendmentRequestDto} amendment: Facility amendment request.
+ * @returns {boolean} True when amendmentType is IncreaseAmount.
+ */
+export const isIncreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is IncreaseAmountAmendmentRequest =>
+  amendment.amendmentType === AMEND_FACILITY_INCREASE_AMOUNT;

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -11,11 +11,13 @@ const {
 
 const {
   AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT },
+  FACILITY_CATEGORY_CODES,
   PATH,
 } = GIFT;
 
 describe('GiftAmountAmendmentService', () => {
   const logger = new PinoLogger({});
+  const mockFacilityCategoryCode = FACILITY_CATEGORY_CODES.CONTINGENT;
 
   let service: GiftAmountAmendmentService;
 
@@ -193,6 +195,7 @@ describe('GiftAmountAmendmentService', () => {
         amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
         date: mockDate,
         facilityId: mockFacilityId,
+        facilityCategoryCode: mockFacilityCategoryCode,
         newFacilityAmount: mockNewFacilityAmount,
         obligations: mockObligations,
         workPackageId: mockWorkPackageId,
@@ -248,6 +251,7 @@ describe('GiftAmountAmendmentService', () => {
         amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
         date: mockDate,
         facilityId: mockFacilityId,
+        facilityCategoryCode: mockFacilityCategoryCode,
         newFacilityAmount: mockNewFacilityAmount,
         obligations: [{ id: '1' }, { id: '2' }],
         workPackageId: mockWorkPackageId,
@@ -263,6 +267,7 @@ describe('GiftAmountAmendmentService', () => {
         amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
         date: mockDate,
         facilityId: mockFacilityId,
+        facilityCategoryCode: mockFacilityCategoryCode,
         newFacilityAmount: 100.5,
         obligations: [{ id: '1' }],
         workPackageId: mockWorkPackageId,
@@ -295,6 +300,7 @@ describe('GiftAmountAmendmentService', () => {
           amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
           date: mockDate,
           facilityId: mockFacilityId,
+          facilityCategoryCode: mockFacilityCategoryCode,
           newFacilityAmount: mockNewFacilityAmount,
           obligations: [{ id: '1' }],
           workPackageId: mockWorkPackageId,

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
-import { EXAMPLES, GIFT } from '@ukef/constants';
+import { AMEND_FACILITY_PREFIX_TYPES, EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse201, mockResponse204, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
@@ -203,7 +203,7 @@ describe('GiftAmountAmendmentService', () => {
       expect(mockHttpServicePost).toHaveBeenCalledTimes(3);
 
       const expectedAmount = mockNewFacilityAmount * (PERCENTAGE_OF_FACILITY_AMOUNT / 100);
-      const expectedPath = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendObligation_${AMEND_FACILITY_INCREASE_AMOUNT}`;
+      const expectedPath = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${AMEND_FACILITY_INCREASE_AMOUNT}`;
 
       expect(mockHttpServicePost).toHaveBeenNthCalledWith(1, {
         path: expectedPath,

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -204,7 +204,7 @@ describe('GiftAmountAmendmentService', () => {
       // Assert
       expect(mockHttpServicePost).toHaveBeenCalledTimes(3);
 
-      const expectedAmount = 128;
+      const expectedAmount = 105;
       const expectedPath = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${AMEND_FACILITY_INCREASE_AMOUNT}`;
 
       expect(mockHttpServicePost).toHaveBeenNthCalledWith(1, {

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -1,0 +1,292 @@
+import { HttpStatus } from '@nestjs/common';
+import { EXAMPLES, GIFT } from '@ukef/constants';
+import { mockResponse201, mockResponse204, mockResponse500 } from '@ukef-test/http-response';
+import { PinoLogger } from 'nestjs-pino';
+
+import { GiftAmountAmendmentService } from '.';
+
+const {
+  GIFT: { FACILITY_AMENDMENT_REQUEST_PAYLOAD, FACILITY_ID: mockFacilityId, WORK_PACKAGE_ID: mockWorkPackageId },
+} = EXAMPLES;
+
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT },
+  AMEND_OBLIGATION_AMOUNT: { PERCENTAGE_OF_FACILITY_AMOUNT },
+  PATH,
+} = GIFT;
+
+describe('GiftAmountAmendmentService', () => {
+  const logger = new PinoLogger({});
+
+  let service: GiftAmountAmendmentService;
+
+  let giftHttpService;
+  let mockHttpServicePost: jest.Mock;
+  let mockHttpServiceDelete: jest.Mock;
+
+  beforeEach(() => {
+    // Arrange
+    mockHttpServicePost = jest.fn().mockResolvedValue(mockResponse201({ id: 'mock-amendment-response' }));
+    mockHttpServiceDelete = jest.fn().mockResolvedValue(mockResponse204());
+
+    giftHttpService = {
+      post: mockHttpServicePost,
+      delete: mockHttpServiceDelete,
+    };
+
+    service = new GiftAmountAmendmentService(giftHttpService, logger);
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('facility', () => {
+    it('should call giftHttpService.post', async () => {
+      // Arrange
+      const amendmentType = AMEND_FACILITY_INCREASE_AMOUNT;
+      const { amendmentData } = FACILITY_AMENDMENT_REQUEST_PAYLOAD;
+
+      // Act
+      await service.facility({
+        amendmentType,
+        amendmentData,
+        facilityId: mockFacilityId,
+        workPackageId: mockWorkPackageId,
+      });
+
+      // Assert
+      expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+      const expected = {
+        path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${amendmentType}`,
+        payload: amendmentData,
+      };
+
+      expect(mockHttpServicePost).toHaveBeenCalledWith(expected);
+    });
+
+    describe(`when giftHttpService.post returns a ${HttpStatus.CREATED} status`, () => {
+      it('should return the response from giftHttpService.post', async () => {
+        // Arrange
+        const mockPostResponse = mockResponse201({ id: 'mock-amendment-response' });
+
+        mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockPostResponse);
+
+        giftHttpService.post = mockHttpServicePost;
+
+        service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+        // Act
+        const response = await service.facility({
+          amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+          amendmentData: FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData,
+          facilityId: mockFacilityId,
+          workPackageId: mockWorkPackageId,
+        });
+
+        // Assert
+        expect(response).toEqual(mockPostResponse);
+      });
+    });
+
+    describe(`when giftHttpService.post does NOT return a ${HttpStatus.CREATED} status`, () => {
+      const mockPostResponse = {
+        status: HttpStatus.BAD_REQUEST,
+        data: { badRequest: true },
+      };
+      const mockDeleteResponse = mockResponse204();
+
+      beforeEach(() => {
+        // Arrange
+        mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockPostResponse);
+        mockHttpServiceDelete = jest.fn().mockResolvedValueOnce(mockDeleteResponse);
+
+        giftHttpService.post = mockHttpServicePost;
+        giftHttpService.delete = mockHttpServiceDelete;
+
+        service = new GiftAmountAmendmentService(giftHttpService, logger);
+      });
+
+      describe('delete behaviour', () => {
+        it('should call giftHttpService.delete', async () => {
+          // Act
+          await service.facility({
+            amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+            amendmentData: FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData,
+            facilityId: mockFacilityId,
+            workPackageId: mockWorkPackageId,
+          });
+
+          // Assert
+          expect(mockHttpServiceDelete).toHaveBeenCalledTimes(1);
+          expect(mockHttpServiceDelete).toHaveBeenCalledWith({
+            path: `${PATH.WORK_PACKAGE}/${mockWorkPackageId}`,
+          });
+        });
+      });
+
+      describe('response', () => {
+        it('should return the response from giftHttpService.delete', async () => {
+          // Act
+          const response = await service.facility({
+            amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+            amendmentData: FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData,
+            facilityId: mockFacilityId,
+            workPackageId: mockWorkPackageId,
+          });
+
+          // Assert
+          expect(response).toEqual(mockDeleteResponse);
+        });
+      });
+    });
+
+    describe('when giftHttpService.post throws an error', () => {
+      it('should throw an error', async () => {
+        // Arrange
+        const mockError = mockResponse500();
+
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+
+        giftHttpService.post = mockHttpServicePost;
+
+        service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+        // Act
+        const promise = service.facility({
+          amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+          amendmentData: FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData,
+          facilityId: mockFacilityId,
+          workPackageId: mockWorkPackageId,
+        });
+
+        // Assert
+        const expected = new Error(
+          `Error amending facility amount ${AMEND_FACILITY_INCREASE_AMOUNT} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
+          { cause: mockError },
+        );
+
+        await expect(promise).rejects.toThrow(expected);
+      });
+    });
+  });
+
+  describe('obligations', () => {
+    const mockObligations = [{ id: '1' }, { id: '2' }, { id: '3' }];
+    const mockDate = FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData.date;
+    const mockNewFacilityAmount = FACILITY_AMENDMENT_REQUEST_PAYLOAD.amendmentData.amount;
+
+    it('should call giftHttpService.post for each obligation', async () => {
+      // Arrange
+      mockHttpServicePost = jest
+        .fn()
+        .mockResolvedValueOnce(mockResponse201({ one: true }))
+        .mockResolvedValueOnce(mockResponse201({ two: true }))
+        .mockResolvedValueOnce(mockResponse201({ three: true }));
+
+      giftHttpService.post = mockHttpServicePost;
+
+      service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+      // Act
+      await service.obligations({
+        amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+        date: mockDate,
+        facilityId: mockFacilityId,
+        newFacilityAmount: mockNewFacilityAmount,
+        obligations: mockObligations,
+        workPackageId: mockWorkPackageId,
+      });
+
+      // Assert
+      expect(mockHttpServicePost).toHaveBeenCalledTimes(3);
+
+      const expectedAmount = mockNewFacilityAmount * (PERCENTAGE_OF_FACILITY_AMOUNT / 100);
+      const expectedPath = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendObligation_${AMEND_FACILITY_INCREASE_AMOUNT}`;
+
+      expect(mockHttpServicePost).toHaveBeenNthCalledWith(1, {
+        path: expectedPath,
+        payload: {
+          obligationId: '1',
+          date: mockDate,
+          amount: expectedAmount,
+        },
+      });
+
+      expect(mockHttpServicePost).toHaveBeenNthCalledWith(2, {
+        path: expectedPath,
+        payload: {
+          obligationId: '2',
+          date: mockDate,
+          amount: expectedAmount,
+        },
+      });
+
+      expect(mockHttpServicePost).toHaveBeenNthCalledWith(3, {
+        path: expectedPath,
+        payload: {
+          obligationId: '3',
+          date: mockDate,
+          amount: expectedAmount,
+        },
+      });
+    });
+
+    it('should return all obligation amendment responses', async () => {
+      // Arrange
+      const responseOne = mockResponse201({ one: true });
+      const responseTwo = mockResponse201({ two: true });
+
+      mockHttpServicePost = jest.fn().mockResolvedValueOnce(responseOne).mockResolvedValueOnce(responseTwo);
+
+      giftHttpService.post = mockHttpServicePost;
+
+      service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+      // Act
+      const response = await service.obligations({
+        amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+        date: mockDate,
+        facilityId: mockFacilityId,
+        newFacilityAmount: mockNewFacilityAmount,
+        obligations: [{ id: '1' }, { id: '2' }],
+        workPackageId: mockWorkPackageId,
+      });
+
+      // Assert
+      expect(response).toEqual([responseOne, responseTwo]);
+    });
+
+    describe('when giftHttpService.post throws an error', () => {
+      it('should throw an error', async () => {
+        // Arrange
+        const mockError = mockResponse500();
+
+        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+
+        giftHttpService.post = mockHttpServicePost;
+
+        service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+        // Act
+        const promise = service.obligations({
+          amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+          date: mockDate,
+          facilityId: mockFacilityId,
+          newFacilityAmount: mockNewFacilityAmount,
+          obligations: [{ id: '1' }],
+          workPackageId: mockWorkPackageId,
+        });
+
+        // Assert
+        const expected = new Error(
+          `Error amending facility obligation amounts ${AMEND_FACILITY_INCREASE_AMOUNT} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
+          { cause: mockError },
+        );
+
+        await expect(promise).rejects.toThrow(expected);
+      });
+    });
+  });
+});

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -11,7 +11,6 @@ const {
 
 const {
   AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT },
-  AMEND_OBLIGATION_AMOUNT: { PERCENTAGE_OF_FACILITY_AMOUNT },
   PATH,
 } = GIFT;
 
@@ -137,7 +136,7 @@ describe('GiftAmountAmendmentService', () => {
           });
 
           // Assert
-          expect(response).toEqual(mockDeleteResponse);
+          expect(response).toEqual(mockPostResponse);
         });
       });
     });
@@ -202,7 +201,7 @@ describe('GiftAmountAmendmentService', () => {
       // Assert
       expect(mockHttpServicePost).toHaveBeenCalledTimes(3);
 
-      const expectedAmount = mockNewFacilityAmount * (PERCENTAGE_OF_FACILITY_AMOUNT / 100);
+      const expectedAmount = 128;
       const expectedPath = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${AMEND_FACILITY_INCREASE_AMOUNT}`;
 
       expect(mockHttpServicePost).toHaveBeenNthCalledWith(1, {
@@ -256,6 +255,28 @@ describe('GiftAmountAmendmentService', () => {
 
       // Assert
       expect(response).toEqual([responseOne, responseTwo]);
+    });
+
+    it('should throw an error when the facility amount is not an integer', async () => {
+      // Act
+      const promise = service.obligations({
+        amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+        date: mockDate,
+        facilityId: mockFacilityId,
+        newFacilityAmount: 100.5,
+        obligations: [{ id: '1' }],
+        workPackageId: mockWorkPackageId,
+      });
+
+      // Assert
+      const expected = new Error(
+        `Error amending facility obligation amounts ${AMEND_FACILITY_INCREASE_AMOUNT} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
+        {
+          cause: new Error('calculatePercentageAmount - amount must be a safe integer. Received: 100.5'),
+        },
+      );
+
+      await expect(promise).rejects.toThrow(expected);
     });
 
     describe('when giftHttpService.post throws an error', () => {

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -1,0 +1,135 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { AmendFacilityType, GIFT } from '@ukef/constants';
+import { UkefId } from '@ukef/helpers/ukef-id.type';
+import { AxiosResponse } from 'axios';
+import { PinoLogger } from 'nestjs-pino';
+
+import { GiftWorkPackageResponseDto } from '../../dto';
+import { GiftHttpService } from '../gift.http.service';
+
+const {
+  AMEND_OBLIGATION_AMOUNT: { PERCENTAGE_OF_FACILITY_AMOUNT },
+  PATH,
+} = GIFT;
+
+type AmendFacilityAmountParams = {
+  amendmentType: AmendFacilityType;
+  amendmentData: {
+    date: string;
+    amount: number;
+  };
+  facilityId: UkefId;
+  workPackageId: number;
+};
+
+type AmendObligationsParams = {
+  amendmentType: AmendFacilityType;
+  date: string;
+  facilityId: UkefId;
+  newFacilityAmount: number;
+  obligations: { id: string }[];
+  workPackageId: number;
+};
+
+/**
+ * GIFT amount amendment service.
+ * This is responsible for all "amount" amendment operations that call the GIFT API.
+ */
+@Injectable()
+export class GiftAmountAmendmentService {
+  constructor(
+    private readonly giftHttpService: GiftHttpService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.giftHttpService = giftHttpService;
+    this.logger = logger;
+  }
+
+  /**
+   * Amend the facility amount for a given facility and work package.
+   * @param {AmendFacilityAmountParams} params - Parameters for the amendment.
+   * @returns {Promise<AxiosResponse>}
+   * @throws {Error}
+   */
+  async facility({ amendmentData, amendmentType, facilityId, workPackageId }: AmendFacilityAmountParams): Promise<AxiosResponse> {
+    try {
+      this.logger.info('Amending facility amount %s for facility %s work package %s', amendmentType, facilityId, workPackageId);
+
+      /**
+       * Construct the full "configuration event type" string for GIFT.
+       * By doing this in APIM, it provides consumers with a simpler payload requirement.
+       * I.e, "IncreaseAmount" rather than "AmendFacility_IncreaseAmount".
+       */
+      const facilityAmendmentTypeString = `AmendFacility_${amendmentType}`;
+
+      const path = `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${facilityAmendmentTypeString}`;
+
+      const facilityAmendmentResponse = await this.giftHttpService.post<GiftWorkPackageResponseDto>({
+        path,
+        payload: amendmentData,
+      });
+
+      if (facilityAmendmentResponse.status !== HttpStatus.CREATED) {
+        this.logger.error('Error creating amendment %s for work package %s facility %s. Deleting work package', amendmentType, workPackageId, facilityId);
+
+        return await this.giftHttpService.delete<GiftWorkPackageResponseDto>({
+          path: `${PATH.WORK_PACKAGE}/${workPackageId}`,
+        });
+      }
+
+      return facilityAmendmentResponse;
+    } catch (error) {
+      this.logger.error('Error amending facility amount %s for facility %s work package %s %o', amendmentType, facilityId, workPackageId, error);
+
+      throw new Error(`Error amending facility amount ${amendmentType} for facility ${facilityId} work package ${workPackageId}`, { cause: error });
+    }
+  }
+
+  /**
+   * Amend the obligations for a given facility and work package.
+   * @param {AmendObligationsParams} params - Parameters for the amendment.
+   * @returns {Promise<void>}
+   * @throws {Error}
+   */
+  async obligations({ amendmentType, newFacilityAmount, date, facilityId, obligations, workPackageId }: AmendObligationsParams) {
+    try {
+      this.logger.info('Amending facility obligation amounts %s for facility %s work package %s', amendmentType, facilityId, workPackageId);
+
+      const basePath = `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}`;
+
+      /**
+       * NOTE: currently only 1x obligation will exist for a facility.
+       * Need to update this logic if an integration has more than 1x obligation.
+       */
+      const newObligationAmount = newFacilityAmount * (PERCENTAGE_OF_FACILITY_AMOUNT / 100);
+
+      /**
+       * NOTE: We need to use a for loop instead of Promise.all, to ensure that the calls are sequential.
+       * Promise.all is not sequential.
+       */
+      const responses = [];
+
+      for (const obligation of obligations) {
+        const payload = {
+          obligationId: obligation.id,
+          date,
+          amount: newObligationAmount,
+        };
+
+        // TODO: constant
+        const response = await this.giftHttpService.post<GiftWorkPackageResponseDto>({
+          path: `${basePath}/AmendObligation_${amendmentType}`,
+          payload,
+        });
+
+        responses.push(response);
+      }
+
+      return responses;
+    } catch (error) {
+      this.logger.error('Error amending facility obligation amounts %s for facility %s work package %s %o', amendmentType, facilityId, workPackageId, error);
+
+      throw new Error(`Error amending facility obligation amounts ${amendmentType} for facility ${facilityId} work package ${workPackageId}`, { cause: error });
+    }
+  }
+}

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -1,5 +1,5 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
-import { AMEND_FACILITY_PREFIX_TYPES, AmendFacilityType, GIFT } from '@ukef/constants';
+import { AMEND_FACILITY_PREFIX_TYPES, AmendFacilityType, FacilityCategoryCode, GIFT } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers/ukef-id.type';
 import { AxiosResponse } from 'axios';
 import { PinoLogger } from 'nestjs-pino';
@@ -27,6 +27,7 @@ type AmendObligationsParams = {
   amendmentType: AmendFacilityType;
   date: string;
   facilityId: UkefId;
+  facilityCategoryCode: FacilityCategoryCode;
   newFacilityAmount: number;
   obligations: { id: string }[];
   workPackageId: number;
@@ -94,7 +95,7 @@ export class GiftAmountAmendmentService {
    * @returns {Promise<void>}
    * @throws {Error}
    */
-  async obligations({ amendmentType, newFacilityAmount, date, facilityId, obligations, workPackageId }: AmendObligationsParams) {
+  async obligations({ amendmentType, newFacilityAmount, date, facilityId, obligations, facilityCategoryCode, workPackageId }: AmendObligationsParams) {
     try {
       this.logger.info('Amending facility obligation amounts %s for facility %s work package %s', amendmentType, facilityId, workPackageId);
 
@@ -104,7 +105,9 @@ export class GiftAmountAmendmentService {
        * NOTE: currently only 1x obligation will exist for a facility.
        * Need to update this logic if an integration has more than 1x obligation.
        */
-      const newObligationAmount = calculatePercentageAmount(newFacilityAmount, PERCENTAGE_OF_FACILITY_AMOUNT);
+      const percentage = PERCENTAGE_OF_FACILITY_AMOUNT[`${facilityCategoryCode}`];
+
+      const newObligationAmount = calculatePercentageAmount(newFacilityAmount, percentage);
 
       /**
        * NOTE: We need to use a for loop instead of Promise.all, to ensure that the calls are sequential.

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -1,5 +1,5 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
-import { AmendFacilityType, GIFT } from '@ukef/constants';
+import { AMEND_FACILITY_PREFIX_TYPES, AmendFacilityType, GIFT } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers/ukef-id.type';
 import { AxiosResponse } from 'axios';
 import { PinoLogger } from 'nestjs-pino';
@@ -118,7 +118,7 @@ export class GiftAmountAmendmentService {
 
         // TODO: constant
         const response = await this.giftHttpService.post<GiftWorkPackageResponseDto>({
-          path: `${basePath}/AmendObligation_${amendmentType}`,
+          path: `${basePath}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${amendmentType}`,
           payload,
         });
 

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -72,9 +72,11 @@ export class GiftAmountAmendmentService {
       if (facilityAmendmentResponse.status !== HttpStatus.CREATED) {
         this.logger.error('Error creating amendment %s for work package %s facility %s. Deleting work package', amendmentType, workPackageId, facilityId);
 
-        return await this.giftHttpService.delete<GiftWorkPackageResponseDto>({
+        await this.giftHttpService.delete<GiftWorkPackageResponseDto>({
           path: `${PATH.WORK_PACKAGE}/${workPackageId}`,
         });
+
+        return facilityAmendmentResponse;
       }
 
       return facilityAmendmentResponse;
@@ -116,7 +118,6 @@ export class GiftAmountAmendmentService {
           amount: newObligationAmount,
         };
 
-        // TODO: constant
         const response = await this.giftHttpService.post<GiftWorkPackageResponseDto>({
           path: `${basePath}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${amendmentType}`,
           payload,

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -5,6 +5,7 @@ import { AxiosResponse } from 'axios';
 import { PinoLogger } from 'nestjs-pino';
 
 import { GiftWorkPackageResponseDto } from '../../dto';
+import { calculatePercentageAmount } from '../../helpers';
 import { GiftHttpService } from '../gift.http.service';
 
 const {
@@ -103,7 +104,7 @@ export class GiftAmountAmendmentService {
        * NOTE: currently only 1x obligation will exist for a facility.
        * Need to update this logic if an integration has more than 1x obligation.
        */
-      const newObligationAmount = newFacilityAmount * (PERCENTAGE_OF_FACILITY_AMOUNT / 100);
+      const newObligationAmount = calculatePercentageAmount(newFacilityAmount, PERCENTAGE_OF_FACILITY_AMOUNT);
 
       /**
        * NOTE: We need to use a for loop instead of Promise.all, to ensure that the calls are sequential.

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
-import { EXAMPLES } from '@ukef/constants';
+import { EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse200, mockResponse201, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
@@ -19,7 +19,16 @@ const {
   },
 } = EXAMPLES;
 
+const { FACILITY_CATEGORY_CODES } = GIFT;
+
 const mockWorkPackageServiceCreateResponse = mockResponse201(WORK_PACKAGE_CREATION_RESPONSE_DATA);
+const mockFacilityResponseData = {
+  ...FACILITY_RESPONSE_DATA,
+  obligations: [{ id: 'obligation-1' }],
+  riskDetails: {
+    facilityCategoryCode: FACILITY_CATEGORY_CODES.CONTINGENT,
+  },
+};
 
 describe('GiftFacilityAmendmentService - error handling', () => {
   const logger = new PinoLogger({});
@@ -50,7 +59,7 @@ describe('GiftFacilityAmendmentService - error handling', () => {
     amountAmendmentService = {} as GiftAmountAmendmentService;
     statusService = new GiftStatusService(giftHttpService, logger);
 
-    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(FACILITY_RESPONSE_DATA));
+    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(mockFacilityResponseData));
     mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
     mockAmountAmendmentFacility = jest.fn().mockResolvedValueOnce(mockResponse201({}));
     mockAmountAmendmentObligations = jest.fn().mockResolvedValueOnce([]);

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
@@ -39,7 +39,7 @@ describe('GiftFacilityAmendmentService - error handling', () => {
   let mockStatusServiceApproved: jest.Mock;
 
   const buildService = () => {
-    service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, facilityService, amountAmendmentService, statusService);
+    service = new GiftFacilityAmendmentService(logger, workPackageService, facilityService, amountAmendmentService, statusService);
   };
 
   beforeEach(() => {

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
@@ -1,20 +1,21 @@
 import { HttpStatus } from '@nestjs/common';
-import { EXAMPLES, GIFT } from '@ukef/constants';
-import { mockResponse200, mockResponse201, mockResponse204, mockResponse500 } from '@ukef-test/http-response';
+import { EXAMPLES } from '@ukef/constants';
+import { mockResponse200, mockResponse201, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
+import { GiftAmountAmendmentService } from '../gift.amount-amendment.service';
+import { GiftFacilityService } from '../gift.facility.service';
 import { GiftStatusService } from '../gift.status.service';
 import { GiftWorkPackageService } from '../gift.work-package.service';
 import { GiftFacilityAmendmentService } from '.';
 
-const { PATH } = GIFT;
-
 const {
   GIFT: {
+    FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload,
+    FACILITY_ID: mockFacilityId,
+    FACILITY_RESPONSE_DATA,
     WORK_PACKAGE_APPROVE_RESPONSE_DATA,
     WORK_PACKAGE_CREATION_RESPONSE_DATA,
-    FACILITY_ID: mockFacilityId,
-    FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload,
   },
 } = EXAMPLES;
 
@@ -23,26 +24,45 @@ const mockWorkPackageServiceCreateResponse = mockResponse201(WORK_PACKAGE_CREATI
 describe('GiftFacilityAmendmentService - error handling', () => {
   const logger = new PinoLogger({});
 
-  let mockHttpServicePost: jest.Mock;
-  let mockHttpServiceDelete: jest.Mock;
-  let workPackageService: GiftWorkPackageService;
-  let statusService: GiftStatusService;
-  let mockWorkPackageServiceCreate: jest.Mock;
-  let mockStatusServiceApproved: jest.Mock;
-
+  let giftHttpService;
   let service: GiftFacilityAmendmentService;
 
-  let giftHttpService;
+  let workPackageService: GiftWorkPackageService;
+  let facilityService: GiftFacilityService;
+  let amountAmendmentService: GiftAmountAmendmentService;
+  let statusService: GiftStatusService;
+
+  let mockWorkPackageServiceCreate: jest.Mock;
+  let mockFacilityServiceGet: jest.Mock;
+  let mockAmountAmendmentFacility: jest.Mock;
+  let mockAmountAmendmentObligations: jest.Mock;
+  let mockStatusServiceApproved: jest.Mock;
+
+  const buildService = () => {
+    service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, facilityService, amountAmendmentService, statusService);
+  };
 
   beforeEach(() => {
-    // Arrange
+    giftHttpService = {};
+
     workPackageService = new GiftWorkPackageService(giftHttpService, logger);
-
-    mockStatusServiceApproved = jest.fn().mockResolvedValueOnce(mockResponse200());
-
+    facilityService = {} as GiftFacilityService;
+    amountAmendmentService = {} as GiftAmountAmendmentService;
     statusService = new GiftStatusService(giftHttpService, logger);
 
+    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(FACILITY_RESPONSE_DATA));
+    mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
+    mockAmountAmendmentFacility = jest.fn().mockResolvedValueOnce(mockResponse201({}));
+    mockAmountAmendmentObligations = jest.fn().mockResolvedValueOnce([]);
+    mockStatusServiceApproved = jest.fn().mockResolvedValueOnce(mockResponse200(WORK_PACKAGE_APPROVE_RESPONSE_DATA));
+
+    facilityService.get = mockFacilityServiceGet;
+    workPackageService.create = mockWorkPackageServiceCreate;
+    amountAmendmentService.facility = mockAmountAmendmentFacility;
+    amountAmendmentService.obligations = mockAmountAmendmentObligations;
     statusService.approved = mockStatusServiceApproved;
+
+    buildService();
   });
 
   afterAll(() => {
@@ -50,12 +70,6 @@ describe('GiftFacilityAmendmentService - error handling', () => {
   });
 
   describe('giftWorkPackageService.create', () => {
-    beforeEach(() => {
-      giftHttpService = {
-        post: mockHttpServicePost,
-      };
-    });
-
     describe(`when giftWorkPackageService.create does NOT return a ${HttpStatus.CREATED} status`, () => {
       it.each([
         HttpStatus.ACCEPTED,
@@ -78,7 +92,7 @@ describe('GiftFacilityAmendmentService - error handling', () => {
 
         workPackageService.create = mockWorkPackageServiceCreate;
 
-        service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+        buildService();
 
         // Act
         const response = await service.create(mockFacilityId, mockPayload);
@@ -102,7 +116,7 @@ describe('GiftFacilityAmendmentService - error handling', () => {
 
         workPackageService.create = mockWorkPackageServiceCreate;
 
-        service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+        buildService();
 
         // Act
         const response = service.create(mockFacilityId, mockPayload);
@@ -115,114 +129,36 @@ describe('GiftFacilityAmendmentService - error handling', () => {
     });
   });
 
-  describe('giftHttpService.post', () => {
-    beforeEach(() => {
-      mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
-
-      workPackageService.create = mockWorkPackageServiceCreate;
-    });
-
-    describe(`when giftHttpService.post does NOT return a ${HttpStatus.CREATED} status`, () => {
-      describe.each([
-        HttpStatus.ACCEPTED,
-        HttpStatus.BAD_GATEWAY,
-        HttpStatus.BAD_REQUEST,
-        HttpStatus.CONFLICT,
-        HttpStatus.FORBIDDEN,
-        HttpStatus.I_AM_A_TEAPOT,
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        HttpStatus.NOT_FOUND,
-        HttpStatus.OK,
-      ])('with status %s', (status) => {
-        const mockResponseData = WORK_PACKAGE_CREATION_RESPONSE_DATA;
-
-        beforeEach(() => {
-          // Arrange
-          mockHttpServicePost = jest.fn().mockResolvedValueOnce({
-            status,
-            data: mockResponseData,
-          });
-
-          mockHttpServiceDelete = jest.fn().mockResolvedValueOnce(mockResponse204());
-
-          giftHttpService = {
-            delete: mockHttpServiceDelete,
-            post: mockHttpServicePost,
-          };
-
-          service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
-        });
-
-        it(`should return a response with the received status and data - %s`, async () => {
-          // Act
-          const response = await service.create(mockFacilityId, mockPayload);
-
-          // Assert
-          const expected = {
-            status,
-            data: mockResponseData,
-          };
-
-          expect(response).toEqual(expected);
-        });
-
-        it('should call giftHttpService.delete', async () => {
-          // Act
-          await service.create(mockFacilityId, mockPayload);
-
-          // Assert
-          expect(mockHttpServiceDelete).toHaveBeenCalledTimes(1);
-
-          const expected = {
-            path: `${PATH.WORK_PACKAGE}/${WORK_PACKAGE_CREATION_RESPONSE_DATA.id}`,
-          };
-
-          expect(mockHttpServiceDelete).toHaveBeenCalledWith(expected);
-        });
-
-        describe('when giftHttpService.delete throws an error', () => {
-          it('should throw an error', async () => {
-            // Arrange
-            const mockError = mockResponse500();
-
-            mockHttpServicePost = jest.fn().mockResolvedValueOnce({
-              status,
-              data: mockResponseData,
-            });
-
-            mockHttpServiceDelete = jest.fn().mockRejectedValueOnce(mockError);
-
-            giftHttpService = {
-              delete: mockHttpServiceDelete,
-              post: mockHttpServicePost,
-            };
-
-            service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
-
-            // Act
-            const response = service.create(mockFacilityId, mockPayload);
-
-            // Assert
-            const expected = new Error(`Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`, { cause: mockError });
-
-            await expect(response).rejects.toThrow(expected);
-          });
-        });
-      });
-    });
-
-    describe('when giftHttpService.post throws an error', () => {
+  describe('giftAmountAmendmentService', () => {
+    describe('when giftAmountAmendmentService.facility throws an error', () => {
       it('should throw an error', async () => {
         // Arrange
         const mockError = mockResponse500();
 
-        mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
+        mockAmountAmendmentFacility = jest.fn().mockRejectedValueOnce(mockError);
+        amountAmendmentService.facility = mockAmountAmendmentFacility;
 
-        giftHttpService = {
-          post: mockHttpServicePost,
-        };
+        buildService();
 
-        service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+        // Act
+        const response = service.create(mockFacilityId, mockPayload);
+
+        // Assert
+        const expected = new Error(`Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`, { cause: mockError });
+
+        await expect(response).rejects.toThrow(expected);
+      });
+    });
+
+    describe('when giftAmountAmendmentService.obligations throws an error', () => {
+      it('should throw an error', async () => {
+        // Arrange
+        const mockError = mockResponse500();
+
+        mockAmountAmendmentObligations = jest.fn().mockRejectedValueOnce(mockError);
+        amountAmendmentService.obligations = mockAmountAmendmentObligations;
+
+        buildService();
 
         // Act
         const response = service.create(mockFacilityId, mockPayload);
@@ -236,20 +172,6 @@ describe('GiftFacilityAmendmentService - error handling', () => {
   });
 
   describe('giftStatusService.approved', () => {
-    beforeEach(() => {
-      mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
-
-      mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockResponse201());
-
-      giftHttpService = {
-        post: mockHttpServicePost,
-      };
-
-      workPackageService.create = mockWorkPackageServiceCreate;
-
-      service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
-    });
-
     describe(`when giftStatusService.approved does NOT return a ${HttpStatus.OK} status`, () => {
       describe.each([
         HttpStatus.ACCEPTED,
@@ -273,21 +195,15 @@ describe('GiftFacilityAmendmentService - error handling', () => {
 
           statusService.approved = mockStatusServiceApproved;
 
-          service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+          buildService();
         });
 
         it('should throw an error', async () => {
-          // Act & Assert
-          await expect(service.create(mockFacilityId, mockPayload)).rejects.toMatchObject({
-            message: `Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`,
-            cause: {
-              message: `Error approving work package ${WORK_PACKAGE_CREATION_RESPONSE_DATA.id} for facility ${mockFacilityId} amendment ${mockPayload.amendmentType}`,
-              cause: {
-                status,
-                data: mockResponseData,
-              },
-            },
-          });
+          // Act
+          const response = service.create(mockFacilityId, mockPayload);
+
+          // Assert
+          await expect(response).rejects.toThrow(`Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`);
         });
       });
     });
@@ -301,15 +217,13 @@ describe('GiftFacilityAmendmentService - error handling', () => {
 
         statusService.approved = mockStatusServiceApproved;
 
-        service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+        buildService();
 
         // Act
         const response = service.create(mockFacilityId, mockPayload);
 
         // Assert
-        const expected = new Error(`Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`, { cause: mockError });
-
-        await expect(response).rejects.toThrow(expected);
+        await expect(response).rejects.toThrow(`Error creating amendment ${mockPayload.amendmentType} for facility ${mockFacilityId}`);
       });
     });
   });

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -22,12 +22,23 @@ const {
 
 const {
   AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT },
+  FACILITY_CATEGORY_CODES,
 } = GIFT;
 
 const mockWorkPackageServiceCreateResponse = mockResponse201(WORK_PACKAGE_CREATION_RESPONSE_DATA);
 
 describe('GiftFacilityAmendmentService', () => {
   const logger = new PinoLogger({});
+  const mockFacilityCategoryCode = FACILITY_CATEGORY_CODES.CONTINGENT;
+  const mockObligations = [{ id: 'obligation-1' }];
+
+  const mockFacilityResponseData = {
+    ...FACILITY_RESPONSE_DATA,
+    obligations: mockObligations,
+    riskDetails: {
+      facilityCategoryCode: mockFacilityCategoryCode,
+    },
+  };
 
   let mockAmountAmendmentServiceFacility: jest.Mock;
   let mockAmountAmendmentServiceObligations: jest.Mock;
@@ -52,8 +63,8 @@ describe('GiftFacilityAmendmentService', () => {
     amountAmendmentService = {} as GiftAmountAmendmentService;
     statusService = new GiftStatusService(giftHttpService, logger);
 
-    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(FACILITY_RESPONSE_DATA));
-    mockAmountAmendmentServiceFacility = jest.fn().mockResolvedValueOnce(mockResponse201({}));
+    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(mockFacilityResponseData));
+    mockAmountAmendmentServiceFacility = jest.fn().mockResolvedValueOnce(mockResponse201(WORK_PACKAGE_CREATION_RESPONSE_DATA));
     mockAmountAmendmentServiceObligations = jest.fn().mockResolvedValueOnce([]);
     mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
     mockStatusServiceApproved = jest.fn().mockResolvedValueOnce(mockResponse200(WORK_PACKAGE_APPROVE_RESPONSE_DATA));
@@ -104,8 +115,10 @@ describe('GiftFacilityAmendmentService', () => {
         1,
         expect.objectContaining({
           amendmentType: increasePayload.amendmentType,
+          facilityCategoryCode: mockFacilityCategoryCode,
           facilityId: mockFacilityId,
           newFacilityAmount: increasePayload.amendmentData.amount,
+          obligations: mockObligations,
           workPackageId: mockWorkPackageId,
         }),
       );
@@ -132,8 +145,10 @@ describe('GiftFacilityAmendmentService', () => {
         1,
         expect.objectContaining({
           amendmentType: decreasePayload.amendmentType,
+          facilityCategoryCode: mockFacilityCategoryCode,
           facilityId: mockFacilityId,
           newFacilityAmount: decreasePayload.amendmentData.amount,
+          obligations: mockObligations,
           workPackageId: mockWorkPackageId,
         }),
       );
@@ -166,7 +181,7 @@ describe('GiftFacilityAmendmentService', () => {
       const expected = {
         status: HttpStatus.CREATED,
         data: {
-          ...WORK_PACKAGE_APPROVE_RESPONSE_DATA,
+          ...WORK_PACKAGE_CREATION_RESPONSE_DATA,
           isApproved: true,
         },
       };

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -45,6 +45,8 @@ describe('GiftFacilityAmendmentService', () => {
 
   beforeEach(() => {
     // Arrange
+    giftHttpService = {};
+
     workPackageService = new GiftWorkPackageService(giftHttpService, logger);
     facilityService = {} as GiftFacilityService;
     amountAmendmentService = {} as GiftAmountAmendmentService;

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -45,8 +45,6 @@ describe('GiftFacilityAmendmentService', () => {
 
   beforeEach(() => {
     // Arrange
-    giftHttpService = {};
-
     workPackageService = new GiftWorkPackageService(giftHttpService, logger);
     facilityService = {} as GiftFacilityService;
     amountAmendmentService = {} as GiftAmountAmendmentService;
@@ -64,7 +62,7 @@ describe('GiftFacilityAmendmentService', () => {
     workPackageService.create = mockWorkPackageServiceCreate;
     statusService.approved = mockStatusServiceApproved;
 
-    service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, facilityService, amountAmendmentService, statusService);
+    service = new GiftFacilityAmendmentService(logger, workPackageService, facilityService, amountAmendmentService, statusService);
   });
 
   afterAll(() => {

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -1,28 +1,40 @@
 import { HttpStatus } from '@nestjs/common';
 import { EXAMPLES, GIFT } from '@ukef/constants';
 import { mockWorkPackageId } from '@ukef-test/gift/test-helpers';
-import { mockResponse200, mockResponse201, mockResponse204 } from '@ukef-test/http-response';
+import { mockResponse200, mockResponse201 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
+import { GiftAmountAmendmentService } from '../gift.amount-amendment.service';
+import { GiftFacilityService } from '../gift.facility.service';
 import { GiftStatusService } from '../gift.status.service';
 import { GiftWorkPackageService } from '../gift.work-package.service';
 import { GiftFacilityAmendmentService } from '.';
 
 const {
-  GIFT: { WORK_PACKAGE_CREATION_RESPONSE_DATA, FACILITY_ID: mockFacilityId, FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload },
+  GIFT: {
+    FACILITY_ID: mockFacilityId,
+    FACILITY_AMENDMENT_REQUEST_PAYLOAD: mockPayload,
+    FACILITY_RESPONSE_DATA,
+    WORK_PACKAGE_APPROVE_RESPONSE_DATA,
+    WORK_PACKAGE_CREATION_RESPONSE_DATA,
+  },
 } = EXAMPLES;
 
-const { PATH } = GIFT;
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_DECREASE_AMOUNT, AMEND_FACILITY_INCREASE_AMOUNT },
+} = GIFT;
 
 const mockWorkPackageServiceCreateResponse = mockResponse201(WORK_PACKAGE_CREATION_RESPONSE_DATA);
-const mockHttpPostResponse = mockResponse201({ mockHttpPostResponse: true });
 
 describe('GiftFacilityAmendmentService', () => {
   const logger = new PinoLogger({});
 
-  let mockHttpServicePost: jest.Mock;
-  let mockHttpServiceDelete: jest.Mock;
+  let mockAmountAmendmentServiceFacility: jest.Mock;
+  let mockAmountAmendmentServiceObligations: jest.Mock;
+  let mockFacilityServiceGet: jest.Mock;
   let workPackageService: GiftWorkPackageService;
+  let facilityService: GiftFacilityService;
+  let amountAmendmentService: GiftAmountAmendmentService;
   let statusService: GiftStatusService;
   let mockWorkPackageServiceCreate: jest.Mock;
   let mockStatusServiceApproved: jest.Mock;
@@ -33,23 +45,26 @@ describe('GiftFacilityAmendmentService', () => {
 
   beforeEach(() => {
     // Arrange
+    giftHttpService = {};
+
     workPackageService = new GiftWorkPackageService(giftHttpService, logger);
+    facilityService = {} as GiftFacilityService;
+    amountAmendmentService = {} as GiftAmountAmendmentService;
     statusService = new GiftStatusService(giftHttpService, logger);
 
+    mockFacilityServiceGet = jest.fn().mockResolvedValueOnce(mockResponse200(FACILITY_RESPONSE_DATA));
+    mockAmountAmendmentServiceFacility = jest.fn().mockResolvedValueOnce(mockResponse201({}));
+    mockAmountAmendmentServiceObligations = jest.fn().mockResolvedValueOnce([]);
     mockWorkPackageServiceCreate = jest.fn().mockResolvedValueOnce(mockWorkPackageServiceCreateResponse);
-    mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockHttpPostResponse);
-    mockHttpServiceDelete = jest.fn().mockResolvedValueOnce(mockResponse204());
-    mockStatusServiceApproved = jest.fn().mockResolvedValueOnce(mockResponse200());
+    mockStatusServiceApproved = jest.fn().mockResolvedValueOnce(mockResponse200(WORK_PACKAGE_APPROVE_RESPONSE_DATA));
 
+    facilityService.get = mockFacilityServiceGet;
+    amountAmendmentService.facility = mockAmountAmendmentServiceFacility;
+    amountAmendmentService.obligations = mockAmountAmendmentServiceObligations;
     workPackageService.create = mockWorkPackageServiceCreate;
     statusService.approved = mockStatusServiceApproved;
 
-    giftHttpService = {
-      post: mockHttpServicePost,
-      delete: mockHttpServiceDelete,
-    };
-
-    service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, statusService);
+    service = new GiftFacilityAmendmentService(giftHttpService, logger, workPackageService, facilityService, amountAmendmentService, statusService);
   });
 
   afterAll(() => {
@@ -66,19 +81,70 @@ describe('GiftFacilityAmendmentService', () => {
     expect(mockWorkPackageServiceCreate).toHaveBeenCalledWith(mockFacilityId);
   });
 
-  it('should call giftHttpService.post', async () => {
-    // Act
-    await service.create(mockFacilityId, mockPayload);
-
-    // Assert
-    expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
-
-    const expected = {
-      path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${mockPayload.amendmentType}`,
-      payload: mockPayload.amendmentData,
+  describe('when amendment is increase amount', () => {
+    const increasePayload = {
+      ...mockPayload,
+      amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
     };
 
-    expect(mockHttpServicePost).toHaveBeenCalledWith(expected);
+    it('should call giftAmountAmendmentService.facility,  then giftAmountAmendmentService.obligations', async () => {
+      // Act
+      await service.create(mockFacilityId, increasePayload);
+
+      // Assert
+      expect(mockAmountAmendmentServiceFacility).toHaveBeenCalledTimes(1);
+      expect(mockAmountAmendmentServiceObligations).toHaveBeenCalledTimes(1);
+
+      expect(mockAmountAmendmentServiceFacility).toHaveBeenNthCalledWith(1, {
+        ...increasePayload,
+        facilityId: mockFacilityId,
+        workPackageId: mockWorkPackageId,
+      });
+      expect(mockAmountAmendmentServiceObligations).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          amendmentType: increasePayload.amendmentType,
+          facilityId: mockFacilityId,
+          newFacilityAmount: increasePayload.amendmentData.amount,
+          workPackageId: mockWorkPackageId,
+        }),
+      );
+
+      expect(mockAmountAmendmentServiceFacility.mock.invocationCallOrder[0]).toBeLessThan(mockAmountAmendmentServiceObligations.mock.invocationCallOrder[0]);
+    });
+  });
+
+  describe('when amendment is decrease amount', () => {
+    const decreasePayload = {
+      ...mockPayload,
+      amendmentType: AMEND_FACILITY_DECREASE_AMOUNT,
+    };
+
+    it('should call giftAmountAmendmentService.obligations then facility', async () => {
+      // Act
+      await service.create(mockFacilityId, decreasePayload);
+
+      // Assert
+      expect(mockAmountAmendmentServiceFacility).toHaveBeenCalledTimes(1);
+      expect(mockAmountAmendmentServiceObligations).toHaveBeenCalledTimes(1);
+
+      expect(mockAmountAmendmentServiceObligations).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          amendmentType: decreasePayload.amendmentType,
+          facilityId: mockFacilityId,
+          newFacilityAmount: decreasePayload.amendmentData.amount,
+          workPackageId: mockWorkPackageId,
+        }),
+      );
+      expect(mockAmountAmendmentServiceFacility).toHaveBeenNthCalledWith(1, {
+        ...decreasePayload,
+        facilityId: mockFacilityId,
+        workPackageId: mockWorkPackageId,
+      });
+
+      expect(mockAmountAmendmentServiceObligations.mock.invocationCallOrder[0]).toBeLessThan(mockAmountAmendmentServiceFacility.mock.invocationCallOrder[0]);
+    });
   });
 
   it('should call giftStatusService.approved', async () => {
@@ -100,7 +166,7 @@ describe('GiftFacilityAmendmentService', () => {
       const expected = {
         status: HttpStatus.CREATED,
         data: {
-          ...mockHttpPostResponse.data,
+          ...WORK_PACKAGE_APPROVE_RESPONSE_DATA,
           isApproved: true,
         },
       };

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -1,14 +1,35 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { GIFT } from '@ukef/constants';
+import { UkefId } from '@ukef/helpers/ukef-id.type';
 import { AxiosResponse } from 'axios';
 import { PinoLogger } from 'nestjs-pino';
 
-import { CreateGiftFacilityAmendmentRequestDto, GiftWorkPackageResponseDto } from '../../dto';
+import { CreateGiftFacilityAmendmentRequestDto, DecreaseAmountDto, GiftWorkPackageResponseDto, IncreaseAmountDto } from '../../dto';
+import { GiftAmountAmendmentService } from '../gift.amount-amendment.service';
+import { GiftFacilityService } from '../gift.facility.service';
 import { GiftHttpService } from '../gift.http.service';
 import { GiftStatusService } from '../gift.status.service';
 import { GiftWorkPackageService } from '../gift.work-package.service';
 
-const { PATH } = GIFT;
+const {
+  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT },
+} = GIFT;
+
+type IncreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
+  amendmentType: typeof AMEND_FACILITY_INCREASE_AMOUNT;
+  amendmentData: IncreaseAmountDto;
+};
+
+type DecreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
+  amendmentType: typeof AMEND_FACILITY_DECREASE_AMOUNT;
+  amendmentData: DecreaseAmountDto;
+};
+
+const isIncreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is IncreaseAmountAmendmentRequest =>
+  amendment.amendmentType === AMEND_FACILITY_INCREASE_AMOUNT;
+
+const isDecreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is DecreaseAmountAmendmentRequest =>
+  amendment.amendmentType === AMEND_FACILITY_DECREASE_AMOUNT;
 
 interface CreateGiftFacilityAmendmentResponseDto {
   status: AxiosResponse['status'];
@@ -25,12 +46,27 @@ export class GiftFacilityAmendmentService {
     private readonly giftHttpService: GiftHttpService,
     private readonly logger: PinoLogger,
     private readonly giftWorkPackageService: GiftWorkPackageService,
+    private readonly giftFacilityService: GiftFacilityService,
+    private readonly giftAmountAmendmentService: GiftAmountAmendmentService,
     private readonly giftStatusService: GiftStatusService,
   ) {
     this.giftHttpService = giftHttpService;
     this.giftWorkPackageService = giftWorkPackageService;
+    this.giftFacilityService = giftFacilityService;
+    this.giftAmountAmendmentService = giftAmountAmendmentService;
     this.giftStatusService = giftStatusService;
   }
+
+  // TODO - combine this documentation with documentation below.
+  // this is for amendmentResponse.status !== HttpStatus.CREATED
+  /**
+   * If an amendment has failed to be created,
+   * For example if GIFT returns a 400 Bad Request due to invalid payload, or a 500 Internal Server Error due to an issue in GIFT,
+   * Then the work package that was created in step 1 needs to be deleted, as it will be empty and unused without the amendment.
+   *
+   * Additionally, there is no need to manually handle any deletion response error - only 1x status is acceptable (GIFT_API_ACCEPTABLE_DELETE_STATUSES).
+   * If that status isn't returned, an error will be thrown, caught in the catch block, and logged accordingly.
+   */
 
   /**
    * Create a GIFT facility amendment
@@ -40,17 +76,23 @@ export class GiftFacilityAmendmentService {
    * As a result, GIFT will have a new, approved work package in the facility, with an amendment in the work package.
    *
    * If there is an error creating the amendment, the previous created work package will be deleted.
-   * @param {string} facilityId: Facility ID
+   * @param {UkefId} facilityId: Facility ID
    * @param {CreateGiftFacilityAmendmentRequestDto} amendmentData: Amendment data
    * @throws {Error} If there is an error creating the amendment or the work package.
    * @returns {Promise<CreateGiftFacilityAmendmentResponseDto>}
    */
-  async create(facilityId: string, amendment: CreateGiftFacilityAmendmentRequestDto): Promise<CreateGiftFacilityAmendmentResponseDto> {
-    const { amendmentType, amendmentData } = amendment;
+  async create(facilityId: UkefId, amendment: CreateGiftFacilityAmendmentRequestDto): Promise<CreateGiftFacilityAmendmentResponseDto> {
+    const { amendmentType } = amendment;
 
     try {
       this.logger.info('Creating amendment %s for facility %s', amendmentType, facilityId);
 
+      const { data: facility } = await this.giftFacilityService.get(facilityId);
+
+      /**
+       * Generate a GIFT work package.
+       * All amendments will be in this work package.
+       */
       const { data: workPackage, status } = await this.giftWorkPackageService.create(facilityId);
 
       if (status !== HttpStatus.CREATED) {
@@ -63,61 +105,55 @@ export class GiftFacilityAmendmentService {
       }
 
       const { id: workPackageId } = workPackage;
+      const { obligations } = facility;
+
+      const baseObligationParams = {
+        amendmentType,
+        facilityId,
+        obligations,
+        workPackageId,
+      };
 
       /**
-       * Construct the full "configuration event type" string for GIFT.
-       * By doing this in APIM, it provides consumers with a simpler payload requirement.
-       * I.e, "IncreaseAmount" rather than "AmendFacility_IncreaseAmount".
+       * If the amendment is "increase amount", the new facility amount will impact the obligation amounts.
+       * Execute in the following order:
+       * 1) Amend the facility
+       * 2) Amend obligations
        */
-      const configTypeString = `AmendFacility_${amendmentType}`;
+      if (isIncreaseAmountAmendment(amendment)) {
+        const {
+          amendmentData: { amount: newFacilityAmount, date },
+        } = amendment;
 
-      const amendmentResponse = await this.giftHttpService.post<GiftWorkPackageResponseDto>({
-        path: `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${configTypeString}`,
-        payload: amendmentData,
-      });
+        await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
 
-      if (amendmentResponse.status !== HttpStatus.CREATED) {
-        this.logger.error('Error creating amendment %s for work package %s facility %s', amendmentType, workPackageId, facilityId);
-
-        /**
-         * If an amendment has failed to be created,
-         * For example if GIFT returns a 400 Bad Request due to invalid payload, or a 500 Internal Server Error due to an issue in GIFT,
-         * Then the work package that was created in step 1 needs to be deleted, as it will be empty and unused without the amendment.
-         *
-         * Additionally, there is no need to manually handle any deletion response error - only 1x status is acceptable (GIFT_API_ACCEPTABLE_DELETE_STATUSES).
-         * If that status isn't returned, an error will be thrown, caught in the catch block, and logged accordingly.
-         */
-        this.logger.info('Deleting work package %s for facility %s', workPackageId, facilityId);
-
-        await this.giftHttpService.delete<GiftWorkPackageResponseDto>({
-          path: `${PATH.WORK_PACKAGE}/${workPackageId}`,
-        });
-
-        return {
-          status: amendmentResponse.status,
-          data: amendmentResponse.data,
-        };
+        await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
       }
 
-      const approvalResponse = await this.giftStatusService.approved(facilityId, workPackageId);
+      /**
+       * If the amendment is "decrease amount", the new facility amount will impact the obligation amounts.
+       * Execute in the following order:
+       * 1) Amend obligations
+       * 2) Amend the facility
+       */
+      if (isDecreaseAmountAmendment(amendment)) {
+        const {
+          amendmentData: { amount: newFacilityAmount, date },
+        } = amendment;
 
-      if (approvalResponse.status !== HttpStatus.OK) {
-        this.logger.error('Error approving work package %s for facility %s amendment %s', workPackageId, facilityId, amendmentType);
+        await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
 
-        throw new Error(`Error approving work package ${workPackageId} for facility ${facilityId} amendment ${amendmentType}`, {
-          cause: {
-            data: approvalResponse.data,
-            status: approvalResponse.status,
-          },
-        });
+        await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
       }
+
+      const approvalResponse = await this.approveWorkPackage(facilityId, workPackageId);
 
       // TODO: GIFT-20331 - validation handling
 
       const returnResponse = {
         status: HttpStatus.CREATED,
         data: {
-          ...amendmentResponse.data,
+          ...approvalResponse.data,
           isApproved: true,
         },
       };
@@ -127,6 +163,38 @@ export class GiftFacilityAmendmentService {
       this.logger.error('Error creating amendment %s for facility %s %o', amendmentType, facilityId, error);
 
       throw new Error(`Error creating amendment ${amendmentType} for facility ${facilityId}`, { cause: error });
+    }
+  }
+
+  /**
+   * Approves a work package for a given facility.
+   * @param {UkefId} facilityId The ID of the facility.
+   * @param {number} workPackageId The ID of the work package.
+   * @returns {Promise<GiftWorkPackageResponseDto>} The approval response.
+   * @throws {Error}
+   */
+  async approveWorkPackage(facilityId: UkefId, workPackageId: number) {
+    try {
+      this.logger.info('Approving amendmentwork package %s for facility %s', workPackageId, facilityId);
+
+      const approvalResponse = await this.giftStatusService.approved(facilityId, workPackageId);
+
+      if (approvalResponse.status !== HttpStatus.OK) {
+        this.logger.error('Error approving amendment work package %s for facility %s amendment %s', workPackageId, facilityId, approvalResponse.data);
+
+        throw new Error(`Error approving amendment work package ${workPackageId} for facility ${facilityId} amendment`, {
+          cause: {
+            data: approvalResponse.data,
+            status: approvalResponse.status,
+          },
+        });
+      }
+
+      return approvalResponse;
+    } catch (error) {
+      this.logger.error('Error approving amendment work package %s for facility %s amendment %o', workPackageId, facilityId, error);
+
+      throw new Error(`Error approving amendment work package ${workPackageId} for facility ${facilityId} amendment`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -49,11 +49,21 @@ export class GiftFacilityAmendmentService {
    */
   async create(facilityId: UkefId, amendment: CreateGiftFacilityAmendmentRequestDto): Promise<CreateGiftFacilityAmendmentResponseDto> {
     const { amendmentType } = amendment;
+    let createdAmendmentData: GiftWorkPackageResponseDto | null = null;
 
     try {
       this.logger.info('Creating amendment %s for facility %s', amendmentType, facilityId);
 
-      const { data: facility } = await this.giftFacilityService.get(facilityId);
+      const facilityResponse = await this.giftFacilityService.get(facilityId);
+
+      if (facilityResponse.status !== HttpStatus.OK) {
+        return {
+          status: facilityResponse.status,
+          data: facilityResponse.data,
+        };
+      }
+
+      const { data: facility } = facilityResponse;
 
       /**
        * Generate a GIFT work package.
@@ -91,7 +101,9 @@ export class GiftFacilityAmendmentService {
           amendmentData: { amount: newFacilityAmount, date },
         } = amendment;
 
-        await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
+        const facilityAmendmentResponse = await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
+
+        createdAmendmentData = facilityAmendmentResponse.data;
 
         await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
       }
@@ -109,7 +121,9 @@ export class GiftFacilityAmendmentService {
 
         await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
 
-        await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
+        const facilityAmendmentResponse = await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
+
+        createdAmendmentData = facilityAmendmentResponse.data;
       }
 
       const approvalResponse = await this.approveWorkPackage(facilityId, workPackageId);
@@ -119,7 +133,7 @@ export class GiftFacilityAmendmentService {
       const returnResponse = {
         status: HttpStatus.CREATED,
         data: {
-          ...approvalResponse.data,
+          ...(createdAmendmentData ?? approvalResponse.data),
           isApproved: true,
         },
       };
@@ -141,12 +155,12 @@ export class GiftFacilityAmendmentService {
    */
   async approveWorkPackage(facilityId: UkefId, workPackageId: number) {
     try {
-      this.logger.info('Approving amendmentwork package %s for facility %s', workPackageId, facilityId);
+      this.logger.info('Approving amendment work package %s for facility %s', workPackageId, facilityId);
 
       const approvalResponse = await this.giftStatusService.approved(facilityId, workPackageId);
 
       if (approvalResponse.status !== HttpStatus.OK) {
-        this.logger.error('Error approving amendment work package %s for facility %s amendment %s', workPackageId, facilityId, approvalResponse.data);
+        this.logger.error('Error approving amendment work package %s for facility %s %o', workPackageId, facilityId, approvalResponse.data);
 
         throw new Error(`Error approving amendment work package ${workPackageId} for facility ${facilityId} amendment`, {
           cause: {
@@ -158,9 +172,9 @@ export class GiftFacilityAmendmentService {
 
       return approvalResponse;
     } catch (error) {
-      this.logger.error('Error approving amendment work package %s for facility %s amendment %o', workPackageId, facilityId, error);
+      this.logger.error('Error approving amendment work package %s for facility %s %o', workPackageId, facilityId, error);
 
-      throw new Error(`Error approving amendment work package ${workPackageId} for facility ${facilityId} amendment`, { cause: error });
+      throw new Error(`Error approving amendment work package ${workPackageId} for facility ${facilityId}`, { cause: error });
     }
   }
 }

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -34,17 +34,6 @@ export class GiftFacilityAmendmentService {
     this.giftStatusService = giftStatusService;
   }
 
-  // TODO - combine this documentation with documentation below.
-  // this is for amendmentResponse.status !== HttpStatus.CREATED
-  /**
-   * If an amendment has failed to be created,
-   * For example if GIFT returns a 400 Bad Request due to invalid payload, or a 500 Internal Server Error due to an issue in GIFT,
-   * Then the work package that was created in step 1 needs to be deleted, as it will be empty and unused without the amendment.
-   *
-   * Additionally, there is no need to manually handle any deletion response error - only 1x status is acceptable (GIFT_API_ACCEPTABLE_DELETE_STATUSES).
-   * If that status isn't returned, an error will be thrown, caught in the catch block, and logged accordingly.
-   */
-
   /**
    * Create a GIFT facility amendment
    * 1) Create a new GIFT work package

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -81,12 +81,16 @@ export class GiftFacilityAmendmentService {
       }
 
       const { id: workPackageId } = workPackage;
-      const { obligations } = facility;
+      const {
+        obligations,
+        riskDetails: { facilityCategoryCode },
+      } = facility;
 
       const baseObligationParams = {
         amendmentType,
         facilityId,
         obligations,
+        facilityCategoryCode,
         workPackageId,
       };
 

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -1,35 +1,14 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
-import { GIFT } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers/ukef-id.type';
 import { AxiosResponse } from 'axios';
 import { PinoLogger } from 'nestjs-pino';
 
-import { CreateGiftFacilityAmendmentRequestDto, DecreaseAmountDto, GiftWorkPackageResponseDto, IncreaseAmountDto } from '../../dto';
+import { CreateGiftFacilityAmendmentRequestDto, GiftWorkPackageResponseDto } from '../../dto';
+import { isDecreaseAmountAmendment, isIncreaseAmountAmendment } from '../../helpers';
 import { GiftAmountAmendmentService } from '../gift.amount-amendment.service';
 import { GiftFacilityService } from '../gift.facility.service';
-import { GiftHttpService } from '../gift.http.service';
 import { GiftStatusService } from '../gift.status.service';
 import { GiftWorkPackageService } from '../gift.work-package.service';
-
-const {
-  AMEND_FACILITY_TYPES: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_DECREASE_AMOUNT },
-} = GIFT;
-
-type IncreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
-  amendmentType: typeof AMEND_FACILITY_INCREASE_AMOUNT;
-  amendmentData: IncreaseAmountDto;
-};
-
-type DecreaseAmountAmendmentRequest = CreateGiftFacilityAmendmentRequestDto & {
-  amendmentType: typeof AMEND_FACILITY_DECREASE_AMOUNT;
-  amendmentData: DecreaseAmountDto;
-};
-
-const isIncreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is IncreaseAmountAmendmentRequest =>
-  amendment.amendmentType === AMEND_FACILITY_INCREASE_AMOUNT;
-
-const isDecreaseAmountAmendment = (amendment: CreateGiftFacilityAmendmentRequestDto): amendment is DecreaseAmountAmendmentRequest =>
-  amendment.amendmentType === AMEND_FACILITY_DECREASE_AMOUNT;
 
 interface CreateGiftFacilityAmendmentResponseDto {
   status: AxiosResponse['status'];
@@ -43,14 +22,12 @@ interface CreateGiftFacilityAmendmentResponseDto {
 @Injectable()
 export class GiftFacilityAmendmentService {
   constructor(
-    private readonly giftHttpService: GiftHttpService,
     private readonly logger: PinoLogger,
     private readonly giftWorkPackageService: GiftWorkPackageService,
     private readonly giftFacilityService: GiftFacilityService,
     private readonly giftAmountAmendmentService: GiftAmountAmendmentService,
     private readonly giftStatusService: GiftStatusService,
   ) {
-    this.giftHttpService = giftHttpService;
     this.giftWorkPackageService = giftWorkPackageService;
     this.giftFacilityService = giftFacilityService;
     this.giftAmountAmendmentService = giftAmountAmendmentService;

--- a/src/modules/gift/services/index.ts
+++ b/src/modules/gift/services/index.ts
@@ -1,4 +1,5 @@
 export * from './gift.accrual-schedule.service';
+export * from './gift.amount-amendment.service';
 export * from './gift.business-calendar.service';
 export * from './gift.business-calendars-convention.service';
 export * from './gift.counterparty.service';

--- a/test/gift/create-facility.api-test.ts
+++ b/test/gift/create-facility.api-test.ts
@@ -121,6 +121,7 @@ describe('POST /gift/facility', () => {
         obligations: Array(payloadObligations.length).fill(mockResponses.obligation.data),
         repaymentProfiles: Array(payloadRepaymentProfiles.length).fill(mockResponses.repaymentProfile.data),
         riskDetails: mockResponses.riskDetails.data,
+        state: mockResponses.approveStatus.state,
       };
 
       expect(body).toStrictEqual(expected);
@@ -229,6 +230,7 @@ describe('POST /gift/facility', () => {
         obligations: Array(payloadObligations.length).fill(mockResponses.obligation.data),
         repaymentProfiles: Array(payloadRepaymentProfiles.length).fill(mockResponses.repaymentProfile.data),
         riskDetails: mockResponses.riskDetails.data,
+        state: mockResponses.approveStatus.state,
       };
 
       expect(body).toStrictEqual(expected);
@@ -256,6 +258,7 @@ describe('POST /gift/facility', () => {
         obligations: Array(payloadObligations.length).fill(mockResponses.obligation.data),
         repaymentProfiles: [],
         riskDetails: mockResponses.riskDetails.data,
+        state: mockResponses.approveStatus.state,
       };
 
       expect(body).toStrictEqual(expected);

--- a/test/gift/facility-amendment-error-handling.api-test.ts
+++ b/test/gift/facility-amendment-error-handling.api-test.ts
@@ -9,8 +9,10 @@ import {
   apimFacilityAmendmentWithoutQueueUrl,
   approveStatusUrl,
   facilityAmendmentUrl,
+  facilityUrl,
   facilityWorkPackageUrl,
   mockResponses,
+  obligationAmendmentUrl,
   workPackageUrl,
 } from './test-helpers';
 
@@ -38,7 +40,16 @@ describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
 
   beforeEach(() => {
     // Arrange
+    nock(GIFT_API_URL)
+      .persist()
+      .get(facilityUrl)
+      .reply(HttpStatus.OK, {
+        obligations: [{ id: 'obligation-1' }],
+      });
+
     nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
+
+    nock(GIFT_API_URL).persist().post(obligationAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
   });
 
   describe('GIFT "create work package - configuration event" endpoint', () => {

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -97,7 +97,10 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
-        expect(body).toStrictEqual({});
+        expect(body).toStrictEqual({
+          ...mockResponses.approveStatus,
+          isApproved: true,
+        });
 
         expect(callOrder).toStrictEqual(['workPackage', 'facilityAmendment', 'obligationAmendment']);
       });
@@ -152,7 +155,10 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
-        expect(body).toStrictEqual({});
+        expect(body).toStrictEqual({
+          ...mockResponses.approveStatus,
+          isApproved: true,
+        });
 
         expect(callOrder).toStrictEqual(['workPackage', 'obligationAmendment', 'facilityAmendment']);
       });
@@ -183,7 +189,10 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
-        expect(body).toStrictEqual({});
+        expect(body).toStrictEqual({
+          ...mockResponses.approveStatus,
+          isApproved: true,
+        });
       });
     });
   });

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -59,6 +59,9 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
           .get(facilityUrl)
           .reply(HttpStatus.OK, {
             obligations: [{ id: 'obligation-1' }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
           });
 
         nock(GIFT_API_URL)
@@ -98,7 +101,7 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
         expect(body).toStrictEqual({
-          ...mockResponses.approveStatus,
+          ...mockResponses.facilityAmendment,
           isApproved: true,
         });
 
@@ -117,6 +120,9 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
           .get(facilityUrl)
           .reply(HttpStatus.OK, {
             obligations: [{ id: 'obligation-1' }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
           });
 
         nock(GIFT_API_URL)
@@ -157,7 +163,7 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
         expect(status).toBe(HttpStatus.CREATED);
 
         expect(body).toStrictEqual({
-          ...mockResponses.approveStatus,
+          ...mockResponses.facilityAmendment,
           isApproved: true,
         });
 
@@ -174,6 +180,9 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
           .get(facilityUrl)
           .reply(HttpStatus.OK, {
             obligations: [{ id: 'obligation-1' }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
           });
 
         nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -6,7 +6,15 @@ import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
 import nock from 'nock';
 
-import { apimFacilityAmendmentWithoutQueueUrl, approveStatusUrl, facilityAmendmentUrl, facilityWorkPackageUrl, mockResponses } from './test-helpers';
+import {
+  apimFacilityAmendmentWithoutQueueUrl,
+  approveStatusUrl,
+  facilityAmendmentUrl,
+  facilityUrl,
+  facilityWorkPackageUrl,
+  mockResponses,
+  obligationAmendmentUrl,
+} from './test-helpers';
 
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
@@ -41,23 +49,44 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
       ),
   });
 
-  beforeEach(() => {
-    // Arrange
-    nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
-
-    nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
-
-    nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_DECREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
-
-    nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_REPLACE_EXPIRY_DATE)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
-
-    nock(GIFT_API_URL).persist().post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
-  });
-
   describe(`${AMEND_FACILITY_INCREASE_AMOUNT}`, () => {
     describe(`when the payload is valid and a ${HttpStatus.CREATED} response is returned by all GIFT endpoints`, () => {
       it(`should return a ${HttpStatus.CREATED} response with a facility and the created amendment`, async () => {
         // Arrange
+        const callOrder: string[] = [];
+
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            obligations: [{ id: 'obligation-1' }],
+          });
+
+        nock(GIFT_API_URL)
+          .post(facilityWorkPackageUrl)
+          .reply(() => {
+            callOrder.push('workPackage');
+
+            return [HttpStatus.CREATED, mockResponses.workPackageCreation];
+          });
+
+        nock(GIFT_API_URL)
+          .post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT))
+          .reply(() => {
+            callOrder.push('facilityAmendment');
+
+            return [HttpStatus.CREATED, mockResponses.facilityAmendment];
+          });
+
+        nock(GIFT_API_URL)
+          .post(obligationAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT))
+          .reply(() => {
+            callOrder.push('obligationAmendment');
+
+            return [HttpStatus.CREATED, mockResponses.facilityAmendment];
+          });
+
+        nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
         const mockPayload = {
           amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
           amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.INCREASE_AMOUNT,
@@ -68,10 +97,9 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
+        expect(body).toStrictEqual({});
 
-        const expected = mockResponses.facilityAmendment;
-
-        expect(body).toStrictEqual(expected);
+        expect(callOrder).toStrictEqual(['workPackage', 'facilityAmendment', 'obligationAmendment']);
       });
     });
   });
@@ -80,6 +108,40 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
     describe(`when the payload is valid and a ${HttpStatus.CREATED} response is returned by all GIFT endpoints`, () => {
       it(`should return a ${HttpStatus.CREATED} response with a facility and the created amendment`, async () => {
         // Arrange
+        const callOrder: string[] = [];
+
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            obligations: [{ id: 'obligation-1' }],
+          });
+
+        nock(GIFT_API_URL)
+          .post(facilityWorkPackageUrl)
+          .reply(() => {
+            callOrder.push('workPackage');
+
+            return [HttpStatus.CREATED, mockResponses.workPackageCreation];
+          });
+
+        nock(GIFT_API_URL)
+          .post(obligationAmendmentUrl(AMEND_FACILITY_DECREASE_AMOUNT))
+          .reply(() => {
+            callOrder.push('obligationAmendment');
+
+            return [HttpStatus.CREATED, mockResponses.facilityAmendment];
+          });
+
+        nock(GIFT_API_URL)
+          .post(facilityAmendmentUrl(AMEND_FACILITY_DECREASE_AMOUNT))
+          .reply(() => {
+            callOrder.push('facilityAmendment');
+
+            return [HttpStatus.CREATED, mockResponses.facilityAmendment];
+          });
+
+        nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
         const mockPayload = {
           amendmentType: AMEND_FACILITY_DECREASE_AMOUNT,
           amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.DECREASE_AMOUNT,
@@ -90,10 +152,9 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
+        expect(body).toStrictEqual({});
 
-        const expected = mockResponses.facilityAmendment;
-
-        expect(body).toStrictEqual(expected);
+        expect(callOrder).toStrictEqual(['workPackage', 'obligationAmendment', 'facilityAmendment']);
       });
     });
   });
@@ -102,6 +163,16 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
     describe(`when the payload is valid and a ${HttpStatus.CREATED} response is returned by all GIFT endpoints`, () => {
       it(`should return a ${HttpStatus.CREATED} response with a facility and the created amendment`, async () => {
         // Arrange
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            obligations: [{ id: 'obligation-1' }],
+          });
+
+        nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+
+        nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
         const mockPayload = {
           amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
           amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
@@ -112,10 +183,7 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
-
-        const expected = mockResponses.facilityAmendment;
-
-        expect(body).toStrictEqual(expected);
+        expect(body).toStrictEqual({});
       });
     });
   });

--- a/test/gift/facility-amendment.api-test.ts
+++ b/test/gift/facility-amendment.api-test.ts
@@ -155,6 +155,7 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
 
         // Assert
         expect(status).toBe(HttpStatus.CREATED);
+
         expect(body).toStrictEqual({
           ...mockResponses.approveStatus,
           isApproved: true,
@@ -176,6 +177,8 @@ describe('POST /gift/facility/:facilityId/amendment', () => {
           });
 
         nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+
+        nock(GIFT_API_URL).post(facilityAmendmentUrl(AMEND_FACILITY_REPLACE_EXPIRY_DATE)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
 
         nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
 

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -117,8 +117,11 @@ export const repaymentProfileUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WOR
 export const riskDetailsUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_RISK_DETAILS}`;
 export const approveStatusUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.APPROVE}`;
 export const facilityWorkPackageUrl = `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}`;
+export const facilityUrl = `${PATH.FACILITY}/${mockFacilityId}`;
 export const facilityAmendmentUrl = (amendmentType: string = AMEND_FACILITY_TYPES.AMEND_FACILITY_INCREASE_AMOUNT) =>
   `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendFacility_${amendmentType}`;
+export const obligationAmendmentUrl = (amendmentType: string = AMEND_FACILITY_TYPES.AMEND_FACILITY_INCREASE_AMOUNT) =>
+  `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/AmendObligation_${amendmentType}`;
 export const workPackageUrl = `${PATH.WORK_PACKAGE}/${mockWorkPackageId}`;
 
 export const businessCalendar = GIFT_EXAMPLES.BUSINESS_CALENDAR;

--- a/test/gift/test-helpers/index.ts
+++ b/test/gift/test-helpers/index.ts
@@ -51,7 +51,7 @@ const iAmATeapot: MockGiftResponse = {
 };
 
 export const mockResponses = {
-  approveStatus: { data: { aStatusUpdate: true } },
+  approveStatus: GIFT_EXAMPLES.WORK_PACKAGE_APPROVE_RESPONSE_DATA,
   accrualSchedule: { data: GIFT_EXAMPLES.ACCRUAL_SCHEDULE },
   businessCalendar: { data: GIFT_EXAMPLES.BUSINESS_CALENDAR },
   businessCalendarsConvention: { data: GIFT_EXAMPLES.BUSINESS_CALENDARS_CONVENTION },
@@ -70,10 +70,7 @@ export const mockResponses = {
       },
     },
   },
-  facilityAmendment: {
-    anAmendedFacility: true,
-    isApproved: true,
-  },
+  facilityAmendment: GIFT_EXAMPLES.WORK_PACKAGE_CREATION_RESPONSE_DATA,
   feeTypes: GIFT_EXAMPLES.FEE_TYPES_RESPONSE_DATA,
   fixedFee: { data: { aFixedFee: true } },
   obligation: { data: { anObligation: true } },


### PR DESCRIPTION
# Introduction :pencil2:

When the amendment endpoint is called for an "increase amount" or "decrease amount" amendment, obligation amounts in the facility need to be updated, as well as the facility.

In either scenario, the obligation amount needs to be updated to be 85% of the facility amount provided in the payload.


## Resolution :heavy_check_mark:

- Update constants.
- Create new service, `GiftAmountAmendmentService`.
- Create new helpers:
  - `isIncreaseAmountAmendment`
  - `isDecreaseAmountAmendment`
  - `calculatePercentageAmount`
- Update `GiftFacilityAmendmentService`.
- Add/update tests.

## Miscellaneous :heavy_plus_sign:

- Minor param improvement (string => UkefId)

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
