### PR TITLE
chore(DTFS2-8534): amend gift facility - conditionally approve package

### DIFF
--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -100,8 +100,8 @@ describe('GiftFacilityController', () => {
     riskDetailsService = new GiftRiskDetailsService(giftHttpService, logger);
     statusService = new GiftStatusService(giftHttpService, logger);
     creationErrorService = new GiftFacilityCreationErrorService(giftWorkPackageService, logger);
-    amountAmendmentService = new GiftAmountAmendmentService(giftHttpService, logger);
-    replaceExpiryDateAmendmentService = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+    amountAmendmentService = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+    replaceExpiryDateAmendmentService = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
     giftFacilityService = new GiftFacilityService(
       giftHttpService,

--- a/src/modules/gift/controllers/gift.facility.controller.test.ts
+++ b/src/modules/gift/controllers/gift.facility.controller.test.ts
@@ -100,7 +100,7 @@ describe('GiftFacilityController', () => {
     riskDetailsService = new GiftRiskDetailsService(giftHttpService, logger);
     statusService = new GiftStatusService(giftHttpService, logger);
     creationErrorService = new GiftFacilityCreationErrorService(giftWorkPackageService, logger);
-    amountAmendmentService = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+    amountAmendmentService = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
     replaceExpiryDateAmendmentService = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
     giftFacilityService = new GiftFacilityService(

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -3,6 +3,7 @@ import { AMEND_FACILITY_PREFIX_TYPES, EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse201, mockResponse204, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
+import { GiftWorkPackageService } from '../gift.work-package.service';
 import { GiftAmountAmendmentService } from '.';
 
 const {
@@ -22,20 +23,24 @@ describe('GiftAmountAmendmentService', () => {
   let service: GiftAmountAmendmentService;
 
   let giftHttpService;
+  let giftWorkPackageService;
   let mockHttpServicePost: jest.Mock;
-  let mockHttpServiceDelete: jest.Mock;
+  let mockWorkPackageServiceDelete: jest.Mock;
 
   beforeEach(() => {
     // Arrange
     mockHttpServicePost = jest.fn().mockResolvedValue(mockResponse201({ id: 'mock-amendment-response' }));
-    mockHttpServiceDelete = jest.fn().mockResolvedValue(mockResponse204());
+    mockWorkPackageServiceDelete = jest.fn().mockResolvedValue(mockResponse204());
 
     giftHttpService = {
       post: mockHttpServicePost,
-      delete: mockHttpServiceDelete,
     };
 
-    service = new GiftAmountAmendmentService(giftHttpService, logger);
+    giftWorkPackageService = {
+      delete: mockWorkPackageServiceDelete,
+    } as unknown as GiftWorkPackageService;
+
+    service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
   });
 
   afterAll(() => {
@@ -73,10 +78,9 @@ describe('GiftAmountAmendmentService', () => {
         const mockPostResponse = mockResponse201({ id: 'mock-amendment-response' });
 
         mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockPostResponse);
-
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
         // Act
         const response = await service.facility({
@@ -101,16 +105,16 @@ describe('GiftAmountAmendmentService', () => {
       beforeEach(() => {
         // Arrange
         mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockPostResponse);
-        mockHttpServiceDelete = jest.fn().mockResolvedValueOnce(mockDeleteResponse);
+        mockWorkPackageServiceDelete = jest.fn().mockResolvedValueOnce(mockDeleteResponse);
 
         giftHttpService.post = mockHttpServicePost;
-        giftHttpService.delete = mockHttpServiceDelete;
+        giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
       });
 
       describe('delete behaviour', () => {
-        it('should call giftHttpService.delete', async () => {
+        it('should call giftWorkPackageService.delete', async () => {
           // Act
           await service.facility({
             amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
@@ -120,10 +124,8 @@ describe('GiftAmountAmendmentService', () => {
           });
 
           // Assert
-          expect(mockHttpServiceDelete).toHaveBeenCalledTimes(1);
-          expect(mockHttpServiceDelete).toHaveBeenCalledWith({
-            path: `${PATH.WORK_PACKAGE}/${mockWorkPackageId}`,
-          });
+          expect(mockWorkPackageServiceDelete).toHaveBeenCalledTimes(1);
+          expect(mockWorkPackageServiceDelete).toHaveBeenCalledWith(mockWorkPackageId, mockFacilityId);
         });
       });
 
@@ -149,10 +151,9 @@ describe('GiftAmountAmendmentService', () => {
         const mockError = mockResponse500();
 
         mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
-
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
         // Act
         const promise = service.facility({
@@ -188,7 +189,7 @@ describe('GiftAmountAmendmentService', () => {
 
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftAmountAmendmentService(giftHttpService, logger);
+      service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
       // Act
       await service.obligations({
@@ -241,10 +242,9 @@ describe('GiftAmountAmendmentService', () => {
       const responseTwo = mockResponse201({ two: true });
 
       mockHttpServicePost = jest.fn().mockResolvedValueOnce(responseOne).mockResolvedValueOnce(responseTwo);
-
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftAmountAmendmentService(giftHttpService, logger);
+      service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
       // Act
       const response = await service.obligations({
@@ -269,7 +269,7 @@ describe('GiftAmountAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockResolvedValueOnce(response);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
         // Act
         await service.obligations({
@@ -322,10 +322,9 @@ describe('GiftAmountAmendmentService', () => {
         const mockError = mockResponse500();
 
         mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
-
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
         // Act
         const promise = service.obligations({
@@ -352,10 +351,12 @@ describe('GiftAmountAmendmentService', () => {
       it('should stop processing obligations and throw an error', async () => {
         // Arrange
         mockHttpServicePost = jest.fn().mockResolvedValueOnce({ status: HttpStatus.BAD_REQUEST, data: { badRequest: true } });
+        mockWorkPackageServiceDelete = jest.fn().mockResolvedValueOnce(mockResponse204());
 
         giftHttpService.post = mockHttpServicePost;
+        giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger);
+        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
 
         // Act
         const promise = service.obligations({
@@ -373,6 +374,8 @@ describe('GiftAmountAmendmentService', () => {
           `Error amending facility obligation amounts ${AMEND_FACILITY_INCREASE_AMOUNT} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
         );
         expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+        expect(mockWorkPackageServiceDelete).toHaveBeenCalledTimes(1);
+        expect(mockWorkPackageServiceDelete).toHaveBeenCalledWith(mockWorkPackageId, mockFacilityId);
       });
     });
   });

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -347,5 +347,33 @@ describe('GiftAmountAmendmentService', () => {
         await expect(promise).rejects.toThrow(expected);
       });
     });
+
+    describe(`when giftHttpService.post does NOT return a ${HttpStatus.CREATED} status`, () => {
+      it('should stop processing obligations and throw an error', async () => {
+        // Arrange
+        mockHttpServicePost = jest.fn().mockResolvedValueOnce({ status: HttpStatus.BAD_REQUEST, data: { badRequest: true } });
+
+        giftHttpService.post = mockHttpServicePost;
+
+        service = new GiftAmountAmendmentService(giftHttpService, logger);
+
+        // Act
+        const promise = service.obligations({
+          amendmentType: AMEND_FACILITY_INCREASE_AMOUNT,
+          date: mockDate,
+          facilityId: mockFacilityId,
+          facilityCategoryCode: mockFacilityCategoryCode,
+          newFacilityAmount: mockNewFacilityAmount,
+          obligations: [{ id: '1' }, { id: '2' }],
+          workPackageId: mockWorkPackageId,
+        });
+
+        // Assert
+        await expect(promise).rejects.toThrow(
+          `Error amending facility obligation amounts ${AMEND_FACILITY_INCREASE_AMOUNT} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
+        );
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.test.ts
@@ -40,7 +40,7 @@ describe('GiftAmountAmendmentService', () => {
       delete: mockWorkPackageServiceDelete,
     } as unknown as GiftWorkPackageService;
 
-    service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+    service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
   });
 
   afterAll(() => {
@@ -80,7 +80,7 @@ describe('GiftAmountAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockPostResponse);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const response = await service.facility({
@@ -110,7 +110,7 @@ describe('GiftAmountAmendmentService', () => {
         giftHttpService.post = mockHttpServicePost;
         giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
       });
 
       describe('delete behaviour', () => {
@@ -153,7 +153,7 @@ describe('GiftAmountAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const promise = service.facility({
@@ -189,7 +189,7 @@ describe('GiftAmountAmendmentService', () => {
 
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+      service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
       // Act
       await service.obligations({
@@ -244,7 +244,7 @@ describe('GiftAmountAmendmentService', () => {
       mockHttpServicePost = jest.fn().mockResolvedValueOnce(responseOne).mockResolvedValueOnce(responseTwo);
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+      service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
       // Act
       const response = await service.obligations({
@@ -269,7 +269,7 @@ describe('GiftAmountAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockResolvedValueOnce(response);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         await service.obligations({
@@ -324,7 +324,7 @@ describe('GiftAmountAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const promise = service.obligations({
@@ -356,7 +356,7 @@ describe('GiftAmountAmendmentService', () => {
         giftHttpService.post = mockHttpServicePost;
         giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
-        service = new GiftAmountAmendmentService(giftHttpService, logger, giftWorkPackageService);
+        service = new GiftAmountAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const promise = service.obligations({

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -121,6 +121,15 @@ export class GiftAmountAmendmentService {
           payload,
         });
 
+        if (response.status !== HttpStatus.CREATED) {
+          throw new Error(
+            `Unexpected status ${response.status} amending facility obligation amounts ${amendmentType} for facility ${facilityId} work package ${workPackageId}`,
+            {
+              cause: response.data,
+            },
+          );
+        }
+
         responses.push(response);
       }
 

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -33,12 +33,12 @@ type AmendObligationsParams = GiftAmendmentBaseParams & {
 export class GiftAmountAmendmentService {
   constructor(
     private readonly giftHttpService: GiftHttpService,
-    private readonly logger: PinoLogger,
     private readonly giftWorkPackageService: GiftWorkPackageService,
+    private readonly logger: PinoLogger,
   ) {
     this.giftHttpService = giftHttpService;
-    this.logger = logger;
     this.giftWorkPackageService = giftWorkPackageService;
+    this.logger = logger;
   }
 
   /**

--- a/src/modules/gift/services/gift.amount-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.amount-amendment.service/index.ts
@@ -7,6 +7,7 @@ import { PinoLogger } from 'nestjs-pino';
 import { DecreaseAmountDto, GiftWorkPackageResponseDto, IncreaseAmountDto } from '../../dto';
 import { calculatePercentageAmount } from '../../helpers';
 import { GiftHttpService } from '../gift.http.service';
+import { GiftWorkPackageService } from '../gift.work-package.service';
 
 const {
   AMEND_OBLIGATION_AMOUNT: { PERCENTAGE_OF_FACILITY_AMOUNT },
@@ -33,9 +34,11 @@ export class GiftAmountAmendmentService {
   constructor(
     private readonly giftHttpService: GiftHttpService,
     private readonly logger: PinoLogger,
+    private readonly giftWorkPackageService: GiftWorkPackageService,
   ) {
     this.giftHttpService = giftHttpService;
     this.logger = logger;
+    this.giftWorkPackageService = giftWorkPackageService;
   }
 
   /**
@@ -65,9 +68,7 @@ export class GiftAmountAmendmentService {
       if (facilityAmendmentResponse.status !== HttpStatus.CREATED) {
         this.logger.error('Error creating amendment %s for work package %s facility %s. Deleting work package', amendmentType, workPackageId, facilityId);
 
-        await this.giftHttpService.delete<GiftWorkPackageResponseDto>({
-          path: `${PATH.WORK_PACKAGE}/${workPackageId}`,
-        });
+        await this.giftWorkPackageService.delete(workPackageId, facilityId);
 
         return facilityAmendmentResponse;
       }
@@ -122,6 +123,10 @@ export class GiftAmountAmendmentService {
         });
 
         if (response.status !== HttpStatus.CREATED) {
+          this.logger.error('Error creating amendment %s for work package %s facility %s. Deleting work package', amendmentType, workPackageId, facilityId);
+
+          await this.giftWorkPackageService.delete(workPackageId, facilityId);
+
           throw new Error(
             `Unexpected status ${response.status} amending facility obligation amounts ${amendmentType} for facility ${facilityId} work package ${workPackageId}`,
             {

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service-error-handling.test.ts
@@ -164,6 +164,28 @@ describe('GiftFacilityAmendmentService - error handling', () => {
   });
 
   describe('giftAmountAmendmentService', () => {
+    describe(`when giftAmountAmendmentService.facility does NOT return a ${HttpStatus.CREATED} status`, () => {
+      it('should return the amendment response and not approve the work package', async () => {
+        // Arrange
+        const mockErrorResponse = {
+          status: HttpStatus.BAD_REQUEST,
+          data: { badRequest: true },
+        };
+
+        mockAmountAmendmentFacility = jest.fn().mockResolvedValueOnce(mockErrorResponse);
+        amountAmendmentService.facility = mockAmountAmendmentFacility;
+
+        buildService();
+
+        // Act
+        const response = await service.create(mockFacilityId, mockPayload);
+
+        // Assert
+        expect(response).toEqual(mockErrorResponse);
+        expect(mockStatusServiceApproved).not.toHaveBeenCalled();
+      });
+    });
+
     describe('when giftAmountAmendmentService.facility throws an error', () => {
       it('should throw an error', async () => {
         // Arrange
@@ -206,6 +228,28 @@ describe('GiftFacilityAmendmentService - error handling', () => {
   });
 
   describe('giftReplaceExpiryDateAmendmentService', () => {
+    describe(`when giftReplaceExpiryDateAmendmentService.facility does NOT return a ${HttpStatus.CREATED} status`, () => {
+      it('should return the amendment response and not approve the work package', async () => {
+        // Arrange
+        const mockErrorResponse = {
+          status: HttpStatus.BAD_REQUEST,
+          data: { badRequest: true },
+        };
+
+        mockReplaceExpiryDateAmendmentFacility = jest.fn().mockResolvedValueOnce(mockErrorResponse);
+        replaceExpiryDateAmendmentService.facility = mockReplaceExpiryDateAmendmentFacility;
+
+        buildService();
+
+        // Act
+        const response = await service.create(mockFacilityId, replaceExpiryDatePayload);
+
+        // Assert
+        expect(response).toEqual(mockErrorResponse);
+        expect(mockStatusServiceApproved).not.toHaveBeenCalled();
+      });
+    });
+
     describe('when giftReplaceExpiryDateAmendmentService.facility throws an error', () => {
       it('should throw an error', async () => {
         // Arrange

--- a/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/gift.facility-amendment.service.test.ts
@@ -364,8 +364,8 @@ describe('GiftFacilityAmendmentService', () => {
     });
   });
 
-  describe('giftStatusService.approved', () => {
-    it('should call giftStatusService.approved when no amendment response data is created before approval', async () => {
+  describe('when no amendment response data is created before approval', () => {
+    it('should throw and not call statusService.approved', async () => {
       // Arrange
       const unsupportedAmendmentPayload = {
         ...mockPayload,
@@ -373,19 +373,11 @@ describe('GiftFacilityAmendmentService', () => {
       } as unknown as Parameters<GiftFacilityAmendmentService['create']>[1];
 
       // Act
-      const response = await service.create(mockFacilityId, unsupportedAmendmentPayload);
+      const response = service.create(mockFacilityId, unsupportedAmendmentPayload);
 
       // Assert
-      expect(mockStatusServiceApproved).toHaveBeenCalledTimes(1);
-      expect(mockStatusServiceApproved).toHaveBeenCalledWith(mockFacilityId, mockWorkPackageId);
-
-      expect(response).toEqual({
-        status: HttpStatus.CREATED,
-        data: {
-          ...WORK_PACKAGE_APPROVE_RESPONSE_DATA,
-          isApproved: true,
-        },
-      });
+      await expect(response).rejects.toThrow(`Error creating amendment UnsupportedAmendmentType for facility ${mockFacilityId}`);
+      expect(mockStatusServiceApproved).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -42,6 +42,11 @@ export class GiftFacilityAmendmentService {
     this.giftStatusService = giftStatusService;
   }
 
+  /**
+   * Check if a GIFT amendment was successful based on the response status.
+   * @param {AxiosResponse<GiftWorkPackageResponseDto>} response
+   * @returns {Boolean} true if the amendment was successful, false otherwise.
+   */
   private wasAmendmentSuccessful(response: AxiosResponse<GiftWorkPackageResponseDto>): boolean {
     return response.status === HttpStatus.CREATED;
   }

--- a/src/modules/gift/services/gift.facility-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.facility-amendment.service/index.ts
@@ -42,6 +42,10 @@ export class GiftFacilityAmendmentService {
     this.giftStatusService = giftStatusService;
   }
 
+  private wasAmendmentSuccessful(response: AxiosResponse<GiftWorkPackageResponseDto>): boolean {
+    return response.status === HttpStatus.CREATED;
+  }
+
   /**
    * Create a GIFT facility amendment
    * 1) Create a new GIFT work package.
@@ -116,6 +120,13 @@ export class GiftFacilityAmendmentService {
 
         const facilityAmendmentResponse = await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
 
+        if (!this.wasAmendmentSuccessful(facilityAmendmentResponse)) {
+          return {
+            status: facilityAmendmentResponse.status,
+            data: facilityAmendmentResponse.data,
+          };
+        }
+
         createdAmendmentData = facilityAmendmentResponse.data;
 
         await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
@@ -135,6 +146,13 @@ export class GiftFacilityAmendmentService {
         await this.giftAmountAmendmentService.obligations({ ...baseObligationParams, date, newFacilityAmount });
 
         const facilityAmendmentResponse = await this.giftAmountAmendmentService.facility({ ...amendment, facilityId, workPackageId });
+
+        if (!this.wasAmendmentSuccessful(facilityAmendmentResponse)) {
+          return {
+            status: facilityAmendmentResponse.status,
+            data: facilityAmendmentResponse.data,
+          };
+        }
 
         createdAmendmentData = facilityAmendmentResponse.data;
       }
@@ -176,20 +194,45 @@ export class GiftFacilityAmendmentService {
         if (!shouldUpdateObligationsMaturityDates) {
           const facilityResponse = await this.giftReplaceExpiryDateAmendmentService.facility({ ...baseParams, expiryDate });
 
+          if (!this.wasAmendmentSuccessful(facilityResponse)) {
+            return {
+              status: facilityResponse.status,
+              data: facilityResponse.data,
+            };
+          }
+
           createdAmendmentData = facilityResponse.data;
         } else if (shouldAmendObligationsFirst) {
           await this.giftReplaceExpiryDateAmendmentService.obligations({ ...baseParams, facilityExpiryDate: expiryDate, obligations });
 
           const facilityResponse = await this.giftReplaceExpiryDateAmendmentService.facility({ ...baseParams, expiryDate });
 
+          if (!this.wasAmendmentSuccessful(facilityResponse)) {
+            return {
+              status: facilityResponse.status,
+              data: facilityResponse.data,
+            };
+          }
+
           createdAmendmentData = facilityResponse.data;
         } else {
           const facilityResponse = await this.giftReplaceExpiryDateAmendmentService.facility({ ...baseParams, expiryDate });
+
+          if (!this.wasAmendmentSuccessful(facilityResponse)) {
+            return {
+              status: facilityResponse.status,
+              data: facilityResponse.data,
+            };
+          }
 
           await this.giftReplaceExpiryDateAmendmentService.obligations({ ...baseParams, facilityExpiryDate: expiryDate, obligations });
 
           createdAmendmentData = facilityResponse.data;
         }
+      }
+
+      if (!createdAmendmentData) {
+        throw new Error(`Unsupported amendment type: ${amendmentType}`);
       }
 
       // TODO: GIFT-20331 - validation handling

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/gift.replace-expiry-date-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/gift.replace-expiry-date-amendment.service-error-handling.test.ts
@@ -3,6 +3,7 @@ import { EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
+import { GiftWorkPackageService } from '../gift.work-package.service';
 import { GiftReplaceExpiryDateAmendmentService } from '.';
 
 const {
@@ -23,18 +24,23 @@ describe('GiftReplaceExpiryDateAmendmentService - error handling', () => {
   let service: GiftReplaceExpiryDateAmendmentService;
 
   let giftHttpService;
+  let giftWorkPackageService;
   let mockHttpServicePost: jest.Mock;
+  let mockWorkPackageServiceDelete: jest.Mock;
 
   const buildService = () => {
-    service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+    service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService as GiftWorkPackageService, logger);
   };
 
   beforeEach(() => {
     giftHttpService = {};
+    giftWorkPackageService = {};
 
     mockHttpServicePost = jest.fn();
+    mockWorkPackageServiceDelete = jest.fn();
 
     giftHttpService.post = mockHttpServicePost;
+    giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
     buildService();
   });

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/gift.replace-expiry-date-amendment.service-error-handling.test.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/gift.replace-expiry-date-amendment.service-error-handling.test.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
@@ -134,7 +135,7 @@ describe('GiftReplaceExpiryDateAmendmentService - error handling', () => {
 
         mockHttpServicePost = jest
           .fn()
-          .mockResolvedValueOnce({ data: { one: true } })
+          .mockResolvedValueOnce({ status: HttpStatus.CREATED, data: { one: true } })
           .mockRejectedValueOnce(mockError);
 
         giftHttpService.post = mockHttpServicePost;

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.test.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { AMEND_FACILITY_PREFIX_TYPES, EXAMPLES, GIFT } from '@ukef/constants';
 import { mockResponse201, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
@@ -216,6 +217,31 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
         );
 
         expect(mockHttpServicePost).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe(`when giftHttpService.post does NOT return a ${HttpStatus.CREATED} status`, () => {
+      it('should stop processing obligations and throw an error', async () => {
+        // Arrange
+        mockHttpServicePost = jest.fn().mockResolvedValueOnce({ status: HttpStatus.BAD_REQUEST, data: { badRequest: true } });
+        giftHttpService.post = mockHttpServicePost;
+
+        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+
+        // Act
+        const response = service.obligations({
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          facilityExpiryDate: REPLACE_EXPIRY_DATE.expiryDate,
+          facilityId: mockFacilityId,
+          obligations: [{ id: '1' }, { id: '2' }],
+          workPackageId: mockWorkPackageId,
+        });
+
+        // Assert
+        await expect(response).rejects.toThrow(
+          `Error amending facility obligations maturity dates ${AMEND_FACILITY_REPLACE_EXPIRY_DATE} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
+        );
+        expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.test.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.test.ts
@@ -1,8 +1,9 @@
 import { HttpStatus } from '@nestjs/common';
 import { AMEND_FACILITY_PREFIX_TYPES, EXAMPLES, GIFT } from '@ukef/constants';
-import { mockResponse201, mockResponse500 } from '@ukef-test/http-response';
+import { mockResponse201, mockResponse204, mockResponse500 } from '@ukef-test/http-response';
 import { PinoLogger } from 'nestjs-pino';
 
+import { GiftWorkPackageService } from '../gift.work-package.service';
 import { GiftReplaceExpiryDateAmendmentService } from '.';
 
 const {
@@ -26,16 +27,23 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
 
   let giftHttpService;
   let mockHttpServicePost: jest.Mock;
+  let giftWorkPackageService;
+  let mockWorkPackageServiceDelete: jest.Mock;
 
   beforeEach(() => {
     // Arrange
     mockHttpServicePost = jest.fn().mockResolvedValue(mockResponse201({ id: 'mock-amendment-response' }));
+    mockWorkPackageServiceDelete = jest.fn().mockResolvedValue(mockResponse204());
 
     giftHttpService = {
       post: mockHttpServicePost,
     };
 
-    service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+    giftWorkPackageService = {
+      delete: mockWorkPackageServiceDelete,
+    } as unknown as GiftWorkPackageService;
+
+    service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
   });
 
   afterAll(() => {
@@ -70,7 +78,7 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
       mockHttpServicePost = jest.fn().mockResolvedValueOnce(mockResponse);
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
       // Act
       const response = await service.facility({
@@ -98,7 +106,7 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
 
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
       // Act
       await service.obligations({
@@ -147,7 +155,7 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
       mockHttpServicePost = jest.fn().mockResolvedValueOnce(responseOne).mockResolvedValueOnce(responseTwo);
       giftHttpService.post = mockHttpServicePost;
 
-      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+      service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
       // Act
       const response = await service.obligations({
@@ -170,7 +178,7 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
         mockHttpServicePost = jest.fn().mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const response = service.obligations({
@@ -200,7 +208,7 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
           .mockRejectedValueOnce(mockError);
         giftHttpService.post = mockHttpServicePost;
 
-        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const response = service.obligations({
@@ -224,9 +232,11 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
       it('should stop processing obligations and throw an error', async () => {
         // Arrange
         mockHttpServicePost = jest.fn().mockResolvedValueOnce({ status: HttpStatus.BAD_REQUEST, data: { badRequest: true } });
+        mockWorkPackageServiceDelete = jest.fn().mockResolvedValueOnce(mockResponse204());
         giftHttpService.post = mockHttpServicePost;
+        giftWorkPackageService.delete = mockWorkPackageServiceDelete;
 
-        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, logger);
+        service = new GiftReplaceExpiryDateAmendmentService(giftHttpService, giftWorkPackageService, logger);
 
         // Act
         const response = service.obligations({
@@ -242,6 +252,8 @@ describe('GiftReplaceExpiryDateAmendmentService', () => {
           `Error amending facility obligations maturity dates ${AMEND_FACILITY_REPLACE_EXPIRY_DATE} for facility ${mockFacilityId} work package ${mockWorkPackageId}`,
         );
         expect(mockHttpServicePost).toHaveBeenCalledTimes(1);
+        expect(mockWorkPackageServiceDelete).toHaveBeenCalledTimes(1);
+        expect(mockWorkPackageServiceDelete).toHaveBeenCalledWith(mockWorkPackageId, mockFacilityId);
       });
     });
   });

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { GIFT } from '@ukef/constants';
 import { GiftAmendmentBaseParams } from '@ukef/types';
 import { PinoLogger } from 'nestjs-pino';
@@ -58,6 +58,15 @@ export class GiftReplaceExpiryDateAmendmentService {
           path: `${basePath}/${AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}${AMEND_OBLIGATION_REPLACE_MATURITY_DATE}`,
           payload,
         });
+
+        if (response.status !== HttpStatus.CREATED) {
+          throw new Error(
+            `Unexpected status ${response.status} amending facility obligations maturity dates ${amendmentType} for facility ${facilityId} work package ${workPackageId}`,
+            {
+              cause: response.data,
+            },
+          );
+        }
 
         responses.push(response.data);
       }

--- a/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.ts
+++ b/src/modules/gift/services/gift.replace-expiry-date-amendment.service/index.ts
@@ -5,6 +5,7 @@ import { PinoLogger } from 'nestjs-pino';
 
 import { GiftWorkPackageResponseDto } from '../../dto';
 import { GiftHttpService } from '../gift.http.service';
+import { GiftWorkPackageService } from '../gift.work-package.service';
 
 const {
   AMEND_FACILITY_PREFIX_TYPES,
@@ -30,12 +31,26 @@ type FacilityParams = GiftAmendmentBaseParams & {
 export class GiftReplaceExpiryDateAmendmentService {
   constructor(
     private readonly giftHttpService: GiftHttpService,
+    private readonly giftWorkPackageService: GiftWorkPackageService,
     private readonly logger: PinoLogger,
   ) {
     this.giftHttpService = giftHttpService;
+    this.giftWorkPackageService = giftWorkPackageService;
     this.logger = logger;
   }
 
+  /**
+   * Amend the obligations maturity dates for a given facility and work package.
+   * @param {ObligationsParams} params - Parameters for the amendment.
+   * @param {string} params.amendmentType - The type of amendment being made.
+   * @param {string} params.facilityExpiryDate - The new expiry date for the facility.
+   * @param {string} params.facilityId - The ID of the facility being amended.
+   * @param {Array<{ id: string }>} params.obligations - An array of obligations to be amended.
+   * @param {number} params.workPackageId - The ID of the work package associated with the amendment.
+   * @returns {Promise<Array<GiftWorkPackageResponseDto>>} - A promise that resolves to an array of responses from the GIFT API for each obligation amended.
+   * @throws {Error} - Throws an error if the amendment fails for any obligation, including details about the failure.
+   * @returns {Promise<Array<GiftWorkPackageResponseDto>>} - A promise that resolves to an array of responses from the GIFT API for each obligation amended.
+   */
   async obligations({ amendmentType, facilityExpiryDate, facilityId, obligations, workPackageId }: ObligationsParams) {
     try {
       this.logger.info('Amending facility obligations maturity dates %s for facility %s work package %s', amendmentType, facilityId, workPackageId);
@@ -60,6 +75,10 @@ export class GiftReplaceExpiryDateAmendmentService {
         });
 
         if (response.status !== HttpStatus.CREATED) {
+          this.logger.error('Error creating amendment %s for work package %s facility %s. Deleting work package', amendmentType, workPackageId, facilityId);
+
+          await this.giftWorkPackageService.delete(workPackageId, facilityId);
+
           throw new Error(
             `Unexpected status ${response.status} amending facility obligations maturity dates ${amendmentType} for facility ${facilityId} work package ${workPackageId}`,
             {
@@ -87,6 +106,16 @@ export class GiftReplaceExpiryDateAmendmentService {
     }
   }
 
+  /**
+   * Amend the expiry date for a given facility and work package.
+   * @param {FacilityParams} params - Parameters for the amendment.
+   * @param {string} params.amendmentType - The type of amendment being made.
+   * @param {string} params.expiryDate - The new expiry date for the facility.
+   * @param {string} params.facilityId - The ID of the facility being amended.
+   * @param {number} params.workPackageId - The ID of the work package associated with the amendment.
+   * @throws {Error} - Throws an error if the amendment fails, including details about the failure.
+   * @returns {Promise<GiftWorkPackageResponseDto>} - A promise that resolves to the response from the GIFT API for the facility amendment.
+   */
   async facility({ amendmentType, expiryDate, facilityId, workPackageId }: FacilityParams) {
     try {
       this.logger.info('Amending facility expiry date %s for facility %s work package %s', amendmentType, facilityId, workPackageId);

--- a/test/gift/facility-amendment-error-handling.api-test.ts
+++ b/test/gift/facility-amendment-error-handling.api-test.ts
@@ -19,7 +19,7 @@ import {
 const { GIFT_API_URL } = ENVIRONMENT_VARIABLES;
 
 const {
-  AMEND_FACILITY_TYPES_CONSUMER: { AMEND_FACILITY_INCREASE_AMOUNT },
+  AMEND_FACILITY_TYPES_CONSUMER: { AMEND_FACILITY_INCREASE_AMOUNT, AMEND_FACILITY_REPLACE_EXPIRY_DATE },
 } = GIFT;
 
 describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
@@ -44,7 +44,11 @@ describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
       .persist()
       .get(facilityUrl)
       .reply(HttpStatus.OK, {
-        obligations: [{ id: 'obligation-1' }],
+        expiryDate: '2035-01-01',
+        obligations: [{ id: 'obligation-1', maturityDateFollowsFacility: true }],
+        riskDetails: {
+          facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+        },
       });
 
     nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
@@ -140,6 +144,74 @@ describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
   });
 
   describe('GIFT "approve work package status" endpoint', () => {
+    describe(`when a prior amount amendment step returns ${HttpStatus.BAD_REQUEST}`, () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response and not call the approve endpoint`, async () => {
+        // Arrange
+        nock.cleanAll();
+
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            expiryDate: '2035-01-01',
+            obligations: [{ id: 'obligation-1', maturityDateFollowsFacility: true }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
+          });
+
+        nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+
+        nock(GIFT_API_URL).post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        nock(GIFT_API_URL).delete(workPackageUrl).reply(HttpStatus.NO_CONTENT);
+
+        const approveStatusScope = nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentWithoutQueueUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+        expect(body).toStrictEqual(mockResponses.badRequest);
+        expect(approveStatusScope.isDone()).toBe(false);
+      });
+    });
+
+    describe(`when a prior replace expiry date amendment step returns ${HttpStatus.BAD_REQUEST}`, () => {
+      it(`should return a ${HttpStatus.BAD_REQUEST} response and not call the approve endpoint`, async () => {
+        // Arrange
+        nock(GIFT_API_URL)
+          .persist()
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            expiryDate: '2035-01-01',
+            obligations: [{ id: 'obligation-1', maturityDateFollowsFacility: true }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
+          });
+
+        nock(GIFT_API_URL).persist().post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+
+        nock(GIFT_API_URL).persist().post(facilityAmendmentUrl(AMEND_FACILITY_REPLACE_EXPIRY_DATE)).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        const approveStatusScope = nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+        const payload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentWithoutQueueUrl, payload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.BAD_REQUEST);
+        expect(body).toStrictEqual(mockResponses.badRequest);
+        expect(approveStatusScope.isDone()).toBe(false);
+      });
+    });
+
     describe(`when a ${HttpStatus.BAD_REQUEST} response is returned`, () => {
       it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response`, async () => {
         // Arrange

--- a/test/gift/facility-amendment-error-handling.api-test.ts
+++ b/test/gift/facility-amendment-error-handling.api-test.ts
@@ -11,7 +11,9 @@ import {
   facilityAmendmentUrl,
   facilityUrl,
   facilityWorkPackageUrl,
+  mockFacilityId,
   mockResponses,
+  mockWorkPackageId,
   obligationAmendmentUrl,
   workPackageUrl,
 } from './test-helpers';
@@ -144,6 +146,79 @@ describe('POST /gift/facility/:facilityId/amendment - error handling', () => {
   });
 
   describe('GIFT "approve work package status" endpoint', () => {
+    describe(`when a prior amount obligation amendment step returns ${HttpStatus.BAD_REQUEST}`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response, delete the work package, and not call the approve endpoint`, async () => {
+        // Arrange
+        nock.cleanAll();
+
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            expiryDate: '2035-01-01',
+            obligations: [{ id: 'obligation-1', maturityDateFollowsFacility: true }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
+          });
+
+        nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+        nock(GIFT_API_URL).post(facilityAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
+        nock(GIFT_API_URL).post(obligationAmendmentUrl(AMEND_FACILITY_INCREASE_AMOUNT)).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        const deleteScope = nock(GIFT_API_URL).delete(workPackageUrl).reply(HttpStatus.NO_CONTENT);
+        const approveStatusScope = nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentWithoutQueueUrl, GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        expect(body).toStrictEqual(mockResponses.internalServerError);
+        expect(deleteScope.isDone()).toBe(true);
+        expect(approveStatusScope.isDone()).toBe(false);
+      });
+    });
+
+    describe(`when a prior replace expiry date obligation amendment step returns ${HttpStatus.BAD_REQUEST}`, () => {
+      it(`should return a ${HttpStatus.INTERNAL_SERVER_ERROR} response, delete the work package, and not call the approve endpoint`, async () => {
+        // Arrange
+        nock.cleanAll();
+
+        const replaceMaturityDateUrl = `${GIFT.PATH.FACILITY}/${mockFacilityId}${GIFT.PATH.WORK_PACKAGE}/${mockWorkPackageId}${GIFT.PATH.CONFIGURATION_EVENT}/${GIFT.AMEND_FACILITY_PREFIX_TYPES.AMEND_OBLIGATION}ReplaceMaturityDate`;
+
+        nock(GIFT_API_URL)
+          .get(facilityUrl)
+          .reply(HttpStatus.OK, {
+            expiryDate: '2020-01-01',
+            obligations: [{ id: 'obligation-1', maturityDateFollowsFacility: false }],
+            riskDetails: {
+              facilityCategoryCode: GIFT.FACILITY_CATEGORY_CODES.CASH,
+            },
+          });
+
+        nock(GIFT_API_URL).post(facilityWorkPackageUrl).reply(HttpStatus.CREATED, mockResponses.workPackageCreation);
+        nock(GIFT_API_URL).post(facilityAmendmentUrl(AMEND_FACILITY_REPLACE_EXPIRY_DATE)).reply(HttpStatus.CREATED, mockResponses.facilityAmendment);
+        nock(GIFT_API_URL).post(replaceMaturityDateUrl).reply(HttpStatus.BAD_REQUEST, mockResponses.badRequest);
+
+        const deleteScope = nock(GIFT_API_URL).delete(workPackageUrl).reply(HttpStatus.NO_CONTENT);
+        const approveStatusScope = nock(GIFT_API_URL).post(approveStatusUrl).reply(HttpStatus.OK, mockResponses.approveStatus);
+
+        const payload = {
+          amendmentType: AMEND_FACILITY_REPLACE_EXPIRY_DATE,
+          amendmentData: GIFT_EXAMPLES.FACILITY_AMENDMENT_REQUEST_PAYLOAD_DATA.REPLACE_EXPIRY_DATE,
+        };
+
+        // Act
+        const { status, body } = await api.post(apimFacilityAmendmentWithoutQueueUrl, payload);
+
+        // Assert
+        expect(status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        expect(body).toStrictEqual(mockResponses.internalServerError);
+        expect(deleteScope.isDone()).toBe(true);
+        expect(approveStatusScope.isDone()).toBe(false);
+      });
+    });
+
     describe(`when a prior amount amendment step returns ${HttpStatus.BAD_REQUEST}`, () => {
       it(`should return a ${HttpStatus.BAD_REQUEST} response and not call the approve endpoint`, async () => {
         // Arrange


### PR DESCRIPTION
# Introduction :pencil2:

APIM TFS was attempting to approve a GIFT work package, even if the GIFT work package or amendment was unsuccessful.

## Resolution :heavy_check_mark:

- Update `GiftAmountAmendmentService` and `GiftReplaceExpiryDateAmendmentService` to delete the work package and throw an error if a 201 status is not returned.
- Update `GiftFacilityAmendmentService` to check if amendments are successful, before approving the work package.
- Add/update tests.

## Miscellaneous :heavy_plus_sign:

- Add missing documentation.


## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
