### PR TITLE
fix(DTFS2-8478): remove validation from queue endpoints

### DIFF
--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -260,7 +260,7 @@ describe('GiftFacilityController', () => {
   });
 
   describe('POST /', () => {
-    const mockBody = FACILITY_CREATION_PAYLOAD;
+    const mockBody = FACILITY_CREATION_PAYLOAD as unknown as Record<string, unknown>;
 
     it('should call giftQueueService.enqueue with the facility creation message and message type', async () => {
       // Act
@@ -283,7 +283,7 @@ describe('GiftFacilityController', () => {
 
   describe('POST :facilityId/amendment', () => {
     const mockParams = { facilityId: mockFacilityId };
-    const mockBody = FACILITY_AMENDMENT_REQUEST_PAYLOAD;
+    const mockBody = FACILITY_AMENDMENT_REQUEST_PAYLOAD as unknown as Record<string, unknown>;
 
     it('should call giftQueueService.enqueue with the facility amendment message and message type', async () => {
       // Act

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -260,7 +260,7 @@ describe('GiftFacilityController', () => {
   });
 
   describe('POST /', () => {
-    const mockBody = FACILITY_CREATION_PAYLOAD as unknown as Record<string, unknown>;
+    const mockBody = FACILITY_CREATION_PAYLOAD;
 
     it('should call giftQueueService.enqueue with the facility creation message and message type', async () => {
       // Act
@@ -283,7 +283,7 @@ describe('GiftFacilityController', () => {
 
   describe('POST :facilityId/amendment', () => {
     const mockParams = { facilityId: mockFacilityId };
-    const mockBody = FACILITY_AMENDMENT_REQUEST_PAYLOAD as unknown as Record<string, unknown>;
+    const mockBody = FACILITY_AMENDMENT_REQUEST_PAYLOAD;
 
     it('should call giftQueueService.enqueue with the facility amendment message and message type', async () => {
       // Act

--- a/src/modules/gift/controllers/gift.facility.controller.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.ts
@@ -94,8 +94,8 @@ export class GiftFacilityController {
   @ApiInternalServerErrorResponse({
     description: 'An internal server error has occurred',
   })
-  async postQueue(@Body() facilityData: Record<string, unknown>, @Res({ passthrough: true }) res: Response) {
-    await this.giftQueueService.enqueue({ messageType: 'FACILITY_CREATION', payload: facilityData as unknown as GiftFacilityCreationRequestDto });
+  async postQueue(@Body() facilityData: unknown, @Res({ passthrough: true }) res: Response) {
+    await this.giftQueueService.enqueue({ messageType: 'FACILITY_CREATION', payload: facilityData as GiftFacilityCreationRequestDto });
 
     res.status(HttpStatus.ACCEPTED);
   }
@@ -125,11 +125,7 @@ export class GiftFacilityController {
   @ApiInternalServerErrorResponse({
     description: 'An internal server error has occurred',
   })
-  async postAmendmentQueue(
-    @Param() { facilityId }: FacilityIdOperationParamsDto,
-    @Body() amendmentData: Record<string, unknown>,
-    @Res({ passthrough: true }) res: Response,
-  ) {
+  async postAmendmentQueue(@Param() { facilityId }: FacilityIdOperationParamsDto, @Body() amendmentData: unknown, @Res({ passthrough: true }) res: Response) {
     await this.giftQueueService.enqueue({
       messageType: 'FACILITY_AMENDMENT',
       facilityId,

--- a/src/modules/gift/controllers/gift.facility.controller.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.ts
@@ -94,8 +94,8 @@ export class GiftFacilityController {
   @ApiInternalServerErrorResponse({
     description: 'An internal server error has occurred',
   })
-  async postQueue(@Body(new ValidationPipe({ transform: true })) facilityData: GiftFacilityCreationRequestDto, @Res({ passthrough: true }) res: Response) {
-    await this.giftQueueService.enqueue({ messageType: 'FACILITY_CREATION', payload: facilityData });
+  async postQueue(@Body() facilityData: Record<string, unknown>, @Res({ passthrough: true }) res: Response) {
+    await this.giftQueueService.enqueue({ messageType: 'FACILITY_CREATION', payload: facilityData as unknown as GiftFacilityCreationRequestDto });
 
     res.status(HttpStatus.ACCEPTED);
   }
@@ -127,10 +127,14 @@ export class GiftFacilityController {
   })
   async postAmendmentQueue(
     @Param() { facilityId }: FacilityIdOperationParamsDto,
-    @Body(new ValidationPipe({ transform: true })) amendmentData: CreateGiftFacilityAmendmentRequestDto,
+    @Body() amendmentData: Record<string, unknown>,
     @Res({ passthrough: true }) res: Response,
   ) {
-    await this.giftQueueService.enqueue({ messageType: 'FACILITY_AMENDMENT', facilityId, payload: amendmentData });
+    await this.giftQueueService.enqueue({
+      messageType: 'FACILITY_AMENDMENT',
+      facilityId,
+      payload: amendmentData as unknown as CreateGiftFacilityAmendmentRequestDto,
+    });
 
     res.status(HttpStatus.ACCEPTED);
   }


### PR DESCRIPTION
# Introduction :pencil2:

Previously, when calling a queue endpoint, if APIM validation throws, the facility would not be added to the queue.

This PR fixes that by removing validation from the queue endpoints.

The validation now only occurs in the `without-queue` endpoints. If a validation error does occur, the facility is still added to the queue.

## Resolution :heavy_check_mark:

- Update GIFT facility controller.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
