### PR TITLE
feat(DTFS2-8491): create a gift facility - date snap back

### DIFF
--- a/src/modules/gift/dto/request/accrual-schedule.ts
+++ b/src/modules/gift/dto/request/accrual-schedule.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EXAMPLES, GIFT } from '@ukef/constants';
-import { IsDateString, IsDefined, IsNumber, IsOptional, IsString, Length, Min } from 'class-validator';
+import { IsBoolean, IsDateString, IsDefined, IsNumber, IsOptional, IsString, Length, Min } from 'class-validator';
 
 const {
   GIFT: { ACCRUAL_SCHEDULE: EXAMPLE },
@@ -81,6 +81,15 @@ export class GiftAccrualScheduleRequestDto {
     required: true,
   })
   baseRate: number;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    example: true,
+    description: 'Whether to enable date snap back (optional)',
+    required: false,
+  })
+  dateSnapBack?: boolean;
 
   @IsOptional()
   @IsDateString()

--- a/src/modules/gift/services/gift.accrual-schedule.service.test.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.test.ts
@@ -143,7 +143,7 @@ describe('GiftAccrualScheduleService', () => {
         };
 
         // Act
-        await service.createOne(mockPayload as any, mockFacilityId, mockWorkPackageId);
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
 
         // Assert
         expect(mockHttpServicePost).toHaveBeenCalledTimes(1);

--- a/src/modules/gift/services/gift.accrual-schedule.service.test.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.test.ts
@@ -37,6 +37,86 @@ describe('GiftAccrualScheduleService', () => {
   describe('createOne', () => {
     const mockAccrualSchedule = ACCRUAL_SCHEDULE;
 
+    describe('when optional dateSnapBack is provided', () => {
+      it('should call giftHttpService.post with dateSnapBack true', async () => {
+        // Arrange
+        const mockPayload = {
+          ...mockAccrualSchedule,
+          dateSnapBack: true,
+        };
+
+        // Act
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        const expected = {
+          path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_ACCRUAL_SCHEDULE_FIXED_RATE}`,
+          payload: {
+            ...mockPayload,
+            dateSnapBackOverride: INTEGRATION_DEFAULTS.DATE_SNAP_BACK_OVERRIDE,
+            baseRateTypeCode: null,
+            additionalRateTypeCode: null,
+            acbsInterestScheduleId: INTEGRATION_DEFAULTS.ACBS_INTEREST_SCHEDULE_ID,
+            accrualEffectiveDate: mockPayload.accrualEffectiveDate,
+            accrualMaturityDate: mockPayload.accrualMaturityDate,
+            firstCycleAccrualEndDate: mockPayload.firstCycleAccrualEndDate,
+          },
+        };
+
+        expect(mockHttpServicePost).toHaveBeenCalledWith(expected);
+      });
+
+      it('should call giftHttpService.post with dateSnapBack false', async () => {
+        // Arrange
+        const mockPayload = {
+          ...mockAccrualSchedule,
+          dateSnapBack: false,
+        };
+
+        // Act
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        const expected = {
+          path: `${PATH.FACILITY}/${mockFacilityId}${PATH.WORK_PACKAGE}/${mockWorkPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_ACCRUAL_SCHEDULE_FIXED_RATE}`,
+          payload: {
+            ...mockPayload,
+            dateSnapBackOverride: INTEGRATION_DEFAULTS.DATE_SNAP_BACK_OVERRIDE,
+            baseRateTypeCode: null,
+            additionalRateTypeCode: null,
+            acbsInterestScheduleId: INTEGRATION_DEFAULTS.ACBS_INTEREST_SCHEDULE_ID,
+            accrualEffectiveDate: mockPayload.accrualEffectiveDate,
+            accrualMaturityDate: mockPayload.accrualMaturityDate,
+            firstCycleAccrualEndDate: mockPayload.firstCycleAccrualEndDate,
+          },
+        };
+
+        expect(mockHttpServicePost).toHaveBeenCalledWith(expected);
+      });
+
+      it('should not include dateSnapBack in payload when it is not provided', async () => {
+        // Arrange
+        const mockPayload = {
+          ...mockAccrualSchedule,
+        };
+
+        // Act
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        const [firstCall] = mockHttpServicePost.mock.calls;
+        const [{ payload }] = firstCall;
+
+        expect(payload).not.toHaveProperty('dateSnapBack');
+      });
+    });
+
     describe('when optional date fields are provided', () => {
       it('should call giftHttpService.post with the provided date fields', async () => {
         // Arrange

--- a/src/modules/gift/services/gift.accrual-schedule.service.test.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.test.ts
@@ -116,7 +116,7 @@ describe('GiftAccrualScheduleService', () => {
         expect(payload).not.toHaveProperty('dateSnapBack');
       });
 
-      it('should keep dateSnapBack as undefined in payload when it is explicitly undefined', async () => {
+      it('should not include dateSnapBack in payload when it is explicitly undefined', async () => {
         // Arrange
         const mockPayload = {
           ...mockAccrualSchedule,
@@ -132,7 +132,26 @@ describe('GiftAccrualScheduleService', () => {
         const [firstCall] = mockHttpServicePost.mock.calls;
         const [{ payload }] = firstCall;
 
-        expect(payload).toHaveProperty('dateSnapBack', undefined);
+        expect(payload).not.toHaveProperty('dateSnapBack');
+      });
+
+      it('should not include dateSnapBack in payload when it is null', async () => {
+        // Arrange
+        const mockPayload = {
+          ...mockAccrualSchedule,
+          dateSnapBack: null,
+        };
+
+        // Act
+        await service.createOne(mockPayload as any, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        const [firstCall] = mockHttpServicePost.mock.calls;
+        const [{ payload }] = firstCall;
+
+        expect(payload).not.toHaveProperty('dateSnapBack');
       });
     });
 

--- a/src/modules/gift/services/gift.accrual-schedule.service.test.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.test.ts
@@ -115,6 +115,25 @@ describe('GiftAccrualScheduleService', () => {
 
         expect(payload).not.toHaveProperty('dateSnapBack');
       });
+
+      it('should keep dateSnapBack as undefined in payload when it is explicitly undefined', async () => {
+        // Arrange
+        const mockPayload = {
+          ...mockAccrualSchedule,
+          dateSnapBack: undefined,
+        };
+
+        // Act
+        await service.createOne(mockPayload, mockFacilityId, mockWorkPackageId);
+
+        // Assert
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+
+        const [firstCall] = mockHttpServicePost.mock.calls;
+        const [{ payload }] = firstCall;
+
+        expect(payload).toHaveProperty('dateSnapBack', undefined);
+      });
     });
 
     describe('when optional date fields are provided', () => {

--- a/src/modules/gift/services/gift.accrual-schedule.service.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.ts
@@ -33,8 +33,15 @@ export class GiftAccrualScheduleService {
     try {
       this.logger.info('Creating an accrual schedule with schedule type code %s for facility %s', accrualScheduleData.accrualScheduleTypeCode, facilityId);
 
+      /**
+       * Only include dateSnapBack in the payload if it is provided in the request body. Otherwise, GIFT will throw a 400 Bad Request error.
+       * This is because GIFT expects dateSnapBack to be a boolean value, and if it is not provided, it will be undefined.
+       * GIFT does not accept an undefined value for this boolean field.
+       */
+      const { dateSnapBack, ...accrualSchedulePayload } = accrualScheduleData;
+
       const payload = {
-        ...accrualScheduleData,
+        ...accrualSchedulePayload,
         dateSnapBackOverride: INTEGRATION_DEFAULTS.DATE_SNAP_BACK_OVERRIDE,
         baseRateTypeCode: null,
         additionalRateTypeCode: null,
@@ -42,16 +49,8 @@ export class GiftAccrualScheduleService {
         accrualEffectiveDate: accrualScheduleData.accrualEffectiveDate || INTEGRATION_DEFAULTS.ACCRUAL_EFFECTIVE_DATE,
         accrualMaturityDate: accrualScheduleData.accrualMaturityDate || INTEGRATION_DEFAULTS.ACCRUAL_MATURITY_DATE,
         firstCycleAccrualEndDate: accrualScheduleData.firstCycleAccrualEndDate || INTEGRATION_DEFAULTS.FIRST_CYCLE_ACCRUAL_END_DATE,
+        ...(typeof dateSnapBack === 'boolean' ? { dateSnapBack } : {}),
       };
-
-      /**
-       * Only include dateSnapBack in the payload if it is provided in the request body. Otherwise, GIFT will throw a 400 Bad Request error.
-       * This is because GIFT expects dateSnapBack to be a boolean value, and if it is not provided, it will be undefined.
-       * GIFT does not accept an undefined value for this boolean field.
-       */
-      if (accrualScheduleData.dateSnapBack !== undefined) {
-        payload.dateSnapBack = accrualScheduleData.dateSnapBack;
-      }
 
       const path = `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_ACCRUAL_SCHEDULE_FIXED_RATE}`;
 

--- a/src/modules/gift/services/gift.accrual-schedule.service.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.ts
@@ -44,7 +44,12 @@ export class GiftAccrualScheduleService {
         firstCycleAccrualEndDate: accrualScheduleData.firstCycleAccrualEndDate || INTEGRATION_DEFAULTS.FIRST_CYCLE_ACCRUAL_END_DATE,
       };
 
-      if (accrualScheduleData.dateSnapBack) {
+      /**
+       * Only include dateSnapBack in the payload if it is provided in the request body. Otherwise, GIFT will throw a 400 Bad Request error.
+       * This is because GIFT expects dateSnapBack to be a boolean value, and if it is not provided, it will be undefined.
+       * GIFT does not accept an undefined value for this boolean field.
+       */
+      if (accrualScheduleData.dateSnapBack !== undefined) {
         payload.dateSnapBack = accrualScheduleData.dateSnapBack;
       }
 

--- a/src/modules/gift/services/gift.accrual-schedule.service.ts
+++ b/src/modules/gift/services/gift.accrual-schedule.service.ts
@@ -44,6 +44,10 @@ export class GiftAccrualScheduleService {
         firstCycleAccrualEndDate: accrualScheduleData.firstCycleAccrualEndDate || INTEGRATION_DEFAULTS.FIRST_CYCLE_ACCRUAL_END_DATE,
       };
 
+      if (accrualScheduleData.dateSnapBack) {
+        payload.dateSnapBack = accrualScheduleData.dateSnapBack;
+      }
+
       const path = `${PATH.FACILITY}/${facilityId}${PATH.WORK_PACKAGE}/${workPackageId}${PATH.CONFIGURATION_EVENT}/${EVENT_TYPES.ADD_ACCRUAL_SCHEDULE_FIXED_RATE}`;
 
       const response = await this.giftHttpService.post<GiftAccrualScheduleRequestDto>({

--- a/test/gift/assertions/array-of-objects-optional-boolean-validation.ts
+++ b/test/gift/assertions/array-of-objects-optional-boolean-validation.ts
@@ -101,38 +101,4 @@ export const arrayOfObjectsOptionalBooleanValidation = ({ fieldName, initialPayl
       expect(body.message).toStrictEqual(expected);
     });
   });
-
-  describe(`when ${fieldName} is true`, () => {
-    let mockPayload;
-
-    beforeAll(() => {
-      // Arrange
-      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: true });
-    });
-
-    it(`should not return a ${HttpStatus.BAD_REQUEST} response`, async () => {
-      // Act
-      const response = await api.post(url, mockPayload);
-
-      // Assert
-      expect(response.status).not.toBe(HttpStatus.BAD_REQUEST);
-    });
-  });
-
-  describe(`when ${fieldName} is false`, () => {
-    let mockPayload;
-
-    beforeAll(() => {
-      // Arrange
-      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: false });
-    });
-
-    it(`should not return a ${HttpStatus.BAD_REQUEST} response`, async () => {
-      // Act
-      const response = await api.post(url, mockPayload);
-
-      // Assert
-      expect(response.status).not.toBe(HttpStatus.BAD_REQUEST);
-    });
-  });
 };

--- a/test/gift/assertions/array-of-objects-optional-boolean-validation.ts
+++ b/test/gift/assertions/array-of-objects-optional-boolean-validation.ts
@@ -1,0 +1,138 @@
+import { HttpStatus } from '@nestjs/common';
+import { Api } from '@ukef-test/support/api';
+
+import { generatePayloadArrayOfObjects } from './generate-payload';
+import { assert400Response } from './response-assertion';
+
+/**
+ * Validation tests for an array of objects - optional boolean field.
+ * When provided, it must be a boolean. When omitted, it is valid.
+ */
+export const arrayOfObjectsOptionalBooleanValidation = ({ fieldName, initialPayload, parentFieldName, url }) => {
+  let api: Api;
+
+  const payloadParams = { initialPayload, fieldName, parentFieldName };
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  describe(`when ${fieldName} is an empty array`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      // Arrange
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: [] });
+    });
+
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+      // Act
+      const response = await api.post(url, mockPayload);
+
+      // Assert
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      // Act
+      const { body } = await api.post(url, mockPayload);
+
+      // Assert
+      const expected = [`${parentFieldName}.0.${fieldName} must be a boolean value`, `${parentFieldName}.1.${fieldName} must be a boolean value`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a string`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      // Arrange
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 'true' });
+    });
+
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+      // Act
+      const response = await api.post(url, mockPayload);
+
+      // Assert
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      // Act
+      const { body } = await api.post(url, mockPayload);
+
+      // Assert
+      const expected = [`${parentFieldName}.0.${fieldName} must be a boolean value`, `${parentFieldName}.1.${fieldName} must be a boolean value`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is a number`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      // Arrange
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: 1 });
+    });
+
+    it(`should return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+      // Act
+      const response = await api.post(url, mockPayload);
+
+      // Assert
+      assert400Response(response);
+    });
+
+    it('should return the correct error messages', async () => {
+      // Act
+      const { body } = await api.post(url, mockPayload);
+
+      // Assert
+      const expected = [`${parentFieldName}.0.${fieldName} must be a boolean value`, `${parentFieldName}.1.${fieldName} must be a boolean value`];
+
+      expect(body.message).toStrictEqual(expected);
+    });
+  });
+
+  describe(`when ${fieldName} is true`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      // Arrange
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: true });
+    });
+
+    it(`should not return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+      // Act
+      const response = await api.post(url, mockPayload);
+
+      // Assert
+      expect(response.status).not.toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe(`when ${fieldName} is false`, () => {
+    let mockPayload;
+
+    beforeAll(() => {
+      // Arrange
+      mockPayload = generatePayloadArrayOfObjects({ ...payloadParams, value: false });
+    });
+
+    it(`should not return a ${HttpStatus.BAD_REQUEST} response`, async () => {
+      // Act
+      const response = await api.post(url, mockPayload);
+
+      // Assert
+      expect(response.status).not.toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+};

--- a/test/gift/assertions/index.ts
+++ b/test/gift/assertions/index.ts
@@ -6,6 +6,7 @@ export * from './array-of-objects-currency-string-validation';
 export * from './array-of-objects-date-string-validation';
 export * from './array-of-objects-fee-type-code-string-validation';
 export * from './array-of-objects-number-validation';
+export * from './array-of-objects-optional-boolean-validation';
 export * from './array-of-objects-optional-date-string-validation';
 export * from './array-of-objects-optional-number-validation';
 export * from './array-of-objects-optional-string-validation';

--- a/test/gift/create-facility-validation-accrual-schedules.api-test.ts
+++ b/test/gift/create-facility-validation-accrual-schedules.api-test.ts
@@ -4,7 +4,12 @@ import { Api } from '@ukef-test/support/api';
 import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
 import nock from 'nock';
 
-import { arrayOfObjectsNumberValidation, arrayOfObjectsOptionalDateStringValidation, arrayOfObjectsStringValidation } from './assertions';
+import {
+  arrayOfObjectsNumberValidation,
+  arrayOfObjectsOptionalBooleanValidation,
+  arrayOfObjectsOptionalDateStringValidation,
+  arrayOfObjectsStringValidation,
+} from './assertions';
 import {
   apimFacilityWithoutQueueUrl,
   apimMdmObligationSubtypesUrl,
@@ -155,6 +160,13 @@ describe('POST /gift/facility - validation - accrual schedules', () => {
     arrayOfObjectsNumberValidation({
       ...baseParams,
       fieldName: 'baseRate',
+    });
+  });
+
+  describe('dateSnapBack', () => {
+    arrayOfObjectsOptionalBooleanValidation({
+      ...baseParams,
+      fieldName: 'dateSnapBack',
     });
   });
 

--- a/test/gift/create-facility.api-test.ts
+++ b/test/gift/create-facility.api-test.ts
@@ -213,6 +213,48 @@ describe('POST /gift/facility', () => {
     });
   });
 
+  describe('when accrual schedule dateSnapBack is true in the payload', () => {
+    it('should post dateSnapBack true to the GIFT accrual schedule endpoint', async () => {
+      // Arrange
+      setupMocks();
+
+      const mockPayload = {
+        ...initPayload,
+        accrualSchedules: initPayload.accrualSchedules.map((accrualSchedule) => ({
+          ...accrualSchedule,
+          dateSnapBack: true,
+        })),
+      };
+
+      // Act
+      const { status } = await api.post(apimFacilityWithoutQueueUrl, mockPayload);
+
+      // Assert
+      expect(status).toBe(HttpStatus.CREATED);
+    });
+  });
+
+  describe('when accrual schedule dateSnapBack is false in the payload', () => {
+    it('should post dateSnapBack false to the GIFT accrual schedule endpoint', async () => {
+      // Arrange
+      setupMocks();
+
+      const mockPayload = {
+        ...initPayload,
+        accrualSchedules: initPayload.accrualSchedules.map((accrualSchedule) => ({
+          ...accrualSchedule,
+          dateSnapBack: false,
+        })),
+      };
+
+      // Act
+      const { status } = await api.post(apimFacilityWithoutQueueUrl, mockPayload);
+
+      // Assert
+      expect(status).toBe(HttpStatus.CREATED);
+    });
+  });
+
   describe('when business calendar startDate, exitDate are NOT explicitly provided to GIFT', () => {
     it('should post null startDate/exitDate to the GIFT business calendar endpoint', async () => {
       // Arrange

--- a/test/gift/create-facility.api-test.ts
+++ b/test/gift/create-facility.api-test.ts
@@ -39,7 +39,10 @@ const { PRODUCT_TYPE_CODES, PRODUCT_TYPE_NAMES } = GIFT;
 
 const { FACILITY_CREATION_PAYLOAD: initPayload } = GIFT_EXAMPLES;
 
-const setupMocks = (options?: { expectedBusinessCalendarPayload?: { centreCode: string; startDate: string | null; exitDate: string | null } }) => {
+const setupMocks = (options?: {
+  expectedBusinessCalendarPayload?: { centreCode: string; startDate: string | null; exitDate: string | null };
+  expectedAccrualScheduleDateSnapBack?: boolean;
+}) => {
   nock(GIFT_API_URL).persist().get(productTypeUrl(PRODUCT_TYPE_CODES.BIP)).reply(HttpStatus.OK, mockResponses.productType);
   nock(GIFT_API_URL).persist().get(productTypeUrl(PRODUCT_TYPE_CODES.EXIP)).reply(HttpStatus.OK, mockResponses.productType);
   nock(GIFT_API_URL).persist().get(productTypeUrl(PRODUCT_TYPE_CODES.BSS)).reply(HttpStatus.OK, mockResponses.productType);
@@ -59,7 +62,14 @@ const setupMocks = (options?: { expectedBusinessCalendarPayload?: { centreCode: 
 
   nock(GIFT_API_URL).persist().post(facilityCreationUrl).reply(HttpStatus.CREATED, mockResponses.facility);
 
-  nock(GIFT_API_URL).persist().post(accrualScheduleUrl).reply(HttpStatus.CREATED, mockResponses.accrualSchedule);
+  if (typeof options?.expectedAccrualScheduleDateSnapBack === 'boolean') {
+    nock(GIFT_API_URL)
+      .persist()
+      .post(accrualScheduleUrl, (body: any) => body?.dateSnapBack === options.expectedAccrualScheduleDateSnapBack)
+      .reply(HttpStatus.CREATED, mockResponses.accrualSchedule);
+  } else {
+    nock(GIFT_API_URL).persist().post(accrualScheduleUrl).reply(HttpStatus.CREATED, mockResponses.accrualSchedule);
+  }
 
   if (options?.expectedBusinessCalendarPayload) {
     nock(GIFT_API_URL).persist().post(businessCalendarUrl, options.expectedBusinessCalendarPayload).reply(HttpStatus.CREATED, mockResponses.businessCalendar);
@@ -216,7 +226,7 @@ describe('POST /gift/facility', () => {
   describe('when accrual schedule dateSnapBack is true in the payload', () => {
     it('should post dateSnapBack true to the GIFT accrual schedule endpoint', async () => {
       // Arrange
-      setupMocks();
+      setupMocks({ expectedAccrualScheduleDateSnapBack: true });
 
       const mockPayload = {
         ...initPayload,
@@ -237,7 +247,7 @@ describe('POST /gift/facility', () => {
   describe('when accrual schedule dateSnapBack is false in the payload', () => {
     it('should post dateSnapBack false to the GIFT accrual schedule endpoint', async () => {
       // Arrange
-      setupMocks();
+      setupMocks({ expectedAccrualScheduleDateSnapBack: false });
 
       const mockPayload = {
         ...initPayload,


### PR DESCRIPTION
# Introduction :pencil2:

This PR updates the accrual schedule to allow an optional `dateSnapBack` field.

## Resolution :heavy_check_mark:

- Update DTO.
- Update `GiftAccrualScheduleService` to conditionally include `dateSnapBack`.
- Add new DRY test assertion, `arrayOfObjectsOptionalBooleanValidation`.
- Add/update tests.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
