### PR TITLE
chore(DTFS2-8488): throttle queue trigger concurrency

### DIFF
--- a/tfs-functions/README.md
+++ b/tfs-functions/README.md
@@ -131,6 +131,9 @@ This tests the full flow: `POST /gift/facility/queue` → Azurite queue → func
 - After `maxDequeueCount` failed attempts (set in `host.json`), the Azure
    Functions host moves the message to `gift-requests-poison` and the poison
    queue function logs it.
+- Queue trigger concurrency is intentionally throttled in `host.json` using
+   `batchSize: 1` and `newBatchThreshold: 0` to reduce parallel calls to GIFT
+   per function host instance.
 - **Important:** `host.json` does not support environment variable substitution,
   so `maxDequeueCount` in `host.json` and `GIFT_MAX_NUMBER_OF_RETRIES` in the
   environment must be kept in sync manually; they should always be the same value.

--- a/tfs-functions/host.json
+++ b/tfs-functions/host.json
@@ -13,7 +13,9 @@
   },
   "extensions": {
     "queues": {
-      "maxDequeueCount": 5
+      "maxDequeueCount": 5,
+      "batchSize": 1,
+      "newBatchThreshold": 0
     }
   },
   "extensionBundle": {


### PR DESCRIPTION
# Introduction :pencil2:

Sometimes, GIFT rejects calls with a 429.

## Resolution :heavy_check_mark:

- Update tfs-functions host JSON to throttle queue trigger concurrency.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
