### PR TITLE
feat(DTFS2-8437): create a gift facility - optional queue delay

### DIFF
--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -155,6 +155,7 @@ export const GIFT = {
     LINKED_FACILITY_ID: null,
     ORIGINAL_FACILITY_EFFECTIVE_DATE: null,
   },
+  QUEUE_DELAY: 3 * 60 * 60, // 3 hours
   PATH: {
     AMENDMENT: '/amendment',
     APPROVE: '/approve',

--- a/src/constants/gift/gift.constant.ts
+++ b/src/constants/gift/gift.constant.ts
@@ -155,7 +155,7 @@ export const GIFT = {
     LINKED_FACILITY_ID: null,
     ORIGINAL_FACILITY_EFFECTIVE_DATE: null,
   },
-  QUEUE_DELAY: 3 * 60 * 60, // 3 hours
+  QUEUE_DELAY: 5 * 60 * 60, // 5 hours
   PATH: {
     AMENDMENT: '/amendment',
     APPROVE: '/approve',

--- a/src/modules/gift/controllers/gift.facility.controller.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.ts
@@ -83,7 +83,7 @@ export class GiftFacilityController {
     type: GiftFacilityCreationRequestDto,
   })
   @ApiAcceptedResponse({
-    description: 'The facility creation request has been accepted and queued',
+    description: 'The facility creation request has been accepted and added to the queue',
   })
   @ApiBadRequestResponse({
     description: 'Bad request',
@@ -114,7 +114,7 @@ export class GiftFacilityController {
     type: CreateGiftFacilityAmendmentRequestDto,
   })
   @ApiAcceptedResponse({
-    description: 'The facility amendment request has been accepted and queued',
+    description: 'The facility amendment request has been accepted and added to the queue',
   })
   @ApiBadRequestResponse({
     description: 'Bad request',

--- a/src/modules/gift/dto/request/facility-creation-generic.ts
+++ b/src/modules/gift/dto/request/facility-creation-generic.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EXAMPLES, GIFT } from '@ukef/constants';
 import { Type } from 'class-transformer';
-import { ArrayNotEmpty, IsArray, IsDefined, IsNotEmptyObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsBoolean, IsDefined, IsNotEmptyObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { IsSupportedConsumer, UniqueRepaymentProfileAllocationDates, UniqueRepaymentProfileNames } from '../../custom-decorators';
 import { GiftAccrualScheduleRequestDto } from './accrual-schedule';
@@ -104,4 +104,14 @@ export class GiftFacilityCreationGenericRequestDto {
   @Type(() => GiftRepaymentProfileRequestDto)
   @ValidateNested()
   repaymentProfiles?: GiftRepaymentProfileRequestDto[];
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    required: false,
+    description:
+      'Indicates whether the creation of the facility should be delayed. For example, if new data was created that ODS/GIFT depends on, ODS needs time to process that data before GIFT can successfully create the facility with it.',
+    example: true,
+  })
+  delayCreation?: boolean;
 }

--- a/src/modules/gift/services/gift.queue.service.test.ts
+++ b/src/modules/gift/services/gift.queue.service.test.ts
@@ -2,6 +2,7 @@ import { DefaultAzureCredential } from '@azure/identity';
 import { QueueServiceClient } from '@azure/storage-queue';
 import { ConfigService } from '@nestjs/config';
 import { GiftQueueConfig, KEY as GIFT_QUEUE_CONFIG_KEY } from '@ukef/config/gift-queue.config';
+import { GIFT } from '@ukef/constants';
 import { PinoLogger } from 'nestjs-pino';
 
 import { GiftQueueService } from './gift.queue.service';
@@ -13,6 +14,7 @@ const mockConnectionString = 'DefaultEndpointsProtocol=https;AccountName=test;Ac
 const mockStorageAccountName = 'mystorageaccount';
 const mockQueueName = 'gift-requests';
 const mockClientId = 'mock-client-id';
+const { QUEUE_DELAY } = GIFT;
 
 const mockQueueConfig: GiftQueueConfig = {
   storageAccountName: undefined,
@@ -21,8 +23,21 @@ const mockQueueConfig: GiftQueueConfig = {
   queueName: mockQueueName,
 };
 
-const mockPayload = { facilityId: '0030000321', dealId: '0020000123' };
-const expectedMessage = Buffer.from(JSON.stringify(mockPayload)).toString('base64');
+const mockCreationMessage = {
+  messageType: 'FACILITY_CREATION' as const,
+  payload: {
+    overview: { facilityId: '0030000321' },
+  },
+};
+
+const mockAmendmentMessage = {
+  messageType: 'FACILITY_AMENDMENT' as const,
+  facilityId: '0030000321',
+  payload: {
+    amendmentType: 'INCREASE_AMOUNT',
+    amendmentData: { amount: 100, date: '2026-01-01' },
+  },
+};
 
 describe('GiftQueueService', () => {
   const logger = new PinoLogger({});
@@ -132,18 +147,73 @@ describe('GiftQueueService', () => {
 
   describe('enqueue', () => {
     it('should call queueClient.sendMessage with a base64-encoded JSON payload', async () => {
+      const expectedMessage = Buffer.from(JSON.stringify(mockCreationMessage)).toString('base64');
+
       // Act
-      await service.enqueue(mockPayload);
+      await service.enqueue(mockCreationMessage as any);
 
       // Assert
       expect(mockSendMessage).toHaveBeenCalledTimes(1);
-      expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage);
+      expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage, {});
+    });
+
+    describe('when message is FACILITY_CREATION and payload.delayCreation is true', () => {
+      it('should set visibilityTimeout', async () => {
+        const delayedCreationMessage = {
+          ...mockCreationMessage,
+          payload: {
+            ...mockCreationMessage.payload,
+            delayCreation: true,
+          },
+        };
+        const expectedMessage = Buffer.from(JSON.stringify(delayedCreationMessage)).toString('base64');
+
+        // Act
+        await service.enqueue(delayedCreationMessage as any);
+
+        // Assert
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage, { visibilityTimeout: QUEUE_DELAY });
+      });
+    });
+
+    describe('when message is FACILITY_CREATION and payload.delayCreation is false', () => {
+      it('should not set visibilityTimeout', async () => {
+        const nonDelayedCreationMessage = {
+          ...mockCreationMessage,
+          payload: {
+            ...mockCreationMessage.payload,
+            delayCreation: false,
+          },
+        };
+        const expectedMessage = Buffer.from(JSON.stringify(nonDelayedCreationMessage)).toString('base64');
+
+        // Act
+        await service.enqueue(nonDelayedCreationMessage as any);
+
+        // Assert
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage, {});
+      });
+    });
+
+    describe('when message is FACILITY_AMENDMENT', () => {
+      it('should not set visibilityTimeout when message is FACILITY_AMENDMENT', async () => {
+        const expectedMessage = Buffer.from(JSON.stringify(mockAmendmentMessage)).toString('base64');
+
+        // Act
+        await service.enqueue(mockAmendmentMessage as any);
+
+        // Assert
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage, {});
+      });
     });
 
     describe('when queueClient.sendMessage is successful', () => {
       it('should resolve without returning a value', async () => {
         // Act
-        const result = await service.enqueue(mockPayload);
+        const result = await service.enqueue(mockCreationMessage as any);
 
         // Assert
         expect(result).toBeUndefined();
@@ -166,7 +236,7 @@ describe('GiftQueueService', () => {
 
       it('should throw the error', async () => {
         // Act
-        const promise = service.enqueue(mockPayload);
+        const promise = service.enqueue(mockCreationMessage as any);
 
         // Assert
         await expect(promise).rejects.toThrow(mockError);

--- a/src/modules/gift/services/gift.queue.service.test.ts
+++ b/src/modules/gift/services/gift.queue.service.test.ts
@@ -2,7 +2,7 @@ import { DefaultAzureCredential } from '@azure/identity';
 import { QueueServiceClient } from '@azure/storage-queue';
 import { ConfigService } from '@nestjs/config';
 import { GiftQueueConfig, KEY as GIFT_QUEUE_CONFIG_KEY } from '@ukef/config/gift-queue.config';
-import { GIFT } from '@ukef/constants';
+import { EXAMPLES, GIFT } from '@ukef/constants';
 import { PinoLogger } from 'nestjs-pino';
 
 import { GiftQueueService } from './gift.queue.service';
@@ -15,6 +15,11 @@ const mockStorageAccountName = 'mystorageaccount';
 const mockQueueName = 'gift-requests';
 const mockClientId = 'mock-client-id';
 const { QUEUE_DELAY } = GIFT;
+const { GIFT: GIFT_EXAMPLES } = EXAMPLES;
+
+type EnqueueMessage = Parameters<GiftQueueService['enqueue']>[0];
+type FacilityCreationMessage = Extract<EnqueueMessage, { messageType: 'FACILITY_CREATION' }>;
+type FacilityAmendmentMessage = Extract<EnqueueMessage, { messageType: 'FACILITY_AMENDMENT' }>;
 
 const mockQueueConfig: GiftQueueConfig = {
   storageAccountName: undefined,
@@ -23,20 +28,15 @@ const mockQueueConfig: GiftQueueConfig = {
   queueName: mockQueueName,
 };
 
-const mockCreationMessage = {
+const mockCreationMessage: FacilityCreationMessage = {
   messageType: 'FACILITY_CREATION' as const,
-  payload: {
-    overview: { facilityId: '0030000321' },
-  },
+  payload: GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD,
 };
 
-const mockAmendmentMessage = {
+const mockAmendmentMessage: FacilityAmendmentMessage = {
   messageType: 'FACILITY_AMENDMENT' as const,
-  facilityId: '0030000321',
-  payload: {
-    amendmentType: 'INCREASE_AMOUNT',
-    amendmentData: { amount: 100, date: '2026-01-01' },
-  },
+  facilityId: GIFT_EXAMPLES.FACILITY_ID,
+  payload: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD,
 };
 
 describe('GiftQueueService', () => {
@@ -150,7 +150,7 @@ describe('GiftQueueService', () => {
       const expectedMessage = Buffer.from(JSON.stringify(mockCreationMessage)).toString('base64');
 
       // Act
-      await service.enqueue(mockCreationMessage as any);
+      await service.enqueue(mockCreationMessage);
 
       // Assert
       expect(mockSendMessage).toHaveBeenCalledTimes(1);
@@ -169,7 +169,7 @@ describe('GiftQueueService', () => {
         const expectedMessage = Buffer.from(JSON.stringify(delayedCreationMessage)).toString('base64');
 
         // Act
-        await service.enqueue(delayedCreationMessage as any);
+        await service.enqueue(delayedCreationMessage);
 
         // Assert
         expect(mockSendMessage).toHaveBeenCalledTimes(1);
@@ -189,7 +189,7 @@ describe('GiftQueueService', () => {
         const expectedMessage = Buffer.from(JSON.stringify(nonDelayedCreationMessage)).toString('base64');
 
         // Act
-        await service.enqueue(nonDelayedCreationMessage as any);
+        await service.enqueue(nonDelayedCreationMessage);
 
         // Assert
         expect(mockSendMessage).toHaveBeenCalledTimes(1);
@@ -202,7 +202,7 @@ describe('GiftQueueService', () => {
         const expectedMessage = Buffer.from(JSON.stringify(mockAmendmentMessage)).toString('base64');
 
         // Act
-        await service.enqueue(mockAmendmentMessage as any);
+        await service.enqueue(mockAmendmentMessage);
 
         // Assert
         expect(mockSendMessage).toHaveBeenCalledTimes(1);
@@ -213,7 +213,7 @@ describe('GiftQueueService', () => {
     describe('when queueClient.sendMessage is successful', () => {
       it('should resolve without returning a value', async () => {
         // Act
-        const result = await service.enqueue(mockCreationMessage as any);
+        const result = await service.enqueue(mockCreationMessage);
 
         // Assert
         expect(result).toBeUndefined();
@@ -236,7 +236,7 @@ describe('GiftQueueService', () => {
 
       it('should throw the error', async () => {
         // Act
-        const promise = service.enqueue(mockCreationMessage as any);
+        const promise = service.enqueue(mockCreationMessage);
 
         // Assert
         await expect(promise).rejects.toThrow(mockError);

--- a/src/modules/gift/services/gift.queue.service.ts
+++ b/src/modules/gift/services/gift.queue.service.ts
@@ -3,7 +3,30 @@ import { QueueClient, QueueServiceClient } from '@azure/storage-queue';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GiftQueueConfig, KEY as GIFT_QUEUE_CONFIG_KEY } from '@ukef/config/gift-queue.config';
+import { GIFT } from '@ukef/constants';
 import { PinoLogger } from 'nestjs-pino';
+
+import { CreateGiftFacilityAmendmentRequestDto, GiftFacilityCreationRequestDto } from '../dto';
+
+const { QUEUE_DELAY } = GIFT;
+
+const MESSAGE_TYPES = {
+  FACILITY_CREATION: 'FACILITY_CREATION',
+  FACILITY_AMENDMENT: 'FACILITY_AMENDMENT',
+} as const;
+
+type GiftFacilityCreationQueueMessage = {
+  messageType: typeof MESSAGE_TYPES.FACILITY_CREATION;
+  payload: GiftFacilityCreationRequestDto;
+};
+
+type GiftFacilityAmendmentQueueMessage = {
+  messageType: typeof MESSAGE_TYPES.FACILITY_AMENDMENT;
+  facilityId: string;
+  payload: CreateGiftFacilityAmendmentRequestDto;
+};
+
+type GiftQueueMessage = GiftFacilityCreationQueueMessage | GiftFacilityAmendmentQueueMessage;
 
 /**
  * Service for interacting with the GIFT Azure Storage Queue.
@@ -18,25 +41,39 @@ export class GiftQueueService {
     private readonly configService: ConfigService,
   ) {
     const { storageAccountName, connectionString, clientId, queueName } = this.configService.get<GiftQueueConfig>(GIFT_QUEUE_CONFIG_KEY);
+
     if (!connectionString && !storageAccountName) {
       throw new Error('Either GIFT_QUEUE_STORAGE_CONNECTION_STRING or GIFT_QUEUE_STORAGE_ACCOUNT_NAME must be set');
     }
+
     // connectionString is for local dev only, should not be used in production
     const serviceClient = connectionString
       ? QueueServiceClient.fromConnectionString(connectionString)
       : new QueueServiceClient(`https://${storageAccountName}.queue.core.windows.net`, new DefaultAzureCredential({ managedIdentityClientId: clientId }));
+
     this.queueClient = serviceClient.getQueueClient(queueName);
   }
 
   /**
    * Encodes the given payload as a Base64 JSON string and sends it
    * to the GIFT requests queue.
-   * @param payload - The message payload to enqueue.
+   * @param message - The message payload to enqueue.
    */
-  async enqueue(payload: object): Promise<void> {
-    const message = Buffer.from(JSON.stringify(payload)).toString('base64');
+  async enqueue(messageInput: GiftQueueMessage): Promise<void> {
     this.logger.info('Enqueuing GIFT request message');
-    await this.queueClient.sendMessage(message);
+
+    const message = Buffer.from(JSON.stringify(messageInput)).toString('base64');
+
+    const { messageType, payload } = messageInput;
+
+    const options: { visibilityTimeout?: number } = {};
+
+    if (messageType === MESSAGE_TYPES.FACILITY_CREATION && payload.delayCreation) {
+      options['visibilityTimeout'] = QUEUE_DELAY;
+    }
+
+    await this.queueClient.sendMessage(message, options);
+
     this.logger.info('GIFT request message enqueued');
   }
 }

--- a/src/modules/gift/services/gift.queue.service.ts
+++ b/src/modules/gift/services/gift.queue.service.ts
@@ -60,7 +60,7 @@ export class GiftQueueService {
    * @param message - The message payload to enqueue.
    */
   async enqueue(messageInput: GiftQueueMessage): Promise<void> {
-    this.logger.info('Enqueuing GIFT request message');
+    this.logger.info('Attempting to enqueue GIFT request message %s', messageInput.messageType);
 
     const message = Buffer.from(JSON.stringify(messageInput)).toString('base64');
 
@@ -68,12 +68,16 @@ export class GiftQueueService {
 
     const options: { visibilityTimeout?: number } = {};
 
-    if (messageType === MESSAGE_TYPES.FACILITY_CREATION && payload.delayCreation) {
+    const isFacilityCreationWithDelay = messageType === MESSAGE_TYPES.FACILITY_CREATION && payload.delayCreation;
+
+    if (isFacilityCreationWithDelay) {
       options['visibilityTimeout'] = QUEUE_DELAY;
     }
 
     await this.queueClient.sendMessage(message, options);
 
-    this.logger.info('GIFT request message enqueued');
+    const delayCopy = isFacilityCreationWithDelay ? `with delay` : '';
+
+    this.logger.info('GIFT request message %s enqueued %s', messageInput.messageType, delayCopy);
   }
 }

--- a/test/gift/enqueue-facility-creation.api-test.ts
+++ b/test/gift/enqueue-facility-creation.api-test.ts
@@ -37,7 +37,7 @@ describe('POST /gift/facility', () => {
   });
 
   describe('when the payload is valid', () => {
-    it('should return 202', async () => {
+    it(`should return ${HttpStatus.ACCEPTED}`, async () => {
       const { status } = await api.post(apimFacilityUrl, GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD);
 
       expect(status).toBe(HttpStatus.ACCEPTED);
@@ -48,6 +48,18 @@ describe('POST /gift/facility', () => {
 
       expect(enqueueSpy).toHaveBeenCalledTimes(1);
       expect(enqueueSpy).toHaveBeenCalledWith({ messageType: 'FACILITY_CREATION', payload: GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD });
+    });
+
+    it('should call giftQueueService.enqueue with delayCreation when provided', async () => {
+      const payloadWithDelayedCreation = {
+        ...GIFT_EXAMPLES.FACILITY_CREATION_PAYLOAD,
+        delayCreation: true,
+      };
+
+      await api.post(apimFacilityUrl, payloadWithDelayedCreation);
+
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueSpy).toHaveBeenCalledWith({ messageType: 'FACILITY_CREATION', payload: payloadWithDelayedCreation });
     });
   });
 });

--- a/tfs-functions/README.md
+++ b/tfs-functions/README.md
@@ -52,7 +52,12 @@ The Functions host will be available on `http://localhost:7071`.
 
 ## Testing the queue
 
-After building the container, run the `seed-azurite.sh` script; this will create the queue.
+After building the container, run the `seed-azurite.sh` script; this will create the queue:
+
+```sh
+cd /scripts
+sh ./seed-azurite.sh
+```
 
 To test the function in isolation (without running tfs-api), encode a valid JSON
 payload matching the `GiftFacilityCreationRequestDto` or

--- a/tfs-functions/local.settings.json.sample
+++ b/tfs-functions/local.settings.json.sample
@@ -7,6 +7,7 @@
     "APIM_TFS_URL": "http://localhost:3001",
     "APIM_TFS_KEY": "x-api-key",
     "APIM_TFS_VALUE": "",
+    "GIFT_MAX_NUMBER_OF_RETRIES": "5",
     "HALO_BASE_URL": "",
     "HALO_TENANT_NAME": "",
     "HALO_AUTH_CLIENT_ID": "",


### PR DESCRIPTION
# Introduction :pencil2:

When a consumer / DTFS sends a facility to APIM - the consumer may have created a new party in Salesforce.

GIFT fetches parties from Salesforce via ODS.

However, ODS has a delay of at least 3 hours to obtain the latest data from Salesforce.

Therefore, facility creation will fail in GIFT, if a new party has been created and cannot be fetched from ODS. "Unrecognised URN".

This PR introduces an optional delay to the APIM TFS queue for GIFT facility creation.

## Resolution :heavy_check_mark:

- Update constants.
- Update `GiftFacilityCreationGenericRequestDto` to have an optional `delayCreation` field.
- Update `GiftQueueService` to conditionally delay.

## Miscellaneous :heavy_plus_sign:

- Minor logging, documentation, sample tweaks.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
